### PR TITLE
pg-pass-through

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,8 @@
       "options": [
         "select `Key`, Size, StorageClass from  aws.s3.objects where region = 'ap-southeast-1' and bucket = 'stackql-trial-bucket-01' order by `Key` ASC;",
         "select name from google.compute.machineTypes where project = 'testing-project' and zone = 'australia-southeast1-a' order by name desc;",
+        "select oid, typbasetype from pg_type where typname = 'lo'",
+        "select relname, nspname, relkind from pg_catalog.pg_class c, pg_catalog.pg_namespace n where relkind in ('r', 'v', 'm', 'f') and nspname not in ('pg_catalog', 'information_schema', 'pg_toast', 'pg_temp_1') and n.oid = relnamespace order by nspname, relname",
         "select r.name, col.login, col.type, col.role_name from stackql_analytics_github.repos.collaborators col inner join stackql_analytics_github.repos.repos r ON col.repo = r.name where col.owner = 'stackql' and r.org = 'stackql' order by r.name, col.login desc;",
         "show providers;"
       ],
@@ -57,11 +59,11 @@
       "type": "pickString",
       "id": "namespaceString",
       "description": "Namespace JSON config String",
-      "default": "{ \"analytics\": { \"ttl\": 86400, \"regex\": \"^stackql_analytics_(?P<objectName>.*)$\", \"template\": \"stackql_analytics_{{ .objectName }}\" } }",
+      "default": "{}",
       "options": [
+        "{}",
         "{ \"analytics\": { \"ttl\": 86400, \"regex\": \"^(?:stackql_analytics_)?(?P<objectName>.*)$\", \"template\": \"stackql_analytics_{{ .objectName }}\" } }",
-        "{ \"analytics\": { \"ttl\": 86400, \"regex\": \"^(?P<objectName>.*)$\", \"template\": \"stackql_analytics_{{ .objectName }}\" } }",
-        "{}"
+        "{ \"analytics\": { \"ttl\": 86400, \"regex\": \"^(?P<objectName>.*)$\", \"template\": \"stackql_analytics_{{ .objectName }}\" } }"
       ]
     },
     {

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update \
       maven \
       openssl \
       postgresql-client \
-    && pip3 install PyYaml robotframework psycopg2-binary "psycopg[binary]" \
+    && pip3 install PyYaml robotframework psycopg2-binary "psycopg[binary]" sqlalchemy \
     && mvn \
         org.apache.maven.plugins:maven-dependency-plugin:3.0.2:copy \
         -Dartifact=org.mock-server:mockserver-netty:5.12.0:jar:shaded \

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -69,6 +69,18 @@ psql -d "host=127.0.0.1 port=5466 user=silly dbname=silly sslmode=verify-full ss
     - Run / adapt [this script](/examples/scripts/python/psycopg2_scratchpad.py) for troubleshooting `psycopg2`. 
     - Run / adapt [this script](/examples/scripts/python/sqlalchemy_scratchpad.py) for troubleshooting `sqlalchemy`. 
 
+### With docker
+
+From the repository root directory.
+
+```bash
+docker compose up stackqlsrv
+```
+
+```bash
+psql -d "host=127.0.0.1 port=5576 user=silly dbname=silly sslmode=verify-full sslcert=./vol/srv/credentials/pg_client_cert.pem sslkey=./vol/srv/credentials/pg_client_key.pem sslrootcert=./vol/srv/credentials/pg_server_cert.pem"
+```
+
 ## Queries
 
 ### SELECT

--- a/examples/scripts/python/sqlalchemy_scratchpad.py
+++ b/examples/scripts/python/sqlalchemy_scratchpad.py
@@ -1,12 +1,25 @@
 import sqlalchemy
 
-eng = sqlalchemy.create_engine('postgresql://sillyuser:sillypw@127.0.0.1:5466/sillydb')
+eng = sqlalchemy.create_engine('postgresql://stackql:stackql@127.0.0.1:5888/stackql')
 
 ## this is the sticking point for now
 conn = eng.raw_connection()
 
 curs = conn.cursor()
 
+SHOW_TRANSACTION_ISOLATION_LEVEL = "show transaction isolation level"
+SELECT_HSTORE_DETAILS = "SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore'"
+
+SHOW_TRANSACTION_ISOLATION_LEVEL_JSON_EXPECTED = [{"transaction_isolation": "read committed"}]
+SELECT_HSTORE_DETAILS_JSON_EXPECTED = []
+
 curs.execute("show transaction isolation level")
 
-curs.fetchall()
+rv = curs.fetchall()
+
+e1 = None
+for entry in rv:
+    dir(entry)
+    print(entry)
+    e1 = entry
+    

--- a/internal/stackql/bundle/bundle.go
+++ b/internal/stackql/bundle/bundle.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"github.com/stackql/stackql/internal/stackql/dbmsinternal"
 	"github.com/stackql/stackql/internal/stackql/garbagecollector"
 	"github.com/stackql/stackql/internal/stackql/kstore"
 	"github.com/stackql/stackql/internal/stackql/sqlcontrol"
@@ -15,6 +16,7 @@ type Bundle interface {
 	GetControlAttributes() sqlcontrol.ControlAttributes
 	GetGC() garbagecollector.GarbageCollector
 	GetNamespaceCollection() tablenamespace.TableNamespaceCollection
+	GetDBMSInternalRouter() dbmsinternal.DBMSInternalRouter
 	GetSQLDialect() sqldialect.SQLDialect
 	GetSQLEngine() sqlengine.SQLEngine
 	GetTxnCounterManager() txncounter.TxnCounterManager
@@ -26,6 +28,7 @@ func NewBundle(
 	namespaces tablenamespace.TableNamespaceCollection,
 	sqlEngine sqlengine.SQLEngine,
 	sqlDialect sqldialect.SQLDialect,
+	pgInternalRouter dbmsinternal.DBMSInternalRouter,
 	controlAttributes sqlcontrol.ControlAttributes,
 	txnStore kstore.KStore,
 	txnCtrMgr txncounter.TxnCounterManager,
@@ -39,6 +42,7 @@ func NewBundle(
 		txnStore:          txnStore,
 		txnCtrMgr:         txnCtrMgr,
 		formatter:         sqlDialect.GetASTFormatter(),
+		pgInternalRouter:  pgInternalRouter,
 	}
 }
 
@@ -51,10 +55,15 @@ type simpleBundle struct {
 	txnStore          kstore.KStore
 	txnCtrMgr         txncounter.TxnCounterManager
 	formatter         sqlparser.NodeFormatter
+	pgInternalRouter  dbmsinternal.DBMSInternalRouter
 }
 
 func (sb *simpleBundle) GetControlAttributes() sqlcontrol.ControlAttributes {
 	return sb.controlAttributes
+}
+
+func (sb *simpleBundle) GetDBMSInternalRouter() dbmsinternal.DBMSInternalRouter {
+	return sb.pgInternalRouter
 }
 
 func (sb *simpleBundle) GetASTFormatter() sqlparser.NodeFormatter {

--- a/internal/stackql/cmd/root.go
+++ b/internal/stackql/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -95,6 +95,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.DBInternalCfgRaw, dto.DBInternalCfgRawKey, "{}", "JSON / YAML string to configure DBMS housekeeping query handling")
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.SQLBackendCfgRaw, dto.SQLBackendCfgRawKey, "{}", "JSON / YAML string representing SQL Backend System Config")
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.NamespaceCfgRaw, dto.NamespaceCfgRawKey, "{}", "JSON / YAML string representing namespaces for cacheing, views etc")
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.StoreTxnCfgRaw, dto.StoreTxnCfgRawKey, "{}", "JSON / YAML string representing Txn store config")

