### PR TITLE
auth-shorthand

### DIFF
--- a/internal/stackql/dto/dto.go
+++ b/internal/stackql/dto/dto.go
@@ -17,6 +17,7 @@ const (
 	AuthApiKeyStr                   string = "api_key"
 	AuthAWSSigningv4Str             string = "aws_signing_v4"
 	AuthBasicStr                    string = "basic"
+	AuthBearerStr                   string = "bearer"
 	AuthInteractiveStr              string = "interactive"
 	AuthServiceAccountStr           string = "service_account"
 	AuthNullStr                     string = "null_auth"
@@ -127,6 +128,7 @@ type AuthCtx struct {
 	ValuePrefix string   `json:"valuePrefix" yaml:"valuePrefix"`
 	ID          string   `json:"-" yaml:"-"`
 	KeyID       string   `json:"keyID" yaml:"keyID"`
+	KeyIDEnvVar string   `json:"keyIDenvvar" yaml:"keyIDenvvar"`
 	KeyFilePath string   `json:"credentialsfilepath" yaml:"credentialsfilepath"`
 	KeyEnvVar   string   `json:"credentialsenvvar" yaml:"credentialsenvvar"`
 	Active      bool     `json:"-" yaml:"-"`
@@ -137,6 +139,17 @@ func (ac *AuthCtx) HasKey() bool {
 		return true
 	}
 	return false
+}
+
+func (ac *AuthCtx) GetKeyIDString() (string, error) {
+	if ac.KeyIDEnvVar != "" {
+		rv := os.Getenv(ac.KeyIDEnvVar)
+		if rv == "" {
+			return "", fmt.Errorf("keyIDenvvar references empty string")
+		}
+		return rv, nil
+	}
+	return ac.KeyID, nil
 }
 
 func (ac *AuthCtx) InferAuthType(authTypeRequested string) string {

--- a/internal/stackql/provider/generic.go
+++ b/internal/stackql/provider/generic.go
@@ -68,6 +68,8 @@ func (gp *GenericProvider) inferAuthType(authCtx dto.AuthCtx, authTypeRequested 
 		return dto.AuthApiKeyStr
 	case dto.AuthBasicStr:
 		return dto.AuthBasicStr
+	case dto.AuthBearerStr:
+		return dto.AuthBearerStr
 	case dto.AuthServiceAccountStr:
 		return dto.AuthServiceAccountStr
 	case dto.AuthInteractiveStr:
@@ -87,7 +89,9 @@ func (gp *GenericProvider) Auth(authCtx *dto.AuthCtx, authTypeRequested string, 
 	at := gp.inferAuthType(*authCtx, authTypeRequested)
 	switch at {
 	case dto.AuthApiKeyStr:
-		return gp.apiTokenFileAuth(authCtx)
+		return gp.apiTokenFileAuth(authCtx, false)
+	case dto.AuthBearerStr:
+		return gp.apiTokenFileAuth(authCtx, true)
 	case dto.AuthServiceAccountStr:
 		return gp.keyFileAuth(authCtx)
 	case dto.AuthBasicStr:
@@ -236,8 +240,8 @@ func (gp *GenericProvider) keyFileAuth(authCtx *dto.AuthCtx) (*http.Client, erro
 	return oauthServiceAccount(gp.GetProviderString(), authCtx, scopes, gp.runtimeCtx)
 }
 
-func (gp *GenericProvider) apiTokenFileAuth(authCtx *dto.AuthCtx) (*http.Client, error) {
-	return apiTokenAuth(authCtx, gp.runtimeCtx)
+func (gp *GenericProvider) apiTokenFileAuth(authCtx *dto.AuthCtx, enforceBearer bool) (*http.Client, error) {
+	return apiTokenAuth(authCtx, gp.runtimeCtx, enforceBearer)
 }
 
 func (gp *GenericProvider) awsSigningAuth(authCtx *dto.AuthCtx) (*http.Client, error) {

--- a/pkg/awssign/aws_sign.go
+++ b/pkg/awssign/aws_sign.go
@@ -13,14 +13,6 @@ import (
 	"github.com/stackql/stackql/internal/stackql/logging"
 )
 
-const (
-	locationHeader string = "header"
-	locationQuery  string = "query"
-	authTypeBasic  string = "BASIC"
-	authTypeBearer string = "Bearer"
-	authTypeSSWS   string = "SSWS"
-)
-
 type AwsSignTransport struct {
 	underlyingTransport http.RoundTripper
 	signer              *v4.Signer


### PR DESCRIPTION
## Summary:

- Support shorthand for api key plus `BEARER` header pattern.
- Obscure AWS keyID; not a secret but just to be exhausitve with identifying data.