### PR TITLE
ci: do not run build workflow on markdown file changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,14 @@ on:
       - develop
     tags:
       - build*
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches:
       - main
       - develop
+    paths-ignore:
+      - "**/*.md"
 
 env:
   GOGETCMD: "go get -v -t -d ./..."


### PR DESCRIPTION
## Description

My last PRs about changing README and PR template both triggered the long `.github/workflows/go.yml` workflow which takes some time and would presumably consume many Actions minutes. To reduce wastage of minutes we can skip running the workflow if only `.md` files have changed.

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Please explain**.

