### PR TITLE
support-for-pg-internal-subquery

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,8 @@
         "describe aws.pseudo_s3.s3_bucket_listing;",
         "select role_name from pgi.information_schema.applicable_roles where role_name = 'pg_database_owner';",
         "select r1.role_name from pgi.information_schema.applicable_roles r1 inner join pgi.information_schema.applicable_roles r2 on r1.role_name = r2.role_name order by r1.role_name desc;",
-        "select rtg.table_catalog, rtg.table_schema, rtg.table_name, rtg.privilege_type, rtg.is_grantable, ar.is_grantable as role_is_grantable from pgi.information_schema.role_table_grants rtg inner join pgi.information_schema.applicable_roles ar on rtg.grantee = ar.grantee where rtg.table_name = 'pg_statistic' order by privilege_type desc;"
+        "select rtg.table_catalog, rtg.table_schema, rtg.table_name, rtg.privilege_type, rtg.is_grantable, ar.is_grantable as role_is_grantable from pgi.information_schema.role_table_grants rtg inner join pgi.information_schema.applicable_roles ar on rtg.grantee = ar.grantee where rtg.table_name = 'pg_statistic' order by privilege_type desc;",
+        "SELECT zone AS zone, count(kind) AS \"COUNT(kind)\" FROM (SELECT *    from stackql_intel.\"google.compute.acceleratorTypes\"    limit 3) AS virtual_table GROUP BY zone ORDER BY \"COUNT(kind)\" DESC LIMIT 1000;"
       ],
       "default": "show providers;"
     },
@@ -139,7 +140,7 @@
       "default": "{}",
       "options": [
         "{}",
-        "{ \"tableRegex\": \"(?i)^(?:public\\\\.)?(?:pg_.*|current_schema|information_schema)\" }"
+        "{ \"tableRegex\": \"(?i)^(?:public\\\\.)?(?:pg_.*|current_schema|information_schema|stackql_intel)\" }"
       ]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ env CGO_ENABLED=1 go build \
   -X github.com/stackql/stackql/internal/stackql/cmd.BuildShortCommitSHA=$BUILDSHORTCOMMITSHA \
   -X \"github.com/stackql/stackql/internal/stackql/cmd.BuildDate=$BUILDDATE\" \
   -X \"stackql/internal/stackql/planbuilder.PlanCacheEnabled=$PLANCACHEENABLED\" \
-  -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform=$BUILDPLATFORM" -o ./build ./...
+  -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform=$BUILDPLATFORM" -o ./build ./stackql
 
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,6 @@ replace github.com/chzyer/readline => github.com/stackql/readline v0.0.2-alpha05
 
 replace github.com/fatih/color => github.com/stackql/color v0.0.1-rc01
 
-replace vitess.io/vitess => github.com/stackql/vitess v0.0.12-alpha06
+replace vitess.io/vitess => github.com/stackql/vitess v0.0.12-alpha07
 
 replace github.com/jeroenrinzema/psql-wire => github.com/stackql/psql-wire v0.0.2-stackqlbeta14

--- a/go.sum
+++ b/go.sum
@@ -794,8 +794,8 @@ github.com/stackql/readline v0.0.2-alpha05 h1:ID4QzGdplFBsrSnTuz8pvKzWw96JbrJg8f
 github.com/stackql/readline v0.0.2-alpha05/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01 h1:3XorfaYEhGpuvEeQK04EmpZUCr42hZ/a4Nh3wE25LF0=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01/go.mod h1:D0WFWa7HOXS+PQAmvN0Nm1E6dMdUkUFtAzRH8cXxg88=
-github.com/stackql/vitess v0.0.12-alpha06 h1:05rpWs895wB46X6DzapzvhLoQ/b5Y08m1sLele80bqo=
-github.com/stackql/vitess v0.0.12-alpha06/go.mod h1:6aOZHbgHclTasEGZvrdoWfca6Y4XJfemKMqwnDL/klI=
+github.com/stackql/vitess v0.0.12-alpha07 h1:efZeRn3VOctkUMoTsATmY1bcyqijej8vcqIjmf6Vhao=
+github.com/stackql/vitess v0.0.12-alpha07/go.mod h1:6aOZHbgHclTasEGZvrdoWfca6Y4XJfemKMqwnDL/klI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/internal/stackql/astindirect/indirect.go
+++ b/internal/stackql/astindirect/indirect.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stackql/go-openapistackql/openapistackql"
 	"github.com/stackql/stackql/internal/stackql/drm"
-	"github.com/stackql/stackql/internal/stackql/parse"
 	"github.com/stackql/stackql/internal/stackql/symtab"
 
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
@@ -32,6 +31,18 @@ func NewViewIndirect(viewDTO internaldto.ViewDTO) (Indirect, error) {
 	return rv, nil
 }
 
+func NewSubqueryIndirect(subQuery *sqlparser.Subquery) (Indirect, error) {
+	if subQuery == nil {
+		return nil, fmt.Errorf("cannot accomodate nil subquery")
+	}
+	rv := &subquery{
+		subQuery:              subQuery,
+		selectStmt:            subQuery.Select,
+		underlyingSymbolTable: symtab.NewHashMapTreeSymTab(),
+	}
+	return rv, nil
+}
+
 type Indirect interface {
 	Parse() error
 	GetAssignedParameters() (internaldto.TableParameterCollection, bool)
@@ -47,95 +58,4 @@ type Indirect interface {
 	SetAssignedParameters(internaldto.TableParameterCollection)
 	SetSelectContext(drm.PreparedStatementCtx)
 	SetUnderlyingSymTab(symtab.SymTab)
-}
-
-type view struct {
-	viewDTO               internaldto.ViewDTO
-	selectStmt            sqlparser.SelectStatement
-	selCtx                drm.PreparedStatementCtx
-	paramCollection       internaldto.TableParameterCollection
-	underlyingSymbolTable symtab.SymTab
-}
-
-func (v *view) GetType() IndirectType {
-	return ViewType
-}
-
-func (v *view) GetAssignedParameters() (internaldto.TableParameterCollection, bool) {
-	return v.paramCollection, v.paramCollection != nil
-}
-
-func (v *view) SetAssignedParameters(paramCollection internaldto.TableParameterCollection) {
-	v.paramCollection = paramCollection
-}
-
-func (v *view) GetUnderlyingSymTab() symtab.SymTab {
-	return v.underlyingSymbolTable
-}
-
-func (v *view) SetUnderlyingSymTab(symbolTable symtab.SymTab) {
-	v.underlyingSymbolTable = symbolTable
-}
-
-func (v *view) GetName() string {
-	return v.viewDTO.GetName()
-}
-
-func (v *view) GetColumns() []internaldto.ColumnMetadata {
-	return v.selCtx.GetNonControlColumns()
-}
-
-func (v *view) GetOptionalParameters() map[string]openapistackql.Addressable {
-	return nil
-}
-
-func (v *view) GetRequiredParameters() map[string]openapistackql.Addressable {
-	return nil
-}
-
-func (v *view) GetColumnByName(name string) (internaldto.ColumnMetadata, bool) {
-	for _, col := range v.selCtx.GetNonControlColumns() {
-		if col.GetIdentifier() == name {
-			return col, true
-		}
-	}
-	return nil, false
-}
-
-func (v *view) SetSelectContext(selCtx drm.PreparedStatementCtx) {
-	v.selCtx = selCtx
-}
-
-func (v *view) GetSelectContext() drm.PreparedStatementCtx {
-	return v.selCtx
-}
-
-func (v *view) GetTables() sqlparser.TableExprs {
-	return nil
-}
-
-func (v *view) getAST() (sqlparser.Statement, error) {
-	return parse.ParseQuery(v.viewDTO.GetRawQuery())
-}
-
-func (v *view) GetSelectAST() sqlparser.SelectStatement {
-	return v.selectStmt
-}
-
-func (v *view) GetSelectionCtx() (drm.PreparedStatementCtx, error) {
-	return v.selCtx, nil
-}
-
-func (v *view) Parse() error {
-	parseResult, err := v.getAST()
-	if err != nil {
-		return err
-	}
-	switch pr := parseResult.(type) {
-	case sqlparser.SelectStatement:
-		v.selectStmt = pr
-		return nil
-	default:
-		return fmt.Errorf("view of type '%T' not yet supported", pr)
-	}
 }

--- a/internal/stackql/astindirect/subquery_indirect.go
+++ b/internal/stackql/astindirect/subquery_indirect.go
@@ -1,0 +1,92 @@
+package astindirect
+
+import (
+	"github.com/stackql/go-openapistackql/openapistackql"
+	"github.com/stackql/stackql/internal/stackql/drm"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stackql/stackql/internal/stackql/parse"
+	"github.com/stackql/stackql/internal/stackql/symtab"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+type subquery struct {
+	viewDTO               internaldto.ViewDTO
+	subQuery              *sqlparser.Subquery
+	selectStmt            sqlparser.SelectStatement
+	selCtx                drm.PreparedStatementCtx
+	paramCollection       internaldto.TableParameterCollection
+	underlyingSymbolTable symtab.SymTab
+}
+
+func (v *subquery) GetType() IndirectType {
+	return SubqueryType
+}
+
+func (v *subquery) GetAssignedParameters() (internaldto.TableParameterCollection, bool) {
+	return v.paramCollection, v.paramCollection != nil
+}
+
+func (v *subquery) SetAssignedParameters(paramCollection internaldto.TableParameterCollection) {
+	v.paramCollection = paramCollection
+}
+
+func (v *subquery) GetUnderlyingSymTab() symtab.SymTab {
+	return v.underlyingSymbolTable
+}
+
+func (v *subquery) SetUnderlyingSymTab(symbolTable symtab.SymTab) {
+	v.underlyingSymbolTable = symbolTable
+}
+
+func (v *subquery) GetName() string {
+	return v.viewDTO.GetName()
+}
+
+func (v *subquery) GetColumns() []internaldto.ColumnMetadata {
+	return v.selCtx.GetNonControlColumns()
+}
+
+func (v *subquery) GetOptionalParameters() map[string]openapistackql.Addressable {
+	return nil
+}
+
+func (v *subquery) GetRequiredParameters() map[string]openapistackql.Addressable {
+	return nil
+}
+
+func (v *subquery) GetColumnByName(name string) (internaldto.ColumnMetadata, bool) {
+	for _, col := range v.selCtx.GetNonControlColumns() {
+		if col.GetIdentifier() == name {
+			return col, true
+		}
+	}
+	return nil, false
+}
+
+func (v *subquery) SetSelectContext(selCtx drm.PreparedStatementCtx) {
+	v.selCtx = selCtx
+}
+
+func (v *subquery) GetSelectContext() drm.PreparedStatementCtx {
+	return v.selCtx
+}
+
+func (v *subquery) GetTables() sqlparser.TableExprs {
+	return nil
+}
+
+func (v *subquery) getAST() (sqlparser.Statement, error) {
+	return parse.ParseQuery(v.viewDTO.GetRawQuery())
+}
+
+func (v *subquery) GetSelectAST() sqlparser.SelectStatement {
+	return v.selectStmt
+}
+
+func (v *subquery) GetSelectionCtx() (drm.PreparedStatementCtx, error) {
+	return v.selCtx, nil
+}
+
+func (v *subquery) Parse() error {
+	return nil
+}

--- a/internal/stackql/astindirect/view_indirect.go
+++ b/internal/stackql/astindirect/view_indirect.go
@@ -1,0 +1,103 @@
+package astindirect
+
+import (
+	"fmt"
+
+	"github.com/stackql/go-openapistackql/openapistackql"
+	"github.com/stackql/stackql/internal/stackql/drm"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stackql/stackql/internal/stackql/parse"
+	"github.com/stackql/stackql/internal/stackql/symtab"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+type view struct {
+	viewDTO               internaldto.ViewDTO
+	selectStmt            sqlparser.SelectStatement
+	selCtx                drm.PreparedStatementCtx
+	paramCollection       internaldto.TableParameterCollection
+	underlyingSymbolTable symtab.SymTab
+}
+
+func (v *view) GetType() IndirectType {
+	return ViewType
+}
+
+func (v *view) GetAssignedParameters() (internaldto.TableParameterCollection, bool) {
+	return v.paramCollection, v.paramCollection != nil
+}
+
+func (v *view) SetAssignedParameters(paramCollection internaldto.TableParameterCollection) {
+	v.paramCollection = paramCollection
+}
+
+func (v *view) GetUnderlyingSymTab() symtab.SymTab {
+	return v.underlyingSymbolTable
+}
+
+func (v *view) SetUnderlyingSymTab(symbolTable symtab.SymTab) {
+	v.underlyingSymbolTable = symbolTable
+}
+
+func (v *view) GetName() string {
+	return v.viewDTO.GetName()
+}
+
+func (v *view) GetColumns() []internaldto.ColumnMetadata {
+	return v.selCtx.GetNonControlColumns()
+}
+
+func (v *view) GetOptionalParameters() map[string]openapistackql.Addressable {
+	return nil
+}
+
+func (v *view) GetRequiredParameters() map[string]openapistackql.Addressable {
+	return nil
+}
+
+func (v *view) GetColumnByName(name string) (internaldto.ColumnMetadata, bool) {
+	for _, col := range v.selCtx.GetNonControlColumns() {
+		if col.GetIdentifier() == name {
+			return col, true
+		}
+	}
+	return nil, false
+}
+
+func (v *view) SetSelectContext(selCtx drm.PreparedStatementCtx) {
+	v.selCtx = selCtx
+}
+
+func (v *view) GetSelectContext() drm.PreparedStatementCtx {
+	return v.selCtx
+}
+
+func (v *view) GetTables() sqlparser.TableExprs {
+	return nil
+}
+
+func (v *view) getAST() (sqlparser.Statement, error) {
+	return parse.ParseQuery(v.viewDTO.GetRawQuery())
+}
+
+func (v *view) GetSelectAST() sqlparser.SelectStatement {
+	return v.selectStmt
+}
+
+func (v *view) GetSelectionCtx() (drm.PreparedStatementCtx, error) {
+	return v.selCtx, nil
+}
+
+func (v *view) Parse() error {
+	parseResult, err := v.getAST()
+	if err != nil {
+		return err
+	}
+	switch pr := parseResult.(type) {
+	case sqlparser.SelectStatement:
+		v.selectStmt = pr
+		return nil
+	default:
+		return fmt.Errorf("view of type '%T' not yet supported", pr)
+	}
+}

--- a/internal/stackql/constants/constants.go
+++ b/internal/stackql/constants/constants.go
@@ -71,4 +71,5 @@ const (
 	BackendExec BackendQueryType = iota
 	BackendQuery
 	BackendNop
+	BackendTableObject
 )

--- a/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
+++ b/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
@@ -22,6 +22,8 @@ type HeirarchyIdentifiers interface {
 	GetTableName() string
 	GetView() (ViewDTO, bool)
 	GetSubAST() sqlparser.Statement
+	ContainsNativeDBMSTable() bool
+	SetContainsNativeDBMSTable(bool)
 	SetSubAST(sqlparser.Statement)
 	SetMethodStr(string)
 	WithView(ViewDTO) HeirarchyIdentifiers
@@ -37,10 +39,19 @@ type standardHeirarchyIdentifiers struct {
 	methodStr         string
 	viewDTO           ViewDTO
 	viewAST           sqlparser.Statement
+	containsDBMSTable bool
 }
 
 func (hi *standardHeirarchyIdentifiers) SetMethodStr(mStr string) {
 	hi.methodStr = mStr
+}
+
+func (hi *standardHeirarchyIdentifiers) ContainsNativeDBMSTable() bool {
+	return hi.containsDBMSTable
+}
+
+func (hi *standardHeirarchyIdentifiers) SetContainsNativeDBMSTable(containsDBMSTable bool) {
+	hi.containsDBMSTable = containsDBMSTable
 }
 
 func (hi *standardHeirarchyIdentifiers) SetSubAST(viewAST sqlparser.Statement) {

--- a/internal/stackql/router/table_routing.go
+++ b/internal/stackql/router/table_routing.go
@@ -55,7 +55,7 @@ func (v *standardTableRouteAstVisitor) analyzeAliasedTable(tb *sqlparser.Aliased
 		}
 		return v.router.Route(tb, v.handlerCtx)
 	default:
-		return nil, fmt.Errorf("table of type '%T' not curently supported", ex)
+		return nil, fmt.Errorf("table of type '%T' not currently supported", ex)
 	}
 }
 

--- a/internal/stackql/taxonomy/hierarchy.go
+++ b/internal/stackql/taxonomy/hierarchy.go
@@ -70,6 +70,11 @@ func getHids(handlerCtx handler.HandlerContext, node sqlparser.SQLNode) (interna
 	if isView {
 		hIds = hIds.WithView(viewDTO)
 	}
+	isInternallyRoutable := handlerCtx.GetPGInternalRouter().ExprIsRoutable(node)
+	if isInternallyRoutable {
+		hIds.SetContainsNativeDBMSTable(true)
+		return hIds, nil
+	}
 	if !(isView) && hIds.GetProviderStr() == "" {
 		if handlerCtx.GetCurrentProvider() == "" {
 			return nil, fmt.Errorf("could not locate table '%s'", hIds.GetTableName())

--- a/test/robot/functional/stackql_sessions_postgres.robot
+++ b/test/robot/functional/stackql_sessions_postgres.robot
@@ -31,10 +31,11 @@ SQLAlchemy Session Postgres PID Function
     [Teardown]    NONE
 
 SQLAlchemy Session Postgres Intel Views Exist
+    Log    This test expects exactly 4 results per query in the sequence
     Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    This is a postgres only test
     Should SQLALchemy Raw Session Inline Have Length Greater Than Or Equal To
     ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
     ...    ${SELECT_ACCELERATOR_TYPES_DESC_SEQUENCE}
-    ...    8
+    ...    12
     ...    stdout=${CURDIR}/tmp/SQLAlchemy-Session-Postgres-Intel-Views-Exist.tmp
     [Teardown]    NONE

--- a/test/robot/lib/stackql_context.py
+++ b/test/robot/lib/stackql_context.py
@@ -515,6 +515,7 @@ SELECT_CONTAINER_SUBNET_AGG_DESC = "select ipCidrRange, sum(5) cc  from  google.
 SELECT_CONTAINER_SUBNET_AGG_ASC = "select ipCidrRange, sum(5) cc  from  google.container.\"projects.aggregated.usableSubnetworks\" where projectsId = 'testing-project' group by ipCidrRange having sum(5) >= 5 order by ipCidrRange asc;"
 SELECT_ACCELERATOR_TYPES_DESC = "select  kind, name  from  google.compute.acceleratorTypes where project = 'testing-project' and zone = 'australia-southeast1-a' order by name desc;"
 SELECT_ACCELERATOR_TYPES_DESC_FROM_INTEL_VIEWS = "select  kind, name  from  stackql_intel.\"google.compute.acceleratorTypes\" where project = 'testing-project' and zone like '%%australia-southeast1-a' order by name desc;"
+SELECT_ACCELERATOR_TYPES_DESC_FROM_INTEL_VIEWS_SUBQUERY = "SELECT name AS name, count(kind) AS \"COUNT(kind)\" FROM (SELECT *    from stackql_intel.\"google.compute.acceleratorTypes\"    limit 80) AS virtual_table GROUP BY name ORDER BY \"COUNT(kind)\" DESC LIMIT 1000;"
 SELECT_MACHINE_TYPES_DESC = "select name from google.compute.machineTypes where project = 'testing-project' and zone = 'australia-southeast1-a' order by name desc;"
 SELECT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY = "SELECT etag FROM google.compute.instances_iam_policies WHERE project = 'testing-project' AND zone = 'australia-southeast1-a' AND resource = '000000001';"
 
@@ -826,7 +827,7 @@ def get_variables(execution_env :str, sql_backend_str :str):
     'REGISTRY_LIST_EXPECTED':                                                 REGISTRY_LIST_EXPECTED,
     'SELECT_ACCELERATOR_TYPES_DESC':                                          SELECT_ACCELERATOR_TYPES_DESC,
     'SELECT_ACCELERATOR_TYPES_DESC_EXPECTED':                                 SELECT_ACCELERATOR_TYPES_DESC_EXPECTED,
-    'SELECT_ACCELERATOR_TYPES_DESC_SEQUENCE':                                 [ SELECT_ACCELERATOR_TYPES_DESC, SELECT_ACCELERATOR_TYPES_DESC_FROM_INTEL_VIEWS ],
+    'SELECT_ACCELERATOR_TYPES_DESC_SEQUENCE':                                 [ SELECT_ACCELERATOR_TYPES_DESC, SELECT_ACCELERATOR_TYPES_DESC_FROM_INTEL_VIEWS, SELECT_ACCELERATOR_TYPES_DESC_FROM_INTEL_VIEWS_SUBQUERY ],
     'SELECT_ANALYTICS_CACHE_GITHUB_REPOSITORIES_COLLABORATORS_EXPECTED':      SELECT_ANALYTICS_CACHE_GITHUB_REPOSITORIES_COLLABORATORS_EXPECTED,
     'SELECT_ANALYTICS_CACHE_GITHUB_REPOSITORIES_COLLABORATORS_SIMPLE':        SELECT_ANALYTICS_CACHE_GITHUB_REPOSITORIES_COLLABORATORS_SIMPLE,
     'SELECT_ANALYTICS_CACHE_GITHUB_REPOSITORIES_COLLABORATORS_TRANSPARENT':   SELECT_ANALYTICS_CACHE_GITHUB_REPOSITORIES_COLLABORATORS_TRANSPARENT,


### PR DESCRIPTION
## Summary:

- Basic support for `postgres` internal subqueries, routed directly to `postgres`.
- Any `postgres` internal tables / views will route the entire query to `postgres`; no hybrids.
- Expanded existing robot test on `google.compute.acceleratorTypes` to verify tables in `stackql_intel` are routable via subquery.
