### PR TITLE
subquery-support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,10 @@
         "select role_name from pgi.information_schema.applicable_roles where role_name = 'pg_database_owner';",
         "select r1.role_name from pgi.information_schema.applicable_roles r1 inner join pgi.information_schema.applicable_roles r2 on r1.role_name = r2.role_name order by r1.role_name desc;",
         "select rtg.table_catalog, rtg.table_schema, rtg.table_name, rtg.privilege_type, rtg.is_grantable, ar.is_grantable as role_is_grantable from pgi.information_schema.role_table_grants rtg inner join pgi.information_schema.applicable_roles ar on rtg.grantee = ar.grantee where rtg.table_name = 'pg_statistic' order by privilege_type desc;",
-        "SELECT zone AS zone, count(kind) AS \"COUNT(kind)\" FROM (SELECT *    from stackql_intel.\"google.compute.acceleratorTypes\"    limit 3) AS virtual_table GROUP BY zone ORDER BY \"COUNT(kind)\" DESC LIMIT 1000;"
+        "SELECT zone AS zone, count(kind) AS \"COUNT(kind)\" FROM (SELECT *    from stackql_intel.\"google.compute.acceleratorTypes\"    limit 3) AS virtual_table GROUP BY zone ORDER BY \"COUNT(kind)\" DESC LIMIT 1000;",
+        "select * from (select VolumeId, Encrypted, Size from aws.ec2.volumes where region = 'ap-southeast-1' order by VolumeId asc) as zz;",
+        "select * from (select id, name, url from github.repos.repos where org = 'stackql') zz;",
+        "select * from zz1;"
       ],
       "default": "show providers;"
     },

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,21 @@
+
+## Dashboard software particulars
+
+- Dashboard software can interrogate views. 
+- Tables and views need to be defined *a priori* for queries to work.  
+  This implies that some AOT pre-charging of tables is required.  Here are some options:
+    - ~~(a) Dedicate some namespace to such queries.  For any query against the namespace, front load table and view creation and then proceed.~~ **This, on its own, will NOT work for creating dashboards because the dashboard software will be unaware of the requisite table / view objects.**
+    - (b) Pre-charge all tables and views upon provider download.  Superficially, seems damned expensive.
+    - (c) **Hack**: Run ad hoc queries (or batches) to pre-charge from within dashboard (or `stackql`) as an offline, admin activity.
+- Doing either (b) or (c) will require `stackql` to natively support subqueries.
+- Could consider some `precharge <table_name_list> ;` grammar to facilitate.
+
+
+## Data flow
+
+1. Admin (or automated) action to pre-charge tables.
+1. Admin user enters `stackql` query to pre-charge tables.
+2. `stackql` executes query and returns results.
+
+
+