--- a/internal/stackql/constants/constants.go
+++ b/internal/stackql/constants/constants.go
@@ -48,3 +48,11 @@ const (
 	GCBlack
 	GCGrey
 )
+
+type BackendQueryType int
+
+const (
+	BackendExec BackendQueryType = iota
+	BackendQuery
+	BackendNop
+)

--- a/internal/stackql/dbmsinternal/dbmsinternal.go
+++ b/internal/stackql/dbmsinternal/dbmsinternal.go
@@ -1,0 +1,110 @@
+package dbmsinternal
+
+import (
+	"regexp"
+
+	"github.com/stackql/stackql/internal/stackql/constants"
+	"github.com/stackql/stackql/internal/stackql/dto"
+	"github.com/stackql/stackql/internal/stackql/logging"
+	"github.com/stackql/stackql/internal/stackql/sqldialect"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+var (
+	_                      DBMSInternalRouter = &standardDBMSInternalRouter{}
+	internalTableRegexp    *regexp.Regexp     = regexp.MustCompile(`(?i)^(?:public\.)?(?:pg_type|pg_namespace|pg_catalog.*|current_schema)`)
+	showHousekeepingRegexp *regexp.Regexp     = regexp.MustCompile(`(?i)(?:\s+transaction\s+isolation\s+level|standard_conforming_strings)`)
+)
+
+type DBMSInternalRouter interface {
+	CanRoute(node sqlparser.SQLNode) (constants.BackendQueryType, bool)
+}
+
+func GetDBMSInternalRouter(cfg dto.DBMSInternalCfg, sqlDialect sqldialect.SQLDialect) (DBMSInternalRouter, error) {
+	showRegexp := showHousekeepingRegexp
+	tableRegexp := internalTableRegexp
+	var err error
+	if cfg.ShowRegex != "" {
+		showRegexp, err = regexp.Compile(cfg.ShowRegex)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if cfg.TableRegex != "" {
+		tableRegexp, err = regexp.Compile(cfg.TableRegex)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &standardDBMSInternalRouter{
+		cfg:         cfg,
+		sqlDialect:  sqlDialect,
+		showRegexp:  showRegexp,
+		tableRegexp: tableRegexp,
+	}, nil
+}
+
+type standardDBMSInternalRouter struct {
+	cfg         dto.DBMSInternalCfg
+	sqlDialect  sqldialect.SQLDialect
+	showRegexp  *regexp.Regexp
+	tableRegexp *regexp.Regexp
+}
+
+func (pgr *standardDBMSInternalRouter) CanRoute(node sqlparser.SQLNode) (constants.BackendQueryType, bool) {
+	if pgr.sqlDialect.GetName() != constants.SQLDialectPostgres {
+		return pgr.negative()
+	}
+	switch node := node.(type) {
+	case *sqlparser.Select:
+		logging.GetLogger().Debugf("node = %v\n", node)
+		return pgr.analyzeSelect(node)
+	case *sqlparser.Set:
+		return constants.BackendExec, true
+	case *sqlparser.Show:
+		return pgr.analyzeShow(node)
+	}
+	return pgr.negative()
+}
+
+func (pgr *standardDBMSInternalRouter) negative() (constants.BackendQueryType, bool) {
+	return constants.BackendNop, false
+}
+
+func (pgr *standardDBMSInternalRouter) analyzeSelect(node *sqlparser.Select) (constants.BackendQueryType, bool) {
+	if len(node.From) < 1 {
+		return pgr.negative()
+	}
+	if pgr.analyzeTableExpr(node.From[0]) {
+		return constants.BackendQuery, true
+	}
+	return pgr.negative()
+}
+
+func (pgr *standardDBMSInternalRouter) analyzeShow(node *sqlparser.Show) (constants.BackendQueryType, bool) {
+	if node.Type != "" && pgr.showRegexp.MatchString(node.Type) {
+		return constants.BackendQuery, true
+	}
+	if pgr.analyzeTableName(node.OnTable) {
+		if pgr.analyzeTableName(node.OnTable) {
+			return constants.BackendQuery, true
+		}
+	}
+	return pgr.negative()
+}
+
+func (pgr *standardDBMSInternalRouter) analyzeTableExpr(node sqlparser.TableExpr) bool {
+	switch node := node.(type) {
+	case *sqlparser.AliasedTableExpr:
+		switch expr := node.Expr.(type) {
+		case sqlparser.TableName:
+			return pgr.analyzeTableName(expr)
+		}
+	}
+	return false
+}
+
+func (pgr *standardDBMSInternalRouter) analyzeTableName(node sqlparser.TableName) bool {
+	rawName := node.GetRawVal()
+	return pgr.tableRegexp.MatchString(rawName)
+}

--- a/internal/stackql/dto/dto.go
+++ b/internal/stackql/dto/dto.go
@@ -64,6 +64,7 @@ const (
 	GCCfgRawKey                     string = "gc"
 	NamespaceCfgRawKey              string = "namespaces"
 	SQLBackendCfgRawKey             string = "sqlBackend"
+	DBInternalCfgRawKey             string = "dbInternal"
 	StoreTxnCfgRawKey               string = "store.txn"
 	TemplateCtxFilePathKey          string = "iqldata"
 	TestWithoutApiCallsKey          string = "testwithoutapicalls"
@@ -267,6 +268,7 @@ type RuntimeCtx struct {
 	ProviderStr                  string
 	RegistryRaw                  string
 	SQLBackendCfgRaw             string
+	DBInternalCfgRaw             string
 	NamespaceCfgRaw              string
 	StoreTxnCfgRaw               string
 	GCCfgRaw                     string
@@ -326,6 +328,8 @@ func (rc *RuntimeCtx) Set(key string, val string) error {
 		retVal = setBool(&rc.CSVHeadersDisable, val)
 	case SQLBackendCfgRawKey:
 		rc.SQLBackendCfgRaw = val
+	case DBInternalCfgRawKey:
+		rc.DBInternalCfgRaw = val
 	case DelimiterKey:
 		rc.Delimiter = val
 	case DryRunFlagKey:

--- a/internal/stackql/dto/pg_internal_config.go
+++ b/internal/stackql/dto/pg_internal_config.go
@@ -1,0 +1,16 @@
+package dto
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+type DBMSInternalCfg struct {
+	ShowRegex  string `json:"showRegex" yaml:"showRegex"`
+	TableRegex string `json:"tableRegex" yaml:"tableRegex"`
+}
+
+func GetDBMSInternalCfg(s string) (DBMSInternalCfg, error) {
+	rv := DBMSInternalCfg{}
+	err := yaml.Unmarshal([]byte(s), &rv)
+	return rv, err
+}

--- a/internal/stackql/entryutil/entryutil.go
+++ b/internal/stackql/entryutil/entryutil.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/stackql/stackql/internal/stackql/bundle"
+	"github.com/stackql/stackql/internal/stackql/dbmsinternal"
 	"github.com/stackql/stackql/internal/stackql/dto"
 	"github.com/stackql/stackql/internal/stackql/garbagecollector"
 	"github.com/stackql/stackql/internal/stackql/gcexec"
@@ -52,6 +53,11 @@ func BuildInputBundle(runtimeCtx dto.RuntimeCtx) (bundle.Bundle, error) {
 	if err != nil {
 		return nil, err
 	}
+	pgInternalCfg, err := dto.GetDBMSInternalCfg(runtimeCtx.DBInternalCfgRaw)
+	if err != nil {
+		return nil, err
+	}
+	pgInternal, err := dbmsinternal.GetDBMSInternalRouter(pgInternalCfg, dialect)
 	namespaces, err = namespaces.WithSQLDialect(dialect)
 	if err != nil {
 		return nil, err
@@ -69,7 +75,7 @@ func BuildInputBundle(runtimeCtx dto.RuntimeCtx) (bundle.Bundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return bundle.NewBundle(gc, namespaces, se, dialect, controlAttributes, txnStore, txnCtrMgr), nil
+	return bundle.NewBundle(gc, namespaces, se, dialect, pgInternal, controlAttributes, txnStore, txnCtrMgr), nil
 }
 
 func initNamespaces(namespaceCfgRaw string, sqlEngine sqlengine.SQLEngine) (tablenamespace.TableNamespaceCollection, error) {

--- a/internal/stackql/handler/handler.go
+++ b/internal/stackql/handler/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackql/go-openapistackql/openapistackql"
 	"github.com/stackql/go-openapistackql/pkg/nomenclature"
 	"github.com/stackql/stackql/internal/stackql/bundle"
+	"github.com/stackql/stackql/internal/stackql/dbmsinternal"
 	"github.com/stackql/stackql/internal/stackql/drm"
 	"github.com/stackql/stackql/internal/stackql/dto"
 	"github.com/stackql/stackql/internal/stackql/garbagecollector"
@@ -48,6 +49,7 @@ type HandlerContext struct {
 	TxnStore            kstore.KStore
 	namespaceCollection tablenamespace.TableNamespaceCollection
 	formatter           sqlparser.NodeFormatter
+	pgInternalRouter    dbmsinternal.DBMSInternalRouter
 }
 
 func getProviderMap(providerName string, providerDesc openapistackql.ProviderDescription) map[string]interface{} {
@@ -155,6 +157,10 @@ func (hc *HandlerContext) GetNamespaceCollection() tablenamespace.TableNamespace
 	return hc.namespaceCollection
 }
 
+func (hc *HandlerContext) GetDBMSInternalRouter() dbmsinternal.DBMSInternalRouter {
+	return hc.pgInternalRouter
+}
+
 func GetRegistry(runtimeCtx dto.RuntimeCtx) (openapistackql.RegistryAPI, error) {
 	return getRegistry(runtimeCtx)
 }
@@ -222,6 +228,7 @@ func GetHandlerCtx(cmdString string, runtimeCtx dto.RuntimeCtx, lruCache *lrucac
 		TxnStore:            inputBundle.GetTxnStore(),
 		namespaceCollection: inputBundle.GetNamespaceCollection(),
 		formatter:           inputBundle.GetSQLDialect().GetASTFormatter(),
+		pgInternalRouter:    inputBundle.GetDBMSInternalRouter(),
 	}
 	drmCfg, err := drm.GetDRMConfig(inputBundle.GetSQLDialect(), rv.namespaceCollection, controlAttributes)
 	if err != nil {

--- a/internal/stackql/primitivebuilder/raw_native_exec.go
+++ b/internal/stackql/primitivebuilder/raw_native_exec.go
@@ -1,0 +1,82 @@
+package primitivebuilder
+
+import (
+	"fmt"
+
+	"github.com/stackql/stackql/internal/stackql/dto"
+	"github.com/stackql/stackql/internal/stackql/handler"
+	"github.com/stackql/stackql/internal/stackql/logging"
+	"github.com/stackql/stackql/internal/stackql/primitive"
+	"github.com/stackql/stackql/internal/stackql/primitivegraph"
+	"github.com/stackql/stackql/internal/stackql/util"
+)
+
+type RawNativeExec struct {
+	graph       *primitivegraph.PrimitiveGraph
+	handlerCtx  *handler.HandlerContext
+	txnCtrlCtr  dto.TxnControlCounters
+	root        primitivegraph.PrimitiveNode
+	nativeQuery string
+}
+
+func NewRawNativeExec(
+	graph *primitivegraph.PrimitiveGraph,
+	handlerCtx *handler.HandlerContext,
+	txnCtrlCtr dto.TxnControlCounters,
+	nativeQuery string,
+) Builder {
+	return &RawNativeExec{
+		graph:       graph,
+		handlerCtx:  handlerCtx,
+		txnCtrlCtr:  txnCtrlCtr,
+		nativeQuery: nativeQuery,
+	}
+}
+
+func (ss *RawNativeExec) GetRoot() primitivegraph.PrimitiveNode {
+	return ss.root
+}
+
+func (ss *RawNativeExec) GetTail() primitivegraph.PrimitiveNode {
+	return ss.root
+}
+
+func (ss *RawNativeExec) Build() error {
+
+	selectEx := func(pc primitive.IPrimitiveCtx) dto.ExecutorOutput {
+
+		// select phase
+		logging.GetLogger().Infoln(fmt.Sprintf("running native query: '''%s''' ", ss.nativeQuery))
+
+		row, err := ss.handlerCtx.SQLEngine.Exec(ss.nativeQuery)
+
+		if row != nil {
+			rowsAffected, countErr := row.RowsAffected()
+			if countErr == nil {
+				logging.GetLogger().Debugf("native exec rows affected = %d\n", rowsAffected)
+			} else {
+				logging.GetLogger().Infof("native exec affected count error = '%s'\n", countErr.Error())
+			}
+		}
+
+		if err != nil {
+			return dto.NewErroneousExecutorOutput(err)
+		}
+
+		return util.PrepareResultSet(
+			dto.NewPrepareResultSetPlusRawDTO(
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				&dto.BackendMessages{WorkingMessages: []string{"exec completed"}}, nil),
+		)
+	}
+
+	graph := ss.graph
+	selectNode := graph.CreatePrimitiveNode(primitive.NewLocalPrimitive(selectEx))
+	ss.root = selectNode
+
+	return nil
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ psycopg2-binary
 psycopg[binary]
 PyYaml
 robotframework
+sqlalchemy

--- a/test/robot/functional/stackql.resource
+++ b/test/robot/functional/stackql.resource
@@ -46,7 +46,7 @@ Prepare StackQL Environment
     Start StackQL PG Server mTLS    ${PG_SRV_PORT_MTLS}    ${PG_SRV_MTLS_CFG_STR}    {}    {}    ${SQL_BACKEND_CFG_STR_CANONICAL}    ${PG_SRV_PORT_DOCKER_MTLS}
     Start StackQL PG Server mTLS    ${PG_SRV_PORT_MTLS_WITH_NAMESPACES}    ${PG_SRV_MTLS_CFG_STR}    ${NAMESPACES_TTL_SPECIALCASE_TRANSPARENT}    {}    ${SQL_BACKEND_CFG_STR_CANONICAL}    ${PG_SRV_PORT_DOCKER_MTLS_WITH_NAMESPACES}
     Start StackQL PG Server mTLS    ${PG_SRV_PORT_MTLS_WITH_EAGER_GC}    ${PG_SRV_MTLS_CFG_STR}    {}    ${GC_CFG_EAGER}    ${SQL_BACKEND_CFG_STR_CANONICAL}    ${PG_SRV_PORT_DOCKER_MTLS_WITH_EAGER_GC}
-    Start StackQL PG Server unencrypted    ${PG_SRV_PORT_UNENCRYPTED}    {}
+    Start StackQL PG Server unencrypted    ${PG_SRV_PORT_UNENCRYPTED}    {}    ${SQL_BACKEND_CFG_STR_CANONICAL}
     Sleep    50s
 
 Generate Container Credentials for StackQL PG Server mTLS
@@ -87,7 +87,7 @@ Start StackQL PG Server mTLS
     [Return]    ${process}
 
 Start StackQL PG Server unencrypted
-    [Arguments]    ${_SRV_PORT_UNENCRYPTED}    ${_NAMESPACES_CFG}
+    [Arguments]    ${_SRV_PORT_UNENCRYPTED}    ${_NAMESPACES_CFG}   ${_SQL_BACKEND_CFG}
     IF    "${EXECUTION_PLATFORM}" == "native"
         ${process} =    Start Process    ${STACKQL_EXE}
                         ...  srv    \-\-registry\=${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('native')}
@@ -96,6 +96,7 @@ Start StackQL PG Server unencrypted
                         ...  \-\-pgsrv\.address\=0.0.0.0 
                         ...  \-\-pgsrv\.port\=${_SRV_PORT_UNENCRYPTED}
                         ...  \-\-namespaces\=${_NAMESPACES_CFG}
+                        ...  \-\-sqlBackend\=${_SQL_BACKEND_CFG}
                         ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
                         ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
     ELSE IF    "${EXECUTION_PLATFORM}" == "docker"
@@ -106,7 +107,7 @@ Start StackQL PG Server unencrypted
                         ...  stackqlsrv
                         ...  bash
                         ...  \-c
-                        ...  stackql srv \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\=0.0.0.0 \-\-pgsrv\.port\=${PG_SRV_PORT_DOCKER_UNENCRYPTED}
+                        ...  stackql srv \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-sqlBackend\='${_SQL_BACKEND_CFG}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\=0.0.0.0 \-\-pgsrv\.port\=${PG_SRV_PORT_DOCKER_UNENCRYPTED}
                         ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
                         ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
     END

--- a/test/robot/functional/stackql_sessions_postgres.robot
+++ b/test/robot/functional/stackql_sessions_postgres.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Resource          ${CURDIR}/stackql.resource
+
+*** Test Cases *** 
+
+SQLAlchemy Session Positive Control
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    This is a postgres only test
+    Should SQLALchemy Raw Session Inline Equal
+    ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
+    ...    ${PG_CLIENT_SETUP_QUERIES}
+    ...    ${PG_CLIENT_SETUP_QUERIES_TUPLE_EXPECTED}
+    ...    stdout=${CURDIR}/tmp/SQLAlchemy-Session-Positive-Control.tmp
+    [Teardown]    NONE
+

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -15,6 +15,7 @@ from stackql_context import RegistryCfg, _TEST_APP_CACHE_ROOT
 from ShellSession import ShellSession
 from psycopg_client import PsycoPGClient
 from psycopg2_client import PsycoPG2Client
+from sqlalchemy_client import SQLAlchemyClient
 
 SQL_BACKEND_CANONICAL_SQLITE_EMBEDDED :str = 'sqlite_embedded'
 SQL_BACKEND_POSTGRES_TCP :str = 'postgres_tcp'
@@ -374,6 +375,16 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
   def should_PG_client_session_inline_equal(self, conn_str :str, queries :typing.List[str], expected_output :typing.List[typing.Dict], **kwargs):
     client = PsycoPGClient(conn_str)
     result =  client.run_queries(
+      queries
+    )
+    self.log(result)
+    return self.lists_should_be_equal(result, expected_output)
+
+
+  @keyword
+  def should_sqlalchemy_raw_session_inline_equal(self, conn_str :str, queries :typing.List[str], expected_output :typing.List, **kwargs):
+    client = SQLAlchemyClient(conn_str)
+    result =  client.run_raw_queries(
       queries
     )
     self.log(result)

--- a/test/robot/lib/sqlalchemy_client.py
+++ b/test/robot/lib/sqlalchemy_client.py
@@ -1,0 +1,31 @@
+import sqlalchemy
+import typing
+
+
+class SQLAlchemyClient(object):
+
+
+  def __init__(self, connection_string :str):
+    self._connection_string :str = connection_string
+    self._eng = sqlalchemy.create_engine(connection_string)
+
+
+  def _exec_raw_query(self, query :str) -> typing.List[typing.Dict]:
+    conn = self._eng.raw_connection()
+    curs = conn.cursor()
+    r = self._eng.execute(query)
+    return [ b for b in r.fetchall() ]
+
+
+  def _run_raw_queries(self, queries :typing.List[str]) -> typing.List[typing.Dict]:
+    ret_val = []
+    for q in queries:
+      nv = self._exec_raw_query(q)
+      if nv:
+        ret_val += nv
+    return ret_val
+
+
+  def run_raw_queries(self, queries :typing.List[str]) -> typing.List:
+    return self._run_raw_queries(queries)
+

--- a/test/robot/lib/stackql_context.py
+++ b/test/robot/lib/stackql_context.py
@@ -379,16 +379,20 @@ PSQL_CLIENT_HOST :str = "127.0.0.1"
 
 PSQL_MTLS_CONN_STR :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH} sslkey={STACKQL_PG_CLIENT_KEY_PATH} sslrootcert={STACKQL_PG_SERVER_CERT_PATH} dbname=mydatabase"
 PSQL_MTLS_CONN_STR_UNIX :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_UNIX} sslkey={STACKQL_PG_CLIENT_KEY_PATH_UNIX} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_UNIX} dbname=mydatabase"
+
 PSQL_MTLS_CONN_STR_UNIX_WITH_NAMESPACES :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS_WITH_NAMESPACES} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_UNIX} sslkey={STACKQL_PG_CLIENT_KEY_PATH_UNIX} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_UNIX} dbname=mydatabase"
 PSQL_MTLS_CONN_STR_UNIX_WITH_EAGER_GC :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS_WITH_EAGER_GC} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_UNIX} sslkey={STACKQL_PG_CLIENT_KEY_PATH_UNIX} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_UNIX} dbname=mydatabase"
 PSQL_MTLS_INVALID_CONN_STR :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=verify-full sslcert={STACKQL_PG_RUBBISH_CERT_PATH} sslkey={STACKQL_PG_RUBBISH_KEY_PATH} sslrootcert={STACKQL_PG_SERVER_CERT_PATH} dbname=mydatabase"
+
 PSQL_UNENCRYPTED_CONN_STR :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_UNENCRYPTED} user=myuser dbname=mydatabase"
+POSTGRES_URL_UNENCRYPTED_CONN :str = f"postgresql://myuser:mypass@{PSQL_CLIENT_HOST}:{PG_SRV_PORT_UNENCRYPTED}/mydatabase"
 
 PSQL_MTLS_CONN_STR_DOCKER :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_DOCKER} sslkey={STACKQL_PG_CLIENT_KEY_PATH_DOCKER} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_DOCKER} dbname=mydatabase"
 PSQL_MTLS_CONN_STR_WITH_NAMESPACES_DOCKER :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS_WITH_NAMESPACES} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_DOCKER} sslkey={STACKQL_PG_CLIENT_KEY_PATH_DOCKER} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_DOCKER} dbname=mydatabase"
 PSQL_MTLS_CONN_STR_WITH_EAGER_GC_DOCKER :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS_WITH_EAGER_GC} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_DOCKER} sslkey={STACKQL_PG_CLIENT_KEY_PATH_DOCKER} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_DOCKER} dbname=mydatabase"
 PSQL_MTLS_INVALID_CONN_STR_DOCKER :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=verify-full sslcert={STACKQL_PG_RUBBISH_CERT_PATH_DOCKER} sslkey={STACKQL_PG_RUBBISH_KEY_PATH_DOCKER} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_DOCKER} dbname=mydatabase"
 PSQL_UNENCRYPTED_CONN_STR_DOCKER :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_UNENCRYPTED} user=myuser dbname=mydatabase"
