### PR TITLE
plan-execution-concurrency-uplift

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -153,7 +153,7 @@ jobs:
           -X 'github.com/stackql/stackql/internal/stackql/cmd.BuildDate=$BuildDate' `
           -X 'stackql/internal/stackql/planbuilder.PlanCacheEnabled=$PlanCacheEnabled' `
           -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform=$BuildPlatform" `
-          -o build/ ./...
+          -o build/ ./stackql
 
     - name: Test
       if: success()
@@ -306,7 +306,7 @@ jobs:
         -X \"github.com/stackql/stackql/internal/stackql/cmd.BuildDate=$BUILDDATE\" \
         -X \"stackql/internal/stackql/planbuilder.PlanCacheEnabled=$PLANCACHEENABLED\" \
         -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform=$BUILDPLATFORM" \
-        -o build/ ./...
+        -o build/ ./stackql
       
     - name: Test
       if: success()
@@ -331,6 +331,16 @@ jobs:
         robot --variable SHOULD_RUN_DOCKER_EXTERNAL_TESTS:true -d test/robot/functional test/robot/functional
 
     - name: Output from mocked functional tests
+      if: always()
+      run: |
+        cat ./test/robot/functional/output.xml
+
+    - name: Run robot mocked functional tests with aggressive concurrency
+      if: success()
+      run: |
+        robot --variable SHOULD_RUN_DOCKER_EXTERNAL_TESTS:true --variable CONCURRENCY_LIMIT:-1 -d test/robot/functional test/robot/functional
+
+    - name: Output from mocked functional tests with aggressive concurrency
       if: always()
       run: |
         cat ./test/robot/functional/output.xml
@@ -559,7 +569,7 @@ jobs:
         -X \"github.com/stackql/stackql/internal/stackql/cmd.BuildDate=$BUILDDATE\" \
         -X \"stackql/internal/stackql/planbuilder.PlanCacheEnabled=$PLANCACHEENABLED\" \
         -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform=$BUILDPLATFORM" \
-        -o build/ ./...
+        -o build/ ./stackql
 
     - name: Test
       if: success()
@@ -681,7 +691,7 @@ jobs:
         -X \"github.com/stackql/stackql/internal/stackql/cmd.BuildDate=$BUILDDATE\" \
         -X \"stackql/internal/stackql/planbuilder.PlanCacheEnabled=$PLANCACHEENABLED\" \
         -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform=$BUILDPLATFORM" \
