### PR TITLE
whitelist-working-postgres-view-robot-test

### DIFF
--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -49,7 +49,6 @@ PG Session GC Eager Behaviour Canonical
     [Teardown]    NONE
 
 PG Session View Handling Behaviour Canonical
-    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should PG Client Session Inline Equal
     ...    ${PSQL_MTLS_CONN_STR_UNIX_WITH_EAGER_GC}
     ...    ${SHELL_COMMANDS_VIEW_HANDLING_SEQUENCE}


### PR DESCRIPTION
## Summary:

- Removed blacklisting for `postgres` backend for one of the robot tests for views: 
    - Remaining view tests will not work in `postgres` due to case sensitivity / xml issue... addressing same is deferred.