### PR TITLE
aws-xpath-support-expansion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,7 @@
         "--registry=${input:registryString}",
         "--auth=${input:authString}",
         "--tls.allowInsecure",
-        "describe aws.ec2.instances;"
+        "describe aws.ec2.spot_datafeed_subscription;"
       ],
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
-	github.com/stackql/go-openapistackql v0.0.9-alpha20
+	github.com/stackql/go-openapistackql v0.0.9-alpha23
 	github.com/stackql/go-sqlite3 v0.0.1-stackqlrc01
 	github.com/stackql/go-suffix-map v0.0.1-alpha01
 	go.uber.org/zap v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -797,6 +797,12 @@ github.com/stackql/go-openapistackql v0.0.9-alpha19 h1:5iTbgFApUA++LsMDXNzwy4GPJ
 github.com/stackql/go-openapistackql v0.0.9-alpha19/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
 github.com/stackql/go-openapistackql v0.0.9-alpha20 h1:lURM3uTmEzPLxk3TZnxkgtkz2+rF80FUQ27pMl0m450=
 github.com/stackql/go-openapistackql v0.0.9-alpha20/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
+github.com/stackql/go-openapistackql v0.0.9-alpha21 h1:7yN3u6OsTD4MBxoUmLs10OR+7lmzuTeWIzgPqxCblKQ=
+github.com/stackql/go-openapistackql v0.0.9-alpha21/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
+github.com/stackql/go-openapistackql v0.0.9-alpha22 h1:kcutuhSxt1F4Jt54Ca9EtOQUrtP1kwNSjE/w7f+RStc=
+github.com/stackql/go-openapistackql v0.0.9-alpha22/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
+github.com/stackql/go-openapistackql v0.0.9-alpha23 h1:YZ5ayTniuh0dTw/Ch7zsL+HbRyYczOrKIJo1C+oIX3o=
+github.com/stackql/go-openapistackql v0.0.9-alpha23/go.mod h1:EmwsXQRcFKKJ+9rHpyLq73k62U5LC+9PCdPTZg3cEBg=
 github.com/stackql/go-spew v1.1.3-alpha24 h1:yNmgWU+OKU8SvlQ0umiQWWgWS6C5U1GuRMlYfQgbmJA=
 github.com/stackql/go-spew v1.1.3-alpha24/go.mod h1:o2MPqg2ee1PN4SxAh9zQSJJmKKFJjpro9pejdK7dXWk=
 github.com/stackql/go-sqlite3 v0.0.1-stackqlrc01 h1:q+LfCfPrIqqG5+v9T5xjyYzOEBB4i77Ek10Lzwyd0D4=

