### PR TITLE
readline-shim-for-mac

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1169,7 +1169,7 @@
       "type": "go",
       "request": "attach",
       "mode": "local",
-      "processId": 8745
+      "processId": 0
     }
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.28.8
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.13.0
 	github.com/getkin/kin-openapi v0.88.0
 	github.com/google/go-jsonnet v0.17.0
@@ -25,7 +26,6 @@ require (
 	gonum.org/v1/gonum v0.11.0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
-	readline v0.0.0-00010101000000-000000000000
 	vitess.io/vitess v0.0.11-alpha04
 )
 
@@ -70,7 +70,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
-	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
+	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.9 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
@@ -82,7 +82,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace readline => github.com/stackql/readline v0.0.1-rc01
+replace github.com/chzyer/readline => github.com/stackql/readline v0.0.2-alpha05
 
 replace github.com/fatih/color => github.com/stackql/color v0.0.1-rc01
 

--- a/go.sum
+++ b/go.sum
@@ -122,9 +122,11 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/mxj/v2 v2.5.5 h1:oT81vUeEiQQ/DcHbzSytRngP6Ky9O+L+0Bw0zSJag9E=
@@ -777,6 +779,16 @@ github.com/stackql/psql-wire v0.0.2-stackqlbeta01 h1:bbIRwFWZ15JrKqLfJ+CrgiSH9iO
 github.com/stackql/psql-wire v0.0.2-stackqlbeta01/go.mod h1:p4SxaTS4m9mLiq08GSOaatXSiai8REL5XPMlcVJxSwE=
 github.com/stackql/readline v0.0.1-rc01 h1:E5Sxe8vB/dZzGlJTJuVYKTYL9EHG0xNrepg8vev5YP0=
 github.com/stackql/readline v0.0.1-rc01/go.mod h1:GsQot9cgbH0B1/8pwoQKJ3KAAXaE+8BjFD2RvJOGs1Y=
+github.com/stackql/readline v0.0.2-alpha01 h1:nPUo30S0I13TquuVxmgqe/iDdOtxvNgiMo4zmD6Yerg=
+github.com/stackql/readline v0.0.2-alpha01/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
+github.com/stackql/readline v0.0.2-alpha02 h1:BQvlVecOEFSQ/2T9undTtZo0Ck7oqJePYKGvssPmX8Y=
+github.com/stackql/readline v0.0.2-alpha02/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/stackql/readline v0.0.2-alpha03 h1:PvKlkTllq7yRYSnHuDfMGCI+ChBLzCJdwCa5UgiDTV0=
+github.com/stackql/readline v0.0.2-alpha03/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
+github.com/stackql/readline v0.0.2-alpha04 h1:2ilfJeckUP2NyRJH1oQqXUpZToDzAEx2uRyEOqWj0Cs=
+github.com/stackql/readline v0.0.2-alpha04/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
+github.com/stackql/readline v0.0.2-alpha05 h1:ID4QzGdplFBsrSnTuz8pvKzWw96JbrJg8fsLry2UriU=
+github.com/stackql/readline v0.0.2-alpha05/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01 h1:3XorfaYEhGpuvEeQK04EmpZUCr42hZ/a4Nh3wE25LF0=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01/go.mod h1:D0WFWa7HOXS+PQAmvN0Nm1E6dMdUkUFtAzRH8cXxg88=
 github.com/stackql/vitess v0.0.11-alpha08 h1:B0M9djqTnDzmEoI+Pvt6UIxFY3dJVfKqjB7TV9k490E=
@@ -1080,6 +1092,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/stackql/cmd/shell.go
+++ b/internal/stackql/cmd/shell.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"readline"
+	"github.com/chzyer/readline"
 
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
## Summary:

- Bugfix for back arrow usage on multiline history items on MAC.  Previously, cursor positioning was errant on MAC.

### Specifics:

1. Transcribed an open source cursor-poistioning shim into our `readline` fork.
2. New functionality only used on `OS == "darwin"`.