-        -o build/ ./...
+        -o build/ ./stackql
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v3

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -24,6 +24,23 @@ env CGO_ENABLED=1 go build \
   -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform=$BUILDPLATFORM" -o ./build ./stackql
 ```
 
+## Testing locally
+
+### Unit tests
+
+```bash
+go test -timeout 1200s --tags "json1 sqleanall" ./...
+```
+
+### Robot tests
+
+**Note**: this requires the local build (above) to have been completed successfully, which builds a binary in `./build/`.
+
+```bash
+robot --variable SHOULD_RUN_DOCKER_EXTERNAL_TESTS:true -d test/robot/functional test/robot/functional
+```
+
+
 ## Provider development
 
 Keen to expose some new functionality though `stackql`?  We are very keen on this!  

--- a/test/robot/functional/stackql.resource
+++ b/test/robot/functional/stackql.resource
@@ -4,6 +4,7 @@ ${EXECUTION_PLATFORM}                  native   # to be overridden from command 
 ${SQL_BACKEND}                         sqlite_embedded   # to be overridden from command line, eg "postgres_tcp"
 ${IS_WSL}                              false   # to be overridden from command line, with string "true"
 ${SHOULD_RUN_DOCKER_EXTERNAL_TESTS}    false   # to be overridden from command line, with string "true"
+${CONCURRENCY_LIMIT}                   1       # to be overridden from command line, with integer value, -1 for no limit
 
 *** Settings ***
 Library           Process
@@ -12,7 +13,7 @@ Variables         ${LOCAL_LIB_HOME}/stackql_context.py    ${EXECUTION_PLATFORM} 
 Library           Process
 Library           OperatingSystem
 Library           String
-Library           ${LOCAL_LIB_HOME}/StackQLInterfaces.py    ${EXECUTION_PLATFORM}    ${SQL_BACKEND}
+Library           ${LOCAL_LIB_HOME}/StackQLInterfaces.py    ${EXECUTION_PLATFORM}    ${SQL_BACKEND}    ${CONCURRENCY_LIMIT}
 Library           ${LOCAL_LIB_HOME}/CloudIntegration.py
 
 *** Keywords ***
@@ -75,6 +76,7 @@ Start StackQL PG Server mTLS
                         ...  \-\-pgsrv\.tls    ${_MTLS_CFG_STR}
                         ...  \-\-namespaces\=${_NAMESPACES_CFG}
                         ...  \-\-gc\=${_GC_CFG}
+                        ...  \-\-execution\.concurrency\.limit\=${CONCURRENCY_LIMIT}
                         ...  \-\-sqlBackend\=${_SQL_BACKEND_CFG}
                         ...  \-\-dbInternal\=${DB_INTERNAL_CFG_LAX}
                         ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
@@ -87,7 +89,7 @@ Start StackQL PG Server mTLS
                         ...  stackqlsrv
                         ...  bash
                         ...  \-c
-                        ...  sleep 2 && stackql srv \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-gc\='${_GC_CFG}' \-\-sqlBackend\='${_SQL_BACKEND_CFG}' \-\-dbInternal\='${DB_INTERNAL_CFG_LAX}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\='0.0.0.0' \-\-pgsrv\.port\=${_DOCKER_PORT} \-\-pgsrv\.tls\='{\"keyFilePath\": \"/opt/stackql/srv/credentials/pg_server_key.pem\", \"certFilePath\": \"/opt/stackql/srv/credentials/pg_server_cert.pem\", \"clientCAs\": [\"'$(base64 -w 0 /opt/stackql/srv/credentials/pg_client_cert.pem)'\"]}'
+                        ...  sleep 2 && stackql srv \-\-execution\.concurrency\.limit\=${CONCURRENCY_LIMIT} \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-gc\='${_GC_CFG}' \-\-sqlBackend\='${_SQL_BACKEND_CFG}' \-\-dbInternal\='${DB_INTERNAL_CFG_LAX}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\='0.0.0.0' \-\-pgsrv\.port\=${_DOCKER_PORT} \-\-pgsrv\.tls\='{\"keyFilePath\": \"/opt/stackql/srv/credentials/pg_server_key.pem\", \"certFilePath\": \"/opt/stackql/srv/credentials/pg_server_cert.pem\", \"clientCAs\": [\"'$(base64 -w 0 /opt/stackql/srv/credentials/pg_client_cert.pem)'\"]}'
                         ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
                         ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
     END
@@ -105,6 +107,7 @@ Start StackQL PG Server unencrypted
                         ...  \-\-namespaces\=${_NAMESPACES_CFG}
                         ...  \-\-sqlBackend\=${_SQL_BACKEND_CFG}
                         ...  \-\-dbInternal\=${DB_INTERNAL_CFG_LAX}
+                        ...  \-\-execution\.concurrency\.limit\=${CONCURRENCY_LIMIT}
                         ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
                         ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
     ELSE IF    "${EXECUTION_PLATFORM}" == "docker"
@@ -115,7 +118,7 @@ Start StackQL PG Server unencrypted
                         ...  stackqlsrv
                         ...  bash
                         ...  \-c
-                        ...  sleep 2 && stackql srv \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-sqlBackend\='${_SQL_BACKEND_CFG}' \-\-dbInternal\='${DB_INTERNAL_CFG_LAX}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\=0.0.0.0 \-\-pgsrv\.port\=${PG_SRV_PORT_DOCKER_UNENCRYPTED}
+                        ...  sleep 2 && stackql srv \-\-execution\.concurrency\.limit\=${CONCURRENCY_LIMIT} \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-sqlBackend\='${_SQL_BACKEND_CFG}' \-\-dbInternal\='${DB_INTERNAL_CFG_LAX}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\=0.0.0.0 \-\-pgsrv\.port\=${PG_SRV_PORT_DOCKER_UNENCRYPTED}
                         ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
                         ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-unencrypted-${_SRV_PORT_UNENCRYPTED}.txt
     END

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -19,16 +19,18 @@ from sqlalchemy_client import SQLAlchemyClient
 
 SQL_BACKEND_CANONICAL_SQLITE_EMBEDDED :str = 'sqlite_embedded'
 SQL_BACKEND_POSTGRES_TCP :str = 'postgres_tcp'
+SQL_CONCURRENCT_LIMIT_DEFAULT :int = 1
 
 
 @library(scope='SUITE', version='0.1.0', doc_format='reST')
 class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
   ROBOT_LISTENER_API_VERSION = 2
 
-  def __init__(self, execution_platform='native', sql_backend=SQL_BACKEND_CANONICAL_SQLITE_EMBEDDED):
+  def __init__(self, execution_platform='native', sql_backend=SQL_BACKEND_CANONICAL_SQLITE_EMBEDDED, concurrency_limit=SQL_CONCURRENCT_LIMIT_DEFAULT):
     self._counter = 0
     self._execution_platform=execution_platform
     self._sql_backend=sql_backend
+    self._concurrency_limit=concurrency_limit
     self.ROBOT_LIBRARY_LISTENER = self
     Process.__init__(self)
 
@@ -181,6 +183,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
     if sql_backend_cfg_str != "":
       supplied_args.append(f"--sqlBackend='{sql_backend_cfg_str}'")
     supplied_args.append("--tls.allowInsecure=true")
+    supplied_args.append(f"--execution.concurrency.limit={self._concurrency_limit}")
     transformed_args = self._docker_transform_args(*args)
     supplied_args = supplied_args + transformed_args
     query_escaped = query.replace("'", "'\"'\"'")
@@ -253,6 +256,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
     if sql_backend_cfg_str != "":
       supplied_args.append(f"--sqlBackend='{sql_backend_cfg_str}'")
     supplied_args.append("--tls.allowInsecure=true")
+    supplied_args.append(f"--execution.concurrency.limit={self._concurrency_limit}")
     transformed_args = self._docker_transform_args(*args)
     supplied_args = supplied_args + transformed_args
     os.environ['REGISTRY_SRC']= f'./{reg_location}'
@@ -322,6 +326,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
     if sql_backend_cfg_str != "":
       supplied_args.append(f"--sqlBackend={sql_backend_cfg_str}")
     supplied_args.append("--tls.allowInsecure=true")
+    supplied_args.append(f"--execution.concurrency.limit={self._concurrency_limit}")
     res = super().run_process(
       *supplied_args,
       query,
@@ -364,6 +369,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       supplied_args.append(f"--sqlBackend={sql_backend_cfg_str}")
     supplied_args.append("--tls.allowInsecure=true")
     supplied_args.append(f'--approot="{_TEST_APP_CACHE_ROOT}"')
+    supplied_args.append(f"--execution.concurrency.limit={self._concurrency_limit}")
     supplied_args = supplied_args + list(args)
     stdout = cfg.get('stdout', subprocess.PIPE)
     stderr = cfg.get('stderr', subprocess.PIPE)


### PR DESCRIPTION
## Description

- Concurrent execution now possible, configurable with `--execution.concurrency.limit`.  Set to any positive integer for concrete limit, `-1` for max aggressive.  Default remains `1`.
- Reset the graph so that cached queries behave acceptably.
- Added aggressive concurrency testing robot run.

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

Please see the github action step `Run robot mocked functional tests with aggressive concurrency`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced by this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