--- a/internal/stackql/primitivebuilder/single_select_acquire.go
+++ b/internal/stackql/primitivebuilder/single_select_acquire.go
@@ -149,7 +149,7 @@ func (ss *SingleSelectAcquire) Build() error {
 				switch pl := target.(type) {
 				// add case for xml object,
 				case map[string]interface{}:
-					if ss.tableMeta.SelectItemsKey != "" {
+					if ss.tableMeta.SelectItemsKey != "" && ss.tableMeta.SelectItemsKey != "/*" {
 						items, ok = pl[ss.tableMeta.SelectItemsKey]
 					} else {
 						items = []interface{}{

--- a/test/registry/src/aws/v0.1.0/services/ec2.yaml
+++ b/test/registry/src/aws/v0.1.0/services/ec2.yaml
@@ -40479,7 +40479,7 @@ components:
             $ref: '#/paths/~1?Action=DescribeAddresses&Version=2016-11-15/get'
           response:
             mediaType: text/xml
-            objectKey: /*/addressSet/item
+            objectKey: /*/addressesSet/item
             openAPIDocKey: '200'
       name: aws.ec2.addresses
       sqlVerbs:
@@ -40809,7 +40809,7 @@ components:
             $ref: '#/paths/~1?Action=DescribeClassicLinkInstances&Version=2016-11-15/get'
           response:
             mediaType: text/xml
-            objectKey: /*/classicLinkInstanceSet/item
+            objectKey: /*/instancesSet/item
             openAPIDocKey: '200'
       name: aws.ec2.classic_link_instances
       sqlVerbs:
@@ -40905,7 +40905,7 @@ components:
             $ref: '#/paths/~1?Action=DescribeClientVpnConnections&Version=2016-11-15/get'
           response:
             mediaType: text/xml
-            objectKey: /*/clientVpnConnectionSet/item
+            objectKey: /*/connections/item
             openAPIDocKey: '200'
         client_vpn_connections_Terminate:
           operation:
@@ -41547,7 +41547,7 @@ components:
             $ref: '#/paths/~1?Action=DescribeFleetInstances&Version=2016-11-15/get'
           response:
             mediaType: text/xml
-            objectKey: /*/fleetInstanceSet/item
+            objectKey: /*/activeInstanceSet/item
             openAPIDocKey: '200'
       name: aws.ec2.fleet_instances
       sqlVerbs:
@@ -42346,7 +42346,7 @@ components:
             $ref: '#/paths/~1?Action=DescribeInstanceStatus&Version=2016-11-15/get'
           response:
             mediaType: text/xml
-            objectKey: /*/statusSet/item
+            objectKey: /*/instanceStatusSet/item
             openAPIDocKey: '200'
         instance_status_Report:
           operation:
@@ -44269,7 +44269,7 @@ components:
             $ref: '#/paths/~1?Action=DescribeSecurityGroups&Version=2016-11-15/get'
           response:
             mediaType: text/xml
-            objectKey: /*/securityGroupSet/item
+            objectKey: /*/securityGroupInfo/item
             openAPIDocKey: '200'
       name: aws.ec2.security_groups
       sqlVerbs:
@@ -46164,7 +46164,7 @@ components:
             $ref: '#/paths/~1?Action=GetVpnConnectionDeviceSampleConfiguration&Version=2016-11-15/get'
           response:
             mediaType: text/xml
-            objectKey: /*/vpnConnectionDeviceSampleConfiguration/item
+            objectKey: /*
             openAPIDocKey: '200'
       name: aws.ec2.vpn_connection_device_sample_configuration
       sqlVerbs:

--- a/test/robot/functional/stackql_from_cmd_line.robot
+++ b/test/robot/functional/stackql_from_cmd_line.robot
@@ -27,6 +27,11 @@ Describe AWS EC2 Instances Exemplifies Deep XPath for schema
                                                  ...  architecture    bootMode    subnetId
                                                  ...  stdout=${CURDIR}/tmp/describe-aws-ec2-instances.tmp
 
+Describe AWS EC2 Default KMS Key ID Exemplifies Top Level XPath for schema
+    Should StackQL NoVerify Only Exec Contain    ${DESCRIBE_AWS_EC2_DEFAULT_KMS_KEY_ID}
+                                                 ...  kmsKeyId
+                                                 ...  stdout=${CURDIR}/tmp/describe-aws-ec2-default-kms-key-id.tmp
+
 Show Methods GitHub
     Should StackQL Novel Exec Equal    ${SHOW_METHODS_GITHUB_REPOS_REPOS}   ${SHOW_METHODS_GITHUB_REPOS_REPOS_EXPECTED}
 

--- a/test/robot/lib/stackql_context.py
+++ b/test/robot/lib/stackql_context.py
@@ -248,6 +248,7 @@ SHOW_OKTA_APPLICATION_RESOURCES_FILTERED_STR  = "show resources from okta.applic
 SHOW_METHODS_GITHUB_REPOS_REPOS = "show methods in github.repos.repos;"
 DESCRIBE_GITHUB_REPOS_PAGES = "describe github.repos.pages;"
 DESCRIBE_AWS_EC2_INSTANCES = "describe aws.ec2.instances;"
+DESCRIBE_AWS_EC2_DEFAULT_KMS_KEY_ID = "describe aws.ec2.ebs_default_kms_key_id;"
 MOCKSERVER_JAR = os.path.join(REPOSITORY_ROOT, 'test', 'downloads', 'mockserver-netty-5.12.0-shaded.jar')
 
 JSON_INIT_FILE_PATH_GOOGLE = os.path.join(REPOSITORY_ROOT, 'test', 'mockserver', 'expectations', 'static-gcp-expectations.json')
@@ -432,6 +433,7 @@ def get_variables(execution_env :str):
     ## queries and expectations
     'CREATE_AWS_VOLUME':                                                    CREATE_AWS_VOLUME,
     'DESCRIBE_AWS_EC2_INSTANCES':                                           DESCRIBE_AWS_EC2_INSTANCES,
+    'DESCRIBE_AWS_EC2_DEFAULT_KMS_KEY_ID':                                  DESCRIBE_AWS_EC2_DEFAULT_KMS_KEY_ID,
     'DESCRIBE_GITHUB_REPOS_PAGES':                                          DESCRIBE_GITHUB_REPOS_PAGES,
     'GET_IAM_POLICY_AGG_ASC_EXPECTED':                                      GET_IAM_POLICY_AGG_ASC_EXPECTED,
     'REGISTRY_GOOGLE_PROVIDER_LIST':                                        REGISTRY_GOOGLE_PROVIDER_LIST,


### PR DESCRIPTION
## Summary:

- Support for different `xpath` idioms.
- `describe` works for all select verbs in `aws.ec2`.