### PR TITLE
json-presentation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -729,7 +729,7 @@
         "--auth=${input:authString}",
         "show providers;",
         "-o",
-        "table"
+        "json"
       ],
     },
     {

--- a/internal/stackql/output/output.go
+++ b/internal/stackql/output/output.go
@@ -152,7 +152,12 @@ func resToArr(res sqldata.ISQLResult) []map[string]interface{} {
 		rowArr := r.GetRowDataNaive()
 		rm := make(map[string]interface{})
 		for i, c := range keys {
-			rm[c] = rowArr[i]
+			switch tp := rowArr[i].(type) {
+			case []byte:
+				rm[c] = string(tp)
+			default:
+				rm[c] = tp
+			}
 		}
 		retVal = append(retVal, rm)
 	}

--- a/test/robot/functional/stackql_from_cmd_line.robot
+++ b/test/robot/functional/stackql_from_cmd_line.robot
@@ -15,6 +15,7 @@ Positive Control
 
 Get Providers
     Should StackQL Exec Contain    ${SHOW_PROVIDERS_STR}   okta
+    Should StackQL Exec Contain JSON output    ${SHOW_PROVIDERS_STR}   okta
 
 Get Providers No Config
     Should StackQL No Cfg Exec Contain    ${SHOW_PROVIDERS_STR}   name
@@ -99,6 +100,15 @@ Should StackQL Exec Contain
     ${result} =    Run StackQL Canonical Exec Command    ${_EXEC_CMD_STR}
     Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
     ${result} =    Run StackQL Deprecated Exec Command    ${_EXEC_CMD_STR}
+    Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
+
+Should StackQL Exec Contain JSON output
+    [Arguments]    ${_EXEC_CMD_STR}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
+    ${result} =    Run StackQL Exec Command    ${_EXEC_CMD_STR}    \-o\=json
+    Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
+    ${result} =    Run StackQL Canonical Exec Command    ${_EXEC_CMD_STR}    \-o\=json
+    Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
+    ${result} =    Run StackQL Deprecated Exec Command    ${_EXEC_CMD_STR}    \-o\=json
     Should contain    ${result.stdout}    ${_EXEC_CMD_EXPECTED_OUTPUT}    @{varargs}
 
 Should StackQL Novel Exec Contain


### PR DESCRIPTION
## Summary

- Patch regression causing string to be rendered `base64` encoded when `-o json` (json output) in use.