+POSTGRES_URL_UNENCRYPTED_CONN_DOCKER :str = f"postgresql://myuser:mypass@{PSQL_CLIENT_HOST}:{PG_SRV_PORT_UNENCRYPTED}/mydatabase"
 
 SELECT_CONTAINER_SUBNET_AGG_DESC = "select ipCidrRange, sum(5) cc  from  google.container.`projects.aggregated.usableSubnetworks` where projectsId = 'testing-project' group by ipCidrRange having sum(5) >= 5 order by ipCidrRange desc;"
 SELECT_CONTAINER_SUBNET_AGG_ASC = "select ipCidrRange, sum(5) cc  from  google.container.`projects.aggregated.usableSubnetworks` where projectsId = 'testing-project' group by ipCidrRange having sum(5) >= 5 order by ipCidrRange asc;"
@@ -406,6 +410,9 @@ SELECT_HSTORE_DETAILS = "SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace
 
 SHOW_TRANSACTION_ISOLATION_LEVEL_JSON_EXPECTED = [{"transaction_isolation": "read committed"}]
 SELECT_HSTORE_DETAILS_JSON_EXPECTED = []
+
+SHOW_TRANSACTION_ISOLATION_LEVEL_TUPLE_EXPECTED = [("read committed",)]
+SELECT_HSTORE_DETAILS_TUPLE_EXPECTED = []
 
 SELECT_AZURE_COMPUTE_PUBLIC_KEYS_EXPECTED = get_output_from_local_file(os.path.join('test', 'assets', 'expected', 'azure', 'compute', 'ssh-public-keys-list.txt'))
 SELECT_AZURE_COMPUTE_VIRTUAL_MACHINES_EXPECTED = get_output_from_local_file(os.path.join('test', 'assets', 'expected', 'azure', 'compute', 'vm-list.txt'))
