### PR TITLE
query-params-in-paths-generic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
         "{ \"url\": \"file://${workspaceFolder}/test/registry\", \"localDocRoot\": \"${workspaceFolder}/test/registry\", \"verifyConfig\": { \"nopVerify\": true } }",
         "{ \"url\": \"file://${workspaceFolder}/test/registry-mocked\", \"localDocRoot\": \"${workspaceFolder}/test/registry-mocked\", \"verifyConfig\": { \"nopVerify\": true } }",
         "{ \"url\": \"https://cdn.statically.io/gh/stackql/stackql-provider-registry/main/providers\", \"localDocRoot\": \"${workspaceFolder}/test/registry\" }",
-        "{ \"url\": \"https://cdn.statically.io/gh/stackql/stackql-provider-registry/feature/add-github-provider-published-05/providers\" }"
+        "{ \"url\": \"https://cdn.statically.io/gh/stackql/stackql-provider-registry/dev/providers\" }"
       ],
       "default": "{ \"url\": \"file://${workspaceFolder}/test/registry-sandbox\", \"localDocRoot\": \"${workspaceFolder}/test/registry-sandbox\", \"verifyConfig\": { \"nopVerify\": true } }"
     },
@@ -38,7 +38,7 @@
 
     // select VolumeId from aws.ec2.volumes where region = 'ap-southeast-1' order by VolumeId asc;
     {
-      "name": "DEBUG aws guff",
+      "name": "DEBUG azure guff",
       "type": "go",
       "request": "launch",
       "mode": "debug",
@@ -48,7 +48,7 @@
         "--registry=${input:registryString}",
         "--auth=${input:authString}",
         "--tls.allowInsecure",
-        "select Identifier, Properties from aws.cloud_control.resources where region = 'ap-southeast-1' and data__TypeName = 'AWS::Logs::LogGroup' and data__Identifier = 'CloudControlExample';"
+        "SELECT * FROM azure.compute.virtual_machines WHERE resourceGroupName = 'stackql-ops-cicd-dev-01' AND subscriptionId = '631d1c6d-2a65-43e7-93c2-688bfe4e1468';"
       ],
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
-	github.com/stackql/go-openapistackql v0.0.9-beta23
+	github.com/stackql/go-openapistackql v0.0.10-alpha01
 	github.com/stackql/go-sqlite3 v0.0.1-stackqlrc01
 	github.com/stackql/go-suffix-map v0.0.1-alpha01
 	go.uber.org/zap v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -652,6 +652,8 @@ github.com/stackql/color v0.0.1-rc01 h1:fq3Gj6gwskaZnQrDXfFYnDP6JyayGHy6Dp7I5P/V
 github.com/stackql/color v0.0.1-rc01/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/stackql/go-openapistackql v0.0.9-beta23 h1:AiX/7olhwqsAbDX1PDCxMHTM7Eb4IisUcIiM5OSYlII=
 github.com/stackql/go-openapistackql v0.0.9-beta23/go.mod h1:lhOGbSlnioAbK8nFAIyvTkGkY7s5Sumz3fVnr81CfaQ=
+github.com/stackql/go-openapistackql v0.0.10-alpha01 h1:/7bumVItxZwcXEZ4S0Al+lOSaLe0S6my3slDsBCHOME=
+github.com/stackql/go-openapistackql v0.0.10-alpha01/go.mod h1:lhOGbSlnioAbK8nFAIyvTkGkY7s5Sumz3fVnr81CfaQ=
 github.com/stackql/go-spew v1.1.3-alpha24 h1:yNmgWU+OKU8SvlQ0umiQWWgWS6C5U1GuRMlYfQgbmJA=
 github.com/stackql/go-spew v1.1.3-alpha24/go.mod h1:o2MPqg2ee1PN4SxAh9zQSJJmKKFJjpro9pejdK7dXWk=
 github.com/stackql/go-sqlite3 v0.0.1-stackqlrc01 h1:q+LfCfPrIqqG5+v9T5xjyYzOEBB4i77Ek10Lzwyd0D4=


### PR DESCRIPTION
## Summary:

- Generic support for query strings in `openapi3` doc paths, via `go-openapistackql` module.
- Motivated by widespread use thereof inside `azure` provider.