### PR TITLE
expected-behaviour-on-incorrect-column-name-input

### DIFF
--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -1,0 +1,17 @@
+
+
+# CICD
+
+Summary:
+
+- At present, PR checks, build and test are all performed through [.github/workflows/go.yml](/.github/workflows/go.yml).
+- Releasing over various channels (website, homebrew, chocolatey...) is performed manually.
+- The strategic state is to split the functions: PR checks, build and test; into separate files, and migrate to use [goreleaser](https://goreleaser.com/).
+
+
+## Secrets
+
+In lieu of a full implementation of [github actions best practices](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), currently:
+- Pull request checks use [the pull_request event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), as per [best practices](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
+- Integration test steps, which require secrets, leverage [the github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to avoid running where secrets are absent.
+    - Therefore, external fork PRs, which are the community contribution model, do not run integration tests.  Strategically, we may funnel community contribution though a staging branch and/or adopt release branches.  This is not an urgent consideration, and we shall decide after some reflection.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -5,7 +5,9 @@
 
 Please see [the contributing document](/CONTRIBUTING.md).
 
-## Quick walkthrough
+## CICD
+
+See [the CICD documentation](/docs/CICD.md).
 
 ## Provider development
 
@@ -162,13 +164,6 @@ Then, run test commands, such as:
 ```
 time ./stackql exec --cpuprofile=./select-disks-improved-05.profile --auth='{ "google": { "credentialsfilepath": "'${HOME}'/stackql/stackql-devel/keys/sa-key.json" }, "okta": { "credentialsfilepath": "'${HOME}'/stackql/stackql-devel/keys/okta-token.txt", "type": "api_key" } } ' "select name from google.compute.disks where project = 'lab-kr-network-01' and zone = 'australia-southeast1-a';"
 ```
-
-## Postgres Server Implementation
-
-1. Heavy duty option as per cockroachdb:
-    - https://github.com/cockroachdb/cockroach/tree/e6a0d23d516203bf5e8d1c8b3c3c26ddfaddc388/pkg/sql/pgwire
-2. Light touch option can be based upon:
-    - https://github.com/jeroenrinzema/psql-wire
 
 
 ## AWS HTTP request signing

--- a/internal/stackql/astformat/ast_format_sqlite.go
+++ b/internal/stackql/astformat/ast_format_sqlite.go
@@ -1,0 +1,17 @@
+package astformat
+
+import (
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+)
+
+func SQLiteSelectExprsFormatter(buf *sqlparser.TrackedBuffer, node sqlparser.SQLNode) {
+	switch node := node.(type) {
+	case sqlparser.ColIdent:
+		formatColIdentCaseInsensitive(node, buf)
+		return
+
+	default:
+		node.Format(buf)
+		return
+	}
+}

--- a/internal/stackql/sql_system/sql_system.go
+++ b/internal/stackql/sql_system/sql_system.go
@@ -80,6 +80,9 @@ func getNodeFormatter(name string) sqlparser.NodeFormatter {
 	if name == constants.SQLDialectPostgres {
 		return astformat.PostgresSelectExprsFormatter
 	}
+	if name == constants.SQLDialectSQLite3 {
+		return astformat.SQLiteSelectExprsFormatter
+	}
 	return astformat.DefaultSelectExprsFormatter
 }
 

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -706,6 +706,17 @@ Basic Query mTLS Returns OK
     ...    ${SELECT_CONTAINER_SUBNET_AGG_ASC}
     ...    ipCidrRange
 
+Basic Error Query mTLS Returns Error Message
+    Should PG Client StdErr Inline Contain
+    ...    ${CURDIR}
+    ...    ${PSQL_EXE}
+    ...    ${PSQL_MTLS_CONN_STR}
+    ...    select fake_name from github.repos.branches where owner \= 'dummyorg' and repo \= 'dummyapp.io' order by name desc;
+    ...    column
+    ...    stdout=${CURDIR}/tmp/Basic-Error-Query-mTLS-Returns-Error-Message.tmp
+    ...    stderr=${CURDIR}/tmp/Basic-Error-Query-mTLS-Returns-Error-Message-stderr.tmp
+
+
 Basic Query unencrypted Returns OK
     Should PG Client Inline Contain
     ...    ${CURDIR}

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -33,7 +33,7 @@ Shell Session Azure Compute Table Nomenclature Mutation Guard
     [Teardown]    Stackql Per Test Teardown
 
 PG Session GC Manual Behaviour Canonical
-    Should PG Client Session Inline Equal
+    Should PG Client Session Inline Equal Strict
     ...    ${PSQL_MTLS_CONN_STR_UNIX}
     ...    ${SHELL_COMMANDS_GC_SEQUENCE_CANONICAL}
     ...    ${SHELL_COMMANDS_GC_SEQUENCE_CANONICAL_JSON_EXPECTED}
@@ -80,6 +80,14 @@ PG Session Azure Compute Table Nomenclature Mutation Guard
     ...    ${SHELL_COMMANDS_AZURE_COMPUTE_MUTATION_GUARD}
     ...    ${SHELL_COMMANDS_AZURE_COMPUTE_MUTATION_GUARD_JSON_EXPECTED}
     ...    stdout=${CURDIR}/tmp/PG-Session-Azure-Compute-Table-Nomenclature-Mutation-Guard.tmp
+    [Teardown]    NONE
+
+PG Session Wrongly Named Column error recovery Azure Compute Table Nomenclature
+    Should PG Client Session Inline Contain
+    ...    ${PSQL_MTLS_CONN_STR_UNIX}
+    ...    ${SHELL_SESSION_SIMPLE_COMMANDS_AFTER_ERROR}
+    ...    ${SHELL_SESSION_SIMPLE_COMMANDS_AFTER_ERROR_EXPECTED}
+    ...    stdout=${CURDIR}/tmp/PG-Session-Wrongly-Named-Column-error-recovery-Azure-Compute-Table-Nomenclature.tmp
     [Teardown]    NONE
 
 Shell Session Azure Billing Path Interrogation Regression Guard

--- a/test/robot/lib/psycopg_client.py
+++ b/test/robot/lib/psycopg_client.py
@@ -23,6 +23,14 @@ class PsycoPGClient(object):
     except Exception as err:
       return []
 
+  def _exec_query_strict(self, query :str) -> typing.List[typing.Dict]:  
+    try:
+      r = self._connection.execute(query)
+      return r.fetchall()
+    except Exception as err:
+      print(err)
+      raise err
+
 
   def _run_queries(self, queries :typing.List[str]) -> typing.List[typing.Dict]:
     ret_val = []
@@ -32,7 +40,20 @@ class PsycoPGClient(object):
         ret_val += nv
     return ret_val
 
+  
+  def _run_queries_strict(self, queries :typing.List[str]) -> typing.List[typing.Dict]:
+    ret_val = []
+    for q in queries:
+      nv = self._exec_query_strict(q)
+      if nv:
+        ret_val += nv
+    return ret_val
+
 
   def run_queries(self, queries :typing.List[str]) -> typing.List[typing.Dict]:
     return self._run_queries(queries)
+  
+
+  def run_queries_strict(self, queries :typing.List[str]) -> typing.List[typing.Dict]:
+    return self._run_queries_strict(queries)
 

--- a/test/robot/lib/stackql_context.py
+++ b/test/robot/lib/stackql_context.py
@@ -571,6 +571,7 @@ UPDATE_GITHUB_ORG = "update github.orgs.orgs set data__description = 'Some silly
 SELECT_GITHUB_REPOS_PAGES_SINGLE = "select url from github.repos.pages where owner = 'dummyorg' and repo = 'dummyapp.io';"
 SELECT_GITHUB_REPOS_IDS_ASC = "select id from github.repos.repos where org = 'dummyorg' order by id ASC;"
 SELECT_GITHUB_BRANCHES_NAMES_DESC = "select name from github.repos.branches where owner = 'dummyorg' and repo = 'dummyapp.io' order by name desc;"
+SELECT_GITHUB_BRANCHES_NAMES_DESC_WRONG_COLUMN = "select name_wrong from github.repos.branches where owner = 'dummyorg' and repo = 'dummyapp.io' order by name desc;"
 SELECT_GITHUB_REPOS_WITH_USEFUL_FUNCTIONS = "select name, split_part(teams_url, '/', 4) as extracted_team, regexp_replace((JSON_EXTRACT(owner, '$.url')), '^https://[^/]+/[^/]+/', 'username = ') as user_suffix, nlike('%docusaurus%', name) as is_docusaurus, unicode_version() as unicode_lib_version from github.repos.repos where org = 'dummyorg' order by name ASC;"
 SELECT_GITHUB_REPOS_FILTERED_SINGLE = "select id, name from github.repos.repos where org = 'dummyorg' and name = 'dummyapp.io';"
 SELECT_GITHUB_SCIM_USERS = "select JSON_EXTRACT(name, '$.givenName') || ' ' || JSON_EXTRACT(name, '$.familyName') as name, userName, externalId, id from github.scim.users where org = 'dummyorg' order by id asc;"
@@ -752,7 +753,7 @@ def get_db_setup_src(sql_backend_str :str) -> str:
 
 def get_variables(execution_env :str, sql_backend_str :str):
   NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_ONE = get_native_query_row_count_from_table('okta.application.apps.Application.generation_1', sql_backend_str)
-  NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_TWO = get_native_query_row_count_from_table('okta.application.apps.Application.generation_2', sql_backend_str)
+  NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_THREE = get_native_query_row_count_from_table('okta.application.apps.Application.generation_3', sql_backend_str)
   rv = {
     ## general config
     'AZURE_SECRET_STR':                               AZURE_SECRET_STR,
@@ -936,7 +937,7 @@ def get_variables(execution_env :str, sql_backend_str :str):
     'SHELL_COMMANDS_DISKS_VIEW_ALIASED_SEQUENCE_JSON_EXPECTED':               [ { "message": "DDL execution completed" } ] + SELECT_CROSS_CLOUD_DISKS_VIEW_EXPECTED_JSON + [ { "message": "DDL execution completed" } ],
     'SHELL_COMMANDS_DISKS_VIEW_NOT_ALIASED_SEQUENCE':                         [ CREATE_DISKS_VIEW_NO_PRIMARY_ALIAS, "select * from cross_cloud_disks_not_aliased order by name desc;", "drop view cross_cloud_disks_not_aliased;" ],
     'SHELL_COMMANDS_DISKS_VIEW_NOT_ALIASED_SEQUENCE_JSON_EXPECTED':           [ { "message": "DDL execution completed" } ] + SELECT_CROSS_CLOUD_DISKS_VIEW_EXPECTED_JSON + [ { "message": "DDL execution completed" } ],
-    'SHELL_COMMANDS_GC_SEQUENCE_CANONICAL':                                   [ SELECT_OKTA_APPS, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_TWO, PURGE_CONSERVATIVE, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_TWO, SELECT_OKTA_APPS, SELECT_OKTA_APPS, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_TWO, PURGE_CONSERVATIVE, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_TWO ],
+    'SHELL_COMMANDS_GC_SEQUENCE_CANONICAL':                                   [ SELECT_OKTA_APPS, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_THREE, PURGE_CONSERVATIVE, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_THREE, SELECT_OKTA_APPS, SELECT_OKTA_APPS, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_THREE, PURGE_CONSERVATIVE, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_THREE ],
     'SHELL_COMMANDS_GC_SEQUENCE_CANONICAL_JSON_EXPECTED':                     SELECT_OKTA_APPS_ASC_EXPECTED_JSON + [ get_object_count_dict(5)] + PURGE_CONSERVATIVE_RESPONSE_JSON + [ get_object_count_dict(0) ] + SELECT_OKTA_APPS_ASC_EXPECTED_JSON + SELECT_OKTA_APPS_ASC_EXPECTED_JSON + [ get_object_count_dict(10)] + PURGE_CONSERVATIVE_RESPONSE_JSON + [get_object_count_dict(0) ],
     'SHELL_COMMANDS_GC_SEQUENCE_EAGER':                                       [ SELECT_OKTA_APPS, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_ONE, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_ONE, SELECT_OKTA_APPS, SELECT_OKTA_APPS, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_ONE, NATIVEQUERY_OKTA_APPS_ROW_COUNT_DISCO_ID_ONE ],
     'SHELL_COMMANDS_GC_SEQUENCE_EAGER_JSON_EXPECTED':                         SELECT_OKTA_APPS_ASC_EXPECTED_JSON + [ get_object_count_dict(0)] + [ get_object_count_dict(0) ] + SELECT_OKTA_APPS_ASC_EXPECTED_JSON + SELECT_OKTA_APPS_ASC_EXPECTED_JSON + [ get_object_count_dict(0)] + [get_object_count_dict(0) ],
@@ -945,6 +946,8 @@ def get_variables(execution_env :str, sql_backend_str :str):
     'SHELL_COMMANDS_VIEW_HANDLING_SEQUENCE':                                  [ _CREATE_SOME_VIEW, "select * from some_view;", "drop view some_view;" ],
     'SHELL_COMMANDS_VIEW_HANDLING_SEQUENCE_JSON_EXPECTED':                    [ { "message": "DDL execution completed" } ] + SELECT_SOME_VIEW_EXPECTED_JSON + [ { "message": "DDL execution completed" } ],
     'SHELL_SESSION_SIMPLE_COMMANDS':                                          [ SELECT_GITHUB_BRANCHES_NAMES_DESC ],
+    'SHELL_SESSION_SIMPLE_COMMANDS_AFTER_ERROR':                              [ SELECT_GITHUB_BRANCHES_NAMES_DESC_WRONG_COLUMN, SELECT_AZURE_COMPUTE_VIRTUAL_MACHINES ],
+    'SHELL_SESSION_SIMPLE_COMMANDS_AFTER_ERROR_EXPECTED':                     SELECT_AZURE_COMPUTE_VIRTUAL_MACHINES_JSON_EXPECTED,
     'SHELL_SESSION_SIMPLE_EXPECTED':                                          _SHELL_WELCOME_MSG + SELECT_GITHUB_BRANCHES_NAMES_DESC_EXPECTED,
     'SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR':                   SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR,
     'SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR':                   SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR,


### PR DESCRIPTION
## Description

- Amend `sqlite` clobbering behaviour where double quoted columns fall back to static string where column not present in table.
- Added robot test `Basic Error Query mTLS Returns Error Message` to verify incorrectly named column throws error in server session.
- Added robot test `PG Session Wrongly Named Column error recovery Azure Compute Table Nomenclature` to verify that the server survives such an input and behaves correctly for a following query.
- Added CICD markdown doc.
- Amended developer guide.


## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

Fixes stackql/stackql#149

## Evidence

- Added robot test `Basic Error Query mTLS Returns Error Message` to verify incorrectly named column throws error in server session.
- Added robot test `PG Session Wrongly Named Column error recovery Azure Compute Table Nomenclature` to verify that the server survives such an input and behaves correctly for a following query.
## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A

## Tech Debt

This change does not add technical debt.
