### PR TITLE
windows-bug

### DIFF
--- a/internal/stackql/cmd/root.go
+++ b/internal/stackql/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/stackql/stackql/internal/stackql/config"
 	"github.com/stackql/stackql/internal/stackql/constants"
@@ -106,7 +107,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint32Var(&runtimeCtx.ApplicationFilesRootPathMode, dto.ApplicationFilesRootPathModeKey, config.GetDefaultProviderCacheDirFileMode(), fmt.Sprintf("Application config and cache file mode"))
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.ViperCfgFileName, dto.ViperCfgFileNameKey, config.GetDefaultViperConfigFileName(), fmt.Sprintf("Config filename"))
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.AuthRaw, dto.AuthCtxKey, "", `auth contexts keyvals in json form, eg: '{ "google": { "credentialsfilepath": "/path/to/google/sevice/account/key.json",  "type": "service_account" }, "okta": { "credentialsenvvar": "OKTA_SECRET_KEY",  "type": "api_key" } }'`)
-	rootCmd.PersistentFlags().StringVar(&runtimeCtx.RegistryRaw, dto.RegistryRawKey, fmt.Sprintf(`{ "url": "%s", "localDocRoot": "%s" }`, defaultRegistryUrlString, path.Join(runtimeCtx.ApplicationFilesRootPath)), fmt.Sprintf(`openapi registry context keyvals in json form, eg: '{ "url": "%s" }'.`, defaultRegistryUrlString))
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.RegistryRaw, dto.RegistryRawKey, fmt.Sprintf(`{ "url": "%s", "localDocRoot": "%s" }`, defaultRegistryUrlString, strings.ReplaceAll(path.Join(runtimeCtx.ApplicationFilesRootPath), `\`, `\\`)), fmt.Sprintf(`openapi registry context keyvals in json form, eg: '{ "url": "%s" }'.`, defaultRegistryUrlString))
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.DbEngine, dto.DbEngineKey, config.GetDefaultDbEngine(), fmt.Sprintf("DB engine id"))
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.DbFilePath, dto.DbFilePathKey, config.GetDefaultDbFilePath(), fmt.Sprintf("DB persistence filename"))
 	rootCmd.PersistentFlags().IntVar(&runtimeCtx.DbGenerationId, dto.DbGenerationIdKey, txncounter.GetNextGenerationId(), fmt.Sprintf("DB generation id"))

--- a/internal/stackql/cmd/shell.go
+++ b/internal/stackql/cmd/shell.go
@@ -124,7 +124,7 @@ var shellCmd = &cobra.Command{
 
 		handlerCtx, handlerrErr := handler.GetHandlerCtx("", runtimeCtx, queryCache, sqlEngine)
 		if handlerrErr != nil {
-			fmt.Fprintln(outErrFile, fmt.Sprintf("Error setting up handler context for provider '%s'", runtimeCtx.ProviderStr))
+			fmt.Fprintln(outErrFile, fmt.Sprintf("Error setting up handler context for provider '%s': \"%s\"", runtimeCtx.ProviderStr, handlerrErr))
 		}
 		var authCtx *dto.AuthCtx
 		var prov provider.IProvider

--- a/test/functional/stackql_from_cmd_line.robot
+++ b/test/functional/stackql_from_cmd_line.robot
@@ -12,6 +12,9 @@ Positive Control
 Get Providers
     Should StackQL Exec Contain    ${SHOW_PROVIDERS_STR}   okta
 
+Get Providers No Config
+    Should StackQL No Cfg Exec Contain    ${SHOW_PROVIDERS_STR}   name
+
 Get Okta Services
     Should StackQL Exec Contain    ${SHOW_OKTA_SERVICES_FILTERED_STR}    Application${SPACE}API
 
@@ -41,6 +44,16 @@ Run StackQL Canonical Exec Command
                     ...  \-\-auth\=${AUTH_CFG_STR}
                     ...  \-\-tls.allowInsecure\=true
                     ...  ${_EXEC_CMD_STR}    @{varargs}
+    Log             ${result.stdout}
+    Log             ${result.stderr}
+    [Return]    ${result}
+
+Run StackQL Canonical No Cfg Exec Command
+    [Arguments]    ${_EXEC_CMD_STR}    @{varargs}
+    Set Environment Variable    OKTA_SECRET_KEY    ${OKTA_SECRET_STR}
+    ${result} =     Run Process    
+                    ...  ${STACKQL_EXE}
+                    ...  exec    ${_EXEC_CMD_STR}    @{varargs}
     Log             ${result.stdout}
     Log             ${result.stderr}
     [Return]    ${result}
@@ -75,6 +88,11 @@ Should StackQL Exec Contain
     ${result} =    Run StackQL Canonical Exec Command    ${_EXEC_CMD_STR}
     Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
     ${result} =    Run StackQL Deprecated Exec Command    ${_EXEC_CMD_STR}
+    Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
+
+Should StackQL No Cfg Exec Contain
+    [Arguments]    ${_EXEC_CMD_STR}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
+    ${result} =    Run StackQL Canonical No Cfg Exec Command    ${_EXEC_CMD_STR}
     Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
 
 


### PR DESCRIPTION
## Summary

- fix yaml escaping for defaulted config directory.  Affected windows only due to `\`.