@@ -608,6 +615,7 @@ def get_variables(execution_env :str, sql_backend_str :str):
     'PG_SRV_PORT_MTLS_WITH_EAGER_GC':                 PG_SRV_PORT_MTLS_WITH_EAGER_GC,
     'PG_SRV_PORT_MTLS_WITH_NAMESPACES':               PG_SRV_PORT_MTLS_WITH_NAMESPACES,
     'PG_SRV_PORT_UNENCRYPTED':                        PG_SRV_PORT_UNENCRYPTED,
+    'POSTGRES_URL_UNENCRYPTED_CONN':                  POSTGRES_URL_UNENCRYPTED_CONN,
     'PSQL_CLIENT_HOST':                               PSQL_CLIENT_HOST,
     'PSQL_EXE':                                       PSQL_EXE,
     'REGISTRY_ROOT_CANONICAL':                        _REGISTRY_CANONICAL,
@@ -635,6 +643,7 @@ def get_variables(execution_env :str, sql_backend_str :str):
     'GET_IAM_POLICY_AGG_ASC_EXPECTED':                                      GET_IAM_POLICY_AGG_ASC_EXPECTED,
     'PG_CLIENT_SETUP_QUERIES':                                              [ SHOW_TRANSACTION_ISOLATION_LEVEL, SELECT_HSTORE_DETAILS ],
     'PG_CLIENT_SETUP_QUERIES_JSON_EXPECTED':                                SHOW_TRANSACTION_ISOLATION_LEVEL_JSON_EXPECTED + SELECT_HSTORE_DETAILS_JSON_EXPECTED,
+    'PG_CLIENT_SETUP_QUERIES_TUPLE_EXPECTED':                               SHOW_TRANSACTION_ISOLATION_LEVEL_TUPLE_EXPECTED + SELECT_HSTORE_DETAILS_TUPLE_EXPECTED,
     'REGISTRY_GOOGLE_PROVIDER_LIST':                                        REGISTRY_GOOGLE_PROVIDER_LIST,
     'REGISTRY_GOOGLE_PROVIDER_LIST_EXPECTED':                               REGISTRY_GOOGLE_PROVIDER_LIST_EXPECTED,
     'REGISTRY_LIST':                                                        REGISTRY_LIST,


### PR DESCRIPTION
## Summary:

  - When using `postgres` as SQL backend, then pass through identifiable housekeeping queries.
  - Housekeeping queries can be identified prior to AST visitor passes.
    - Queries thus identified can pre-empt subsequent analysis and proceed straight to execution against `postgres`.
  - **TECH DEBT**: parser does not assemble viable trees for all housekeeping queries. 
     - Existing `postgres` formatter throws panic from this. 
      - RCA and fix should be done later but priority lower due to above pre-emption of analysis.
  - Previously failing `sqlalchemy` setup added as a robot test.