--- a/internal/stackql/astanalysis/annotatedast/annotated_ast.go
+++ b/internal/stackql/astanalysis/annotatedast/annotated_ast.go
@@ -67,6 +67,10 @@ func (aa *standardAnnotatedAst) SetSelectMetadata(selNode *sqlparser.Select, met
 func (aa *standardAnnotatedAst) GetIndirect(node sqlparser.SQLNode) (astindirect.Indirect, bool) {
 	switch n := node.(type) {
 	case *sqlparser.AliasedTableExpr:
+		rv, ok := aa.tableIndirects[n.As.GetRawVal()]
+		if ok {
+			return rv, true
+		}
 		return aa.GetIndirect(n.Expr)
 	case sqlparser.TableName:
 		rv, ok := aa.tableIndirects[n.GetRawVal()]
@@ -84,6 +88,9 @@ func (aa *standardAnnotatedAst) SetIndirect(node sqlparser.SQLNode, indirect ast
 	switch n := node.(type) {
 	case sqlparser.TableName:
 		aa.tableIndirects[n.GetRawVal()] = indirect
+	case *sqlparser.AliasedTableExpr:
+		// this is for subqueries
+		aa.tableIndirects[n.As.GetRawVal()] = indirect
 	default:
 	}
 }

--- a/internal/stackql/astindirect/indirect.go
+++ b/internal/stackql/astindirect/indirect.go
@@ -31,13 +31,14 @@ func NewViewIndirect(viewDTO internaldto.ViewDTO) (Indirect, error) {
 	return rv, nil
 }
 
-func NewSubqueryIndirect(subQuery *sqlparser.Subquery) (Indirect, error) {
-	if subQuery == nil {
+func NewSubqueryIndirect(subQueryDTO internaldto.SubqueryDTO) (Indirect, error) {
+	if subQueryDTO == nil {
 		return nil, fmt.Errorf("cannot accomodate nil subquery")
 	}
 	rv := &subquery{
-		subQuery:              subQuery,
-		selectStmt:            subQuery.Select,
+		subQueryDTO:           subQueryDTO,
+		subQuery:              subQueryDTO.GetSubquery(),
+		selectStmt:            subQueryDTO.GetSubquery().Select,
 		underlyingSymbolTable: symtab.NewHashMapTreeSymTab(),
 	}
 	return rv, nil

--- a/internal/stackql/astindirect/subquery_indirect.go
+++ b/internal/stackql/astindirect/subquery_indirect.go
@@ -4,13 +4,12 @@ import (
 	"github.com/stackql/go-openapistackql/openapistackql"
 	"github.com/stackql/stackql/internal/stackql/drm"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
-	"github.com/stackql/stackql/internal/stackql/parse"
 	"github.com/stackql/stackql/internal/stackql/symtab"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 type subquery struct {
-	viewDTO               internaldto.ViewDTO
+	subQueryDTO           internaldto.SubqueryDTO
 	subQuery              *sqlparser.Subquery
 	selectStmt            sqlparser.SelectStatement
 	selCtx                drm.PreparedStatementCtx
@@ -39,7 +38,7 @@ func (v *subquery) SetUnderlyingSymTab(symbolTable symtab.SymTab) {
 }
 
 func (v *subquery) GetName() string {
-	return v.viewDTO.GetName()
+	return v.subQueryDTO.GetAlias().GetRawVal()
 }
 
 func (v *subquery) GetColumns() []internaldto.ColumnMetadata {
@@ -76,7 +75,7 @@ func (v *subquery) GetTables() sqlparser.TableExprs {
 }
 
 func (v *subquery) getAST() (sqlparser.Statement, error) {
-	return parse.ParseQuery(v.viewDTO.GetRawQuery())
+	return v.subQuery.Select, nil
 }
 
 func (v *subquery) GetSelectAST() sqlparser.SelectStatement {

--- a/internal/stackql/astvisit/from_rewrite.go
+++ b/internal/stackql/astvisit/from_rewrite.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackql/stackql/internal/stackql/astanalysis/annotatedast"
 	"github.com/stackql/stackql/internal/stackql/astformat"
+	"github.com/stackql/stackql/internal/stackql/astindirect"
 	"github.com/stackql/stackql/internal/stackql/drm"
 	"github.com/stackql/stackql/internal/stackql/sql_system"
 	"github.com/stackql/stackql/internal/stackql/tablenamespace"
@@ -634,7 +635,11 @@ func (v *standardFromRewriteAstVisitor) Visit(node sqlparser.SQLNode) error {
 			if indirect, isIndirect := anCtx.GetTableMeta().GetIndirect(); isIndirect {
 				//
 				alias := indirect.GetName()
-				templateString := fmt.Sprintf(` ( %%s ) AS "%s" `, alias)
+				indirectType := indirect.GetType()
+				templateString := ` ( %s ) `
+				if indirectType == astindirect.ViewType {
+					templateString = fmt.Sprintf(` ( %%s ) AS "%s" `, alias)
+				}
 				v.rewrittenQuery = templateString
 				v.indirectContexts = append(v.indirectContexts, indirect.GetSelectContext())
 

--- a/internal/stackql/dependencyplanner/dependencyplanner.go
+++ b/internal/stackql/dependencyplanner/dependencyplanner.go
@@ -121,7 +121,9 @@ func (dp *standardDependencyPlanner) Plan() error {
 			}
 			tableExpr := unit.GetTableExpr()
 			annotation := unit.GetAnnotation()
-			if _, isView := annotation.GetView(); isView {
+			_, isView := annotation.GetView()
+			_, isSubquery := annotation.GetSubquery()
+			if isView || isSubquery {
 				dp.annMap[tableExpr] = annotation
 				continue
 			}

--- a/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
+++ b/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
@@ -20,6 +20,7 @@ type HeirarchyIdentifiers interface {
 	GetSQLDataSourceTableName() string
 	GetStackQLTableName() string
 	GetTableName() string
+	GetSubquery() (SubqueryDTO, bool)
 	GetView() (ViewDTO, bool)
 	GetSubAST() sqlparser.Statement
 	ContainsNativeDBMSTable() bool
@@ -27,6 +28,7 @@ type HeirarchyIdentifiers interface {
 	SetSubAST(sqlparser.Statement)
 	SetMethodStr(string)
 	WithView(ViewDTO) HeirarchyIdentifiers
+	withSubquery(SubqueryDTO) HeirarchyIdentifiers
 	WithProviderStr(string) HeirarchyIdentifiers
 	WithResponseSchemaStr(rss string) HeirarchyIdentifiers
 }
@@ -38,6 +40,7 @@ type standardHeirarchyIdentifiers struct {
 	responseSchemaStr string
 	methodStr         string
 	viewDTO           ViewDTO
+	subqueryDTO       SubqueryDTO
 	viewAST           sqlparser.Statement
 	containsDBMSTable bool
 }
@@ -74,6 +77,10 @@ func (hi *standardHeirarchyIdentifiers) GetView() (ViewDTO, bool) {
 	return hi.viewDTO, hi.viewDTO != nil
 }
 
+func (hi *standardHeirarchyIdentifiers) GetSubquery() (SubqueryDTO, bool) {
+	return hi.subqueryDTO, hi.subqueryDTO != nil
+}
+
 func (hi *standardHeirarchyIdentifiers) GetResourceStr() string {
 	return hi.resourceStr
 }
@@ -93,6 +100,11 @@ func (hi *standardHeirarchyIdentifiers) WithProviderStr(ps string) HeirarchyIden
 
 func (hi *standardHeirarchyIdentifiers) WithView(viewDTO ViewDTO) HeirarchyIdentifiers {
 	hi.viewDTO = viewDTO
+	return hi
+}
+
+func (hi *standardHeirarchyIdentifiers) withSubquery(subQuery SubqueryDTO) HeirarchyIdentifiers {
+	hi.subqueryDTO = subQuery
 	return hi
 }
 
@@ -161,4 +173,13 @@ func ResolveResourceTerminalHeirarchyIdentifiers(node sqlparser.TableName) Heira
 		iqlutil.SanitisePossibleTickEscapedTerm(node.Name.String()),
 		"",
 	)
+}
+
+func ObtainSubqueryHeirarchyIdentifiers(subQuery SubqueryDTO) HeirarchyIdentifiers {
+	return NewHeirarchyIdentifiers(
+		"",
+		"",
+		"",
+		"",
+	).withSubquery(subQuery)
 }

--- a/internal/stackql/internal_data_transfer/internaldto/subquery_dto.go
+++ b/internal/stackql/internal_data_transfer/internaldto/subquery_dto.go
@@ -1,0 +1,37 @@
+package internaldto
+
+import "vitess.io/vitess/go/vt/sqlparser"
+
+var (
+	_ SubqueryDTO = &standardSubqueryDTO{}
+)
+
+func NewSubqueryDTO(aliasedTableExpr *sqlparser.AliasedTableExpr, subQuery *sqlparser.Subquery) SubqueryDTO {
+	return &standardSubqueryDTO{
+		aliasedTableExpr: aliasedTableExpr,
+		subQuery:         subQuery,
+	}
+}
+
+type SubqueryDTO interface {
+	GetSubquery() *sqlparser.Subquery
+	GetAlias() sqlparser.TableIdent
+	GetAliasedTableExpr() *sqlparser.AliasedTableExpr
+}
+
+type standardSubqueryDTO struct {
+	subQuery         *sqlparser.Subquery
+	aliasedTableExpr *sqlparser.AliasedTableExpr
+}
+
+func (v *standardSubqueryDTO) GetSubquery() *sqlparser.Subquery {
+	return v.subQuery
+}
+
+func (v *standardSubqueryDTO) GetAlias() sqlparser.TableIdent {
+	return v.aliasedTableExpr.As
+}
+
+func (v *standardSubqueryDTO) GetAliasedTableExpr() *sqlparser.AliasedTableExpr {
+	return v.aliasedTableExpr
+}

--- a/internal/stackql/router/annotations_machinery.go
+++ b/internal/stackql/router/annotations_machinery.go
@@ -18,7 +18,8 @@ func obtainAnnotationCtx(
 ) (taxonomy.AnnotationCtx, error) {
 	_, isView := tbl.GetView()
 	_, isSQLDataSource := tbl.GetSQLDataSource()
-	if isView || isSQLDataSource {
+	_, isSubquery := tbl.GetSubquery()
+	if isView || isSQLDataSource || isSubquery {
 		// TODO: upgrade this flow; nil == YUCK!!!
 		return taxonomy.NewStaticStandardAnnotationCtx(nil, tbl.GetHeirarchyObjects().GetHeirarchyIds(), tbl, parameters), nil
 	}

--- a/internal/stackql/router/table_routing.go
+++ b/internal/stackql/router/table_routing.go
@@ -46,6 +46,8 @@ func NewTableRouteAstVisitor(handlerCtx handler.HandlerContext, router Parameter
 
 func (v *standardTableRouteAstVisitor) analyzeAliasedTable(tb *sqlparser.AliasedTableExpr) (taxonomy.AnnotationCtx, error) {
 	switch ex := tb.Expr.(type) {
+	case *sqlparser.Subquery:
+		return v.router.Route(tb, v.handlerCtx)
 	case sqlparser.TableName:
 		hIDs, err := taxonomy.GetHeirarchyIDsFromParserNode(v.handlerCtx, ex)
 		if err != nil {
@@ -456,7 +458,9 @@ func (v *standardTableRouteAstVisitor) Visit(node sqlparser.SQLNode) error {
 		}
 
 	case *sqlparser.AliasedTableExpr:
-		if node.Expr != nil {
+		switch node.Expr.(type) {
+		case nil:
+		default:
 			annotation, err := v.analyzeAliasedTable(node)
 			if err != nil {
 				return err

--- a/internal/stackql/tablemetadata/extended_table_metadata.go
+++ b/internal/stackql/tablemetadata/extended_table_metadata.go
@@ -49,6 +49,7 @@ type ExtendedTableMetadata interface {
 	IsSimple() bool
 	GetIndirect() (astindirect.Indirect, bool)
 	GetView() (internaldto.ViewDTO, bool)
+	GetSubquery() (internaldto.SubqueryDTO, bool)
 	LookupSelectItemsKey() string
 	SetSelectItemsKey(string)
 	SetSQLDataSource(sql_datasource.SQLDataSource)
@@ -89,10 +90,7 @@ func (ex *standardExtendedTableMetadata) SetSQLDataSource(sqlDataSource sql_data
 }
 
 func (ex *standardExtendedTableMetadata) GetIndirect() (astindirect.Indirect, bool) {
-	if ex.indirect != nil {
-		return ex.indirect, true
-	}
-	return nil, false
+	return ex.indirect, ex.indirect != nil
 }
 
 func (ex *standardExtendedTableMetadata) GetSelectItemsKey() string {
@@ -161,6 +159,10 @@ func (ex *standardExtendedTableMetadata) GetAlias() string {
 
 func (ex *standardExtendedTableMetadata) IsSimple() bool {
 	return ex.isSimple()
+}
+
+func (ex *standardExtendedTableMetadata) GetSubquery() (internaldto.SubqueryDTO, bool) {
+	return ex.heirarchyObjects.GetSubquery()
 }
 
 func (ex *standardExtendedTableMetadata) GetView() (internaldto.ViewDTO, bool) {

--- a/internal/stackql/tablemetadata/hierarchy_objects.go
+++ b/internal/stackql/tablemetadata/hierarchy_objects.go
@@ -23,6 +23,7 @@ type HeirarchyObjects interface {
 	GetSelectSchemaAndObjectPath() (*openapistackql.Schema, string, error)
 	GetSQLDataSource() (sql_datasource.SQLDataSource, bool)
 	GetTableName() string
+	GetSubquery() (internaldto.SubqueryDTO, bool)
 	GetView() (internaldto.ViewDTO, bool)
 	LookupSelectItemsKey() string
 	SetProvider(provider.IProvider)
@@ -67,6 +68,10 @@ func (ho *standardHeirarchyObjects) SetSQLDataSource(sqlDataSource sql_datasourc
 
 func (ho *standardHeirarchyObjects) GetView() (internaldto.ViewDTO, bool) {
 	return ho.heirarchyIds.GetView()
+}
+
+func (ho *standardHeirarchyObjects) GetSubquery() (internaldto.SubqueryDTO, bool) {
+	return ho.heirarchyIds.GetSubquery()
 }
 
 func (ho *standardHeirarchyObjects) GetResource() *openapistackql.Resource {

--- a/internal/stackql/taxonomy/annotation_context.go
+++ b/internal/stackql/taxonomy/annotation_context.go
@@ -17,6 +17,7 @@ type AnnotationCtx interface {
 	GetHIDs() internaldto.HeirarchyIdentifiers
 	IsDynamic() bool
 	GetView() (internaldto.ViewDTO, bool)
+	GetSubquery() (internaldto.SubqueryDTO, bool)
 	GetInputTableName() (string, error)
 	GetParameters() map[string]interface{}
 	GetSchema() *openapistackql.Schema
@@ -54,6 +55,10 @@ func (ac *standardAnnotationCtx) IsDynamic() bool {
 
 func (ac *standardAnnotationCtx) GetView() (internaldto.ViewDTO, bool) {
 	return ac.hIDs.GetView()
+}
+
+func (ac *standardAnnotationCtx) GetSubquery() (internaldto.SubqueryDTO, bool) {
+	return ac.hIDs.GetSubquery()
 }
 
 func (ac *standardAnnotationCtx) SetDynamic() {

--- a/internal/stackql/taxonomy/hierarchy.go
+++ b/internal/stackql/taxonomy/hierarchy.go
@@ -37,6 +37,11 @@ func getHids(handlerCtx handler.HandlerContext, node sqlparser.SQLNode) (interna
 	case sqlparser.TableName:
 		hIds = internaldto.ResolveResourceTerminalHeirarchyIdentifiers(n)
 	case *sqlparser.AliasedTableExpr:
+		switch t := n.Expr.(type) {
+		case *sqlparser.Subquery:
+			sq := internaldto.NewSubqueryDTO(n, t)
+			return internaldto.ObtainSubqueryHeirarchyIdentifiers(sq), nil
+		}
 		return getHids(handlerCtx, n.Expr)
 	case *sqlparser.DescribeTable:
 		return getHids(handlerCtx, n.Table)
@@ -63,6 +68,9 @@ func getHids(handlerCtx handler.HandlerContext, node sqlparser.SQLNode) (interna
 			return nil, err
 		}
 		hIds = internaldto.ResolveResourceTerminalHeirarchyIdentifiers(*currentSvcRsc)
+	// case *sqlparser.Subquery:
+	// suq := internaldto
+	// hIds = internaldto.ObtainSubqueryHeirarchyIdentifiers()
 	default:
 		return nil, fmt.Errorf("cannot resolve taxonomy")
 	}
@@ -130,6 +138,11 @@ func GetHeirarchyFromStatement(handlerCtx handler.HandlerContext, node sqlparser
 	case *sqlparser.DescribeTable:
 	case sqlparser.TableName:
 	case *sqlparser.AliasedTableExpr:
+		switch n.Expr.(type) {
+		case *sqlparser.Subquery:
+			retVal := tablemetadata.NewHeirarchyObjects(hIds)
+			return retVal, nil
+		}
 		return GetHeirarchyFromStatement(handlerCtx, n.Expr, parameters)
 	case *sqlparser.Show:
 		switch strings.ToUpper(n.Type) {

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -735,6 +735,19 @@ Basic View Returns Results
     ...    dummyapp.io
     ...    stdout=${CURDIR}/tmp/Basic-View-Returns-Results.tmp
 
+Basic Subquery Returns Results
+    Should Stackql Exec Inline Contain
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    SELECT * FROM (select id, name, url from github.repos.repos where org \= 'stackql') some_alias ;
+    ...    dummyapp.io
+    ...    stdout=${CURDIR}/tmp/Basic-Subquery-Returns-Results.tmp
+
 Basic View of Union Returns Results
     Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should Stackql Exec Inline Contain


### PR DESCRIPTION
## Description

- Support for **strictly aliased** subqueries.
- Robot test in place.

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

Please add deep links to any issues impacted by this PR.

## Evidence

Robot test `Basic Subquery Returns Results`;  will be visible in PR checks.

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

Please add fulsome explanations for any variations to the checklist.

## Tech Debt

If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge.
