### PR TITLE
case-sensitive-select-expressions

### DIFF
--- a/internal/stackql/astformat/ast_format_postgres.go
+++ b/internal/stackql/astformat/ast_format_postgres.go
@@ -14,6 +14,8 @@ var (
 
 func PostgresSelectExprsFormatter(buf *sqlparser.TrackedBuffer, node sqlparser.SQLNode) {
 	switch node := node.(type) {
+	case *sqlparser.ColName:
+		buf.WriteString(fmt.Sprintf(`"%s"`, node.GetRawVal()))
 	case sqlparser.ColIdent:
 		formatColIdent(node, buf)
 		return

--- a/internal/stackql/parserutil/parser_util.go
+++ b/internal/stackql/parserutil/parser_util.go
@@ -431,7 +431,7 @@ func inferColNameFromExpr(node *sqlparser.AliasedExpr, formatter sqlparser.NodeF
 	case *sqlparser.ColName:
 		retVal.Name = expr.Name.String()
 		retVal.Qualifier = expr.Qualifier.GetRawVal()
-		decoratedCol := expr.GetRawVal()
+		decoratedCol := astformat.String(expr, formatter)
 		// if decoratedCol != retVal.Name {
 		retVal.Alias = alias
 		retVal.DecoratedColumn = getDecoratedColRendition(decoratedCol, alias)

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -132,7 +132,6 @@ PG Session Server Survives Defective Query
     [Teardown]    NONE
 
 PG Session Postgres Client V2 Typed Queries
-    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should PG Client V2 Session Inline Equal
     ...    ${PSQL_MTLS_CONN_STR_UNIX}
     ...    ${SELECT_AWS_CLOUD_CONTROL_EVENTS_MINIMAL}


### PR DESCRIPTION
## Description

- Amended `postgres` rewriting formatter to surround column names with double quotes.
- This supports queries against columns that are not uniformly cased, when using a `postgres` backend.
- Robot test `PG Session Postgres Client V2 Typed Queries` un-skipped to demonstrate the fix is successful.

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A

## Evidence

Please see outcome of test `PG Session Postgres Client V2 Typed Queries` in `Run POSTGRES BACKEND robot mocked functional tests` step of `Docker Build` job in PR actions.

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.

### Variations

N/A

## Tech Debt

This change does not add new tech debt; rather, it addresses existing tech debt.