### PR TITLE
aws-enablement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,7 @@
         "--registry=${input:registryString}",
         "--auth=${input:authString}",
         "--tls.allowInsecure",
-        "select VolumeId from aws.ec2.volumes where region = 'ap-southeast-1' order by VolumeId asc;"
+        "insert into aws.ec2.vpcs(CidrBlock, region) select '10.0.0.0/16', 'ap-southeast-1';"
       ],
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
-	github.com/stackql/go-openapistackql v0.0.9-alpha16
+	github.com/stackql/go-openapistackql v0.0.9-alpha17
 	github.com/stackql/go-sqlite3 v0.0.1-stackqlrc01
 	github.com/stackql/go-suffix-map v0.0.1-alpha01
 	go.uber.org/zap v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -789,6 +789,8 @@ github.com/stackql/go-openapistackql v0.0.9-alpha15 h1:pQqViClbBXpWlqcAQFIhcH1zZ
 github.com/stackql/go-openapistackql v0.0.9-alpha15/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
 github.com/stackql/go-openapistackql v0.0.9-alpha16 h1:oqjFn8YP6TsvixKbzi4GNEBMYVNCBzapXAT5P1b9kz0=
 github.com/stackql/go-openapistackql v0.0.9-alpha16/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
+github.com/stackql/go-openapistackql v0.0.9-alpha17 h1:fniPI8dYcNLgPzoBqoIHQZlH0YW5ZYYizoQVRiNsFVk=
+github.com/stackql/go-openapistackql v0.0.9-alpha17/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
 github.com/stackql/go-spew v1.1.3-alpha24 h1:yNmgWU+OKU8SvlQ0umiQWWgWS6C5U1GuRMlYfQgbmJA=
 github.com/stackql/go-spew v1.1.3-alpha24/go.mod h1:o2MPqg2ee1PN4SxAh9zQSJJmKKFJjpro9pejdK7dXWk=
 github.com/stackql/go-sqlite3 v0.0.1-stackqlrc01 h1:q+LfCfPrIqqG5+v9T5xjyYzOEBB4i77Ek10Lzwyd0D4=

--- a/test/registry/src/aws/v0.1.0/services/ec2.yaml
+++ b/test/registry/src/aws/v0.1.0/services/ec2.yaml
@@ -34,36 +34,6 @@ externalDocs:
   description: Amazon Web Services documentation
   url: 'https://docs.aws.amazon.com/ec2/'
 servers:
-  - url: 'http://ec2.{region}.amazonaws.com'
-    variables:
-      region:
-        description: The AWS region
-        enum:
-          - us-east-1
-          - us-east-2
-          - us-west-1
-          - us-west-2
-          - us-gov-west-1
-          - us-gov-east-1
-          - ca-central-1
-          - eu-north-1
-          - eu-west-1
-          - eu-west-2
-          - eu-west-3
-          - eu-central-1
-          - eu-south-1
-          - af-south-1
-          - ap-northeast-1
-          - ap-northeast-2
-          - ap-northeast-3
-          - ap-southeast-1
-          - ap-southeast-2
-          - ap-east-1
-          - ap-south-1
-          - sa-east-1
-          - me-south-1
-        default: us-east-1
-    description: The Amazon EC2 multi-region endpoint
   - url: 'https://ec2.{region}.amazonaws.com'
     variables:
       region:
@@ -94,21 +64,9 @@ servers:
           - me-south-1
         default: us-east-1
     description: The Amazon EC2 multi-region endpoint
-  - url: 'http://ec2.amazonaws.com'
-    variables: {}
-    description: The general Amazon EC2 endpoint for US East (N. Virginia)
   - url: 'https://ec2.amazonaws.com'
     variables: {}
     description: The general Amazon EC2 endpoint for US East (N. Virginia)
-  - url: 'http://ec2.{region}.amazonaws.com.cn'
-    variables:
-      region:
-        description: The AWS region
-        enum:
-          - cn-north-1
-          - cn-northwest-1
-        default: cn-north-1
-    description: The Amazon EC2 endpoint for China (Beijing) and China (Ningxia)
   - url: 'https://ec2.{region}.amazonaws.com.cn'
     variables:
       region:
@@ -45710,7 +45668,6 @@ components:
           response:
             mediaType: text/xml
             openAPIDocKey: '200'
-            objectKey: '/CreateVolumeResponse'
         volume_Delete:
           operation:
             $ref: '#/paths/~1?Action=DeleteVolume&Version=2016-11-15/get'


### PR DESCRIPTION
## Summary:

- Sensible defaults for xml responses supported via `go-openapistackql`.
- Volume insert robot test adjusted to cover the change.