### PR TITLE
trivial-transactions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.4-bullseye AS sourceprep
+FROM golang:1.20.3-bullseye AS sourceprep
 
 ENV SRC_DIR=/work/stackql/src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackql/stackql
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.2.0

--- a/internal/stackql/acid/binlog/log.go
+++ b/internal/stackql/acid/binlog/log.go
@@ -1,6 +1,53 @@
 package binlog
 
+import "strings"
+
+var (
+	_ LogEntry = &simpleLogEntry{}
+)
+
 type LogEntry interface {
-	// Get bytes
+	AppendHumanReadable(string)
+	AppendRaw([]byte)
+	Clone() LogEntry
+	GetHumanReadable() string
 	GetRaw() []byte
+}
+
+type simpleLogEntry struct {
+	raw           []byte
+	humanReadable string
+}
+
+func NewSimpleLogEntry(
+	raw []byte,
+	humanReadable string,
+) LogEntry {
+	return &simpleLogEntry{
+		raw:           raw,
+		humanReadable: humanReadable,
+	}
+}
+
+func (l *simpleLogEntry) Clone() LogEntry {
+	rawCopy := make([]byte, len(l.raw))
+	copy(rawCopy, l.raw)
+	humanReadableCopy := strings.Clone(l.humanReadable)
+	return NewSimpleLogEntry(rawCopy, humanReadableCopy)
+}
+
+func (l *simpleLogEntry) GetRaw() []byte {
+	return l.raw
+}
+
+func (l *simpleLogEntry) AppendRaw(b []byte) {
+	l.raw = append(l.raw, b...)
+}
+
+func (l *simpleLogEntry) GetHumanReadable() string {
+	return l.humanReadable
+}
+
+func (l *simpleLogEntry) AppendHumanReadable(s string) {
+	l.humanReadable += s
 }

--- a/internal/stackql/acid/operation/operation.go
+++ b/internal/stackql/acid/operation/operation.go
@@ -40,7 +40,7 @@ type Operation interface {
 	//
 	SetInputAlias(alias string, id int64) error
 	//
-	IsNotMutating() bool
+	IsReadOnly() bool
 }
 
 type reversibleOperation struct {
@@ -75,8 +75,8 @@ func (op *reversibleOperation) Redo() error {
 }
 
 // TODO: interrogate the primitive
-func (op *reversibleOperation) IsNotMutating() bool {
-	return op.pr.IsNotMutating()
+func (op *reversibleOperation) IsReadOnly() bool {
+	return op.pr.IsReadOnly()
 }
 
 func (op *reversibleOperation) GetRedoLog() (binlog.LogEntry, bool) {
@@ -118,8 +118,8 @@ func (op *irreversibleOperation) Redo() error {
 }
 
 // TODO: interrogate the primitive
-func (op *irreversibleOperation) IsNotMutating() bool {
-	return op.pr.IsNotMutating()
+func (op *irreversibleOperation) IsReadOnly() bool {
+	return op.pr.IsReadOnly()
 }
 
 func (op *irreversibleOperation) GetRedoLog() (binlog.LogEntry, bool) {

--- a/internal/stackql/acid/transact/statement.go
+++ b/internal/stackql/acid/transact/statement.go
@@ -1,6 +1,8 @@
 package transact
 
 import (
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/acid/binlog"
 	"github.com/stackql/stackql/internal/stackql/acid/txn_context"
 	"github.com/stackql/stackql/internal/stackql/handler"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
@@ -10,6 +12,15 @@ import (
 type Statement interface {
 	Prepare() error
 	Execute() internaldto.ExecutorOutput
+	GetAST() (sqlparser.Statement, bool)
+	GetUndoLog() (binlog.LogEntry, bool)
+	GetRedoLog() (binlog.LogEntry, bool)
+	IsReadOnly() bool
+	SetUndoLog(binlog.LogEntry)
+	SetRedoLog(binlog.LogEntry)
+	IsBegin() bool
+	IsCommit() bool
+	IsRollback() bool
 }
 
 type basicStatement struct {
@@ -17,6 +28,8 @@ type basicStatement struct {
 	handlerCtx         handler.HandlerContext
 	querySubmitter     querysubmit.QuerySubmitter
 	transactionContext txn_context.ITransactionContext
+	undoLog            binlog.LogEntry
+	redoLog            binlog.LogEntry
 }
 
 func NewStatement(
@@ -32,6 +45,56 @@ func NewStatement(
 	}
 }
 
+func (st *basicStatement) IsBegin() bool {
+	ast, hasAst := st.GetAST()
+	if hasAst {
+		_, isBegin := ast.(*sqlparser.Begin)
+		return isBegin
+	}
+	return false
+}
+
+func (st *basicStatement) IsCommit() bool {
+	ast, hasAst := st.GetAST()
+	if hasAst {
+		_, isCommit := ast.(*sqlparser.Commit)
+		return isCommit
+	}
+	return false
+}
+
+func (st *basicStatement) IsRollback() bool {
+	ast, hasAst := st.GetAST()
+	if hasAst {
+		_, isRollback := ast.(*sqlparser.Rollback)
+		return isRollback
+	}
+	return false
+}
+
+func (st *basicStatement) IsReadOnly() bool {
+	if st.querySubmitter == nil {
+		return true
+	}
+	return st.querySubmitter.IsReadOnly()
+}
+
+func (st *basicStatement) SetUndoLog(log binlog.LogEntry) {
+	st.undoLog = log
+}
+
+func (st *basicStatement) SetRedoLog(log binlog.LogEntry) {
+	st.redoLog = log
+}
+
+func (st *basicStatement) GetUndoLog() (binlog.LogEntry, bool) {
+	return st.undoLog, st.undoLog != nil
+}
+
+func (st *basicStatement) GetRedoLog() (binlog.LogEntry, bool) {
+	return st.redoLog, st.redoLog != nil
+}
+
 func (st *basicStatement) Prepare() error {
 	cmdString := st.query
 	clonedCtx := st.handlerCtx.Clone()
@@ -44,4 +107,8 @@ func (st *basicStatement) Prepare() error {
 
 func (st *basicStatement) Execute() internaldto.ExecutorOutput {
 	return st.querySubmitter.SubmitQuery()
+}
+
+func (st *basicStatement) GetAST() (sqlparser.Statement, bool) {
+	return st.querySubmitter.GetStatement()
 }

--- a/internal/stackql/acid/transact/txn.go
+++ b/internal/stackql/acid/transact/txn.go
@@ -3,6 +3,11 @@ package transact
 import (
 	"fmt"
 	"sync"
+
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/acid/binlog"
+	"github.com/stackql/stackql/internal/stackql/acid/txn_context"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
 )
 
 //nolint:gochecknoglobals // singleton pattern
@@ -13,6 +18,10 @@ var (
 	_                    Manager     = &basicTransactionManager{}
 )
 
+const (
+	defaultMaxStackDepth = 1
+)
+
 // The transaction coordinator is singleton
 // that orchestrates transaction managers.
 type Coordinator interface {
@@ -21,19 +30,26 @@ type Coordinator interface {
 }
 
 type standardCoordinator struct {
+	ctx txn_context.ITransactionCoordinatorContext
 }
 
 func (c *standardCoordinator) NewTxnManager() (Manager, error) {
-	return nil, fmt.Errorf("not implemented")
+	maxTxnDepth := defaultMaxStackDepth
+	if c.ctx != nil {
+		maxTxnDepth = c.ctx.GetMaxStackDepth()
+	}
+	return NewManager(maxTxnDepth), nil
 }
 
-func GetCoordinatorInstance() (Coordinator, error) {
+func GetCoordinatorInstance(ctx txn_context.ITransactionCoordinatorContext) (Coordinator, error) {
 	var err error
 	coordinatorOnce.Do(func() {
 		if err != nil {
 			return
 		}
-		coordinatorSingleton = &standardCoordinator{}
+		coordinatorSingleton = &standardCoordinator{
+			ctx: ctx,
+		}
 	})
 	return coordinatorSingleton, err
 }
@@ -42,10 +58,11 @@ func GetCoordinatorInstance() (Coordinator, error) {
 // that undo and redo logs are kept
 // and that 2PC is performed.
 type Manager interface {
+	Statement
 	// Begin a new transaction.
 	Begin() (Manager, error)
 	// Commit the current transaction.
-	Commit() error
+	Commit() ([]internaldto.ExecutorOutput, error)
 	// Rollback the current transaction.
 	Rollback() error
 	// Enqueue a transaction operation.
@@ -56,34 +73,93 @@ type Manager interface {
 	Enqueue(Statement) error
 	// Get the depth of transaction nesting.
 	Depth() int
+	// Get the parent transaction manager.
+	GetParent() (Manager, bool)
+	//
+	IsRoot() bool
 }
 
 type basicTransactionManager struct {
 	parent            Manager
 	statementSequence []Statement
+	undoLogs          []binlog.LogEntry
+	redoLogs          []binlog.LogEntry
+	maxTxnDepth       int
+	outputs           []internaldto.ExecutorOutput
 }
 
-func newBasicTransactionManager(parent Manager) Manager {
+func newBasicTransactionManager(parent Manager, maxTxnDepth int) Manager {
 	return &basicTransactionManager{
-		parent: parent,
+		parent:      parent,
+		maxTxnDepth: maxTxnDepth,
 	}
 }
 
-func NewManager() Manager {
-	return newBasicTransactionManager(nil)
+func NewManager(maxTxnDepth int) Manager {
+	return newBasicTransactionManager(nil, maxTxnDepth)
 }
 
-func (m *basicTransactionManager) Begin() (Manager, error) {
-	if m.Depth() >= 1 {
-		return nil, fmt.Errorf("cannot begin nested transaction")
+func (m *basicTransactionManager) IsReadOnly() bool {
+	for _, statement := range m.statementSequence {
+		if !statement.IsReadOnly() {
+			return false
+		}
 	}
-	return newBasicTransactionManager(m), nil
+	return true
 }
 
-func (m *basicTransactionManager) Commit() error {
+func (m *basicTransactionManager) GetAST() (sqlparser.Statement, bool) {
+	return nil, false
+}
+
+func (m *basicTransactionManager) GetParent() (Manager, bool) {
+	return m.parent, m.parent != nil
+}
+
+func (m *basicTransactionManager) SetRedoLog(log binlog.LogEntry) {
+	m.redoLogs = []binlog.LogEntry{log}
+}
+
+func (m *basicTransactionManager) IsBegin() bool {
+	return false
+}
+
+func (m *basicTransactionManager) IsCommit() bool {
+	return false
+}
+
+func (m *basicTransactionManager) IsRollback() bool {
+	return false
+}
+
+func (m *basicTransactionManager) SetUndoLog(log binlog.LogEntry) {
+	m.undoLogs = []binlog.LogEntry{log}
+}
+
+func (m *basicTransactionManager) GetUndoLog() (binlog.LogEntry, bool) {
+	if len(m.undoLogs) == 0 {
+		return nil, false
+	}
+	initialUndoLog := m.undoLogs[len(m.undoLogs)-1]
+	rv := initialUndoLog.Clone()
+	for i := len(m.undoLogs) - 2; i >= 0; i-- { //nolint:gomnd // magic number second from last
+		currentLog := m.undoLogs[i]
+		if currentLog != nil {
+			rv.AppendHumanReadable(currentLog.GetHumanReadable())
+			rv.AppendRaw(currentLog.GetRaw())
+		}
+	}
+	return rv, true
+}
+
+func (m *basicTransactionManager) GetRedoLog() (binlog.LogEntry, bool) {
+	return nil, false
+}
+
+func (m *basicTransactionManager) Prepare() error {
+	var err error
 	for _, stmt := range m.statementSequence {
-		coDomain := stmt.Execute()
-		err := coDomain.GetError()
+		err = stmt.Prepare()
 		if err != nil {
 			return err
 		}
@@ -91,15 +167,74 @@ func (m *basicTransactionManager) Commit() error {
 	return nil
 }
 
-func (m *basicTransactionManager) Rollback() error {
-	return fmt.Errorf("not implemented")
+func (m *basicTransactionManager) Execute() internaldto.ExecutorOutput {
+	outputs, err := m.execute()
+	m.outputs = outputs
+	if err != nil {
+		return internaldto.NewErroneousExecutorOutput(err)
+	}
+	return internaldto.NewExecutorOutput(
+		nil,
+		nil,
+		nil,
+		internaldto.NewBackendMessages([]string{"transaction committed"}),
+		nil,
+	)
 }
 
-func (m *basicTransactionManager) Enqueue(_ Statement) error {
-	return fmt.Errorf("not implemented")
+func (m *basicTransactionManager) execute() ([]internaldto.ExecutorOutput, error) {
+	var rv []internaldto.ExecutorOutput
+	for _, stmt := range m.statementSequence {
+		coDomain := stmt.Execute()
+		rv = append(rv, coDomain)
+		err := coDomain.GetError()
+		undoLog, undoLogExists := stmt.GetUndoLog()
+		redoLog, redoLogExists := stmt.GetRedoLog()
+		if undoLogExists {
+			m.undoLogs = append(m.undoLogs, undoLog)
+		}
+		if redoLogExists {
+			m.redoLogs = append(m.redoLogs, redoLog)
+		}
+		if err != nil {
+			return rv, err
+		}
+	}
+	return rv, nil
+}
+
+func (m *basicTransactionManager) Begin() (Manager, error) {
+	if m.maxTxnDepth >= 0 && m.Depth() >= m.maxTxnDepth {
+		return nil, fmt.Errorf("cannot begin nested transaction of depth = %d", m.Depth()+1)
+	}
+	return newBasicTransactionManager(m, m.maxTxnDepth), nil
+}
+
+func (m *basicTransactionManager) Commit() ([]internaldto.ExecutorOutput, error) {
+	return m.execute()
+}
+
+// Rollback is a no-op for now.
+// The redo logs will simply be
+// displayed to the user.
+func (m *basicTransactionManager) Rollback() error {
+	return nil
+}
+
+func (m *basicTransactionManager) Enqueue(stmt Statement) error {
+	m.statementSequence = append(m.statementSequence, stmt)
+	return nil
 }
 
 func (m *basicTransactionManager) Depth() int {
+	return m.depth()
+}
+
+func (m *basicTransactionManager) IsRoot() bool {
+	return m.parent == nil
+}
+
+func (m *basicTransactionManager) depth() int {
 	if m.parent != nil {
 		return m.parent.Depth() + 1
 	}

--- a/internal/stackql/acid/txn_context/txn_coordinator_context.go
+++ b/internal/stackql/acid/txn_context/txn_coordinator_context.go
@@ -1,0 +1,25 @@
+package txn_context //nolint:revive,stylecheck // meaning of package name is clear
+
+var (
+	_ ITransactionCoordinatorContext = &transactionCoordinatorContext{}
+)
+
+type ITransactionCoordinatorContext interface {
+	GetMaxStackDepth() int
+}
+
+type transactionCoordinatorContext struct {
+	maxStackDepth int
+}
+
+func NewTransactionCoordinatorContext(
+	maxStackDepth int,
+) ITransactionCoordinatorContext {
+	return &transactionCoordinatorContext{
+		maxStackDepth: maxStackDepth,
+	}
+}
+
+func (tc *transactionCoordinatorContext) GetMaxStackDepth() int {
+	return tc.maxStackDepth
+}

--- a/internal/stackql/astanalysis/annotatedast/annotated_ast.go
+++ b/internal/stackql/astanalysis/annotatedast/annotated_ast.go
@@ -31,6 +31,7 @@ type AnnotatedAst interface {
 	SetSQLDataSource(node sqlparser.SQLNode, sqlDataSource sql_datasource.SQLDataSource)
 	SetWhereParamMapsEntry(*sqlparser.Where, parserutil.ParameterMap)
 	GetWhereParamMapsEntry(*sqlparser.Where) (parserutil.ParameterMap, bool)
+	IsReadOnly() bool
 }
 
 type standardAnnotatedAst struct {
@@ -53,6 +54,10 @@ func (aa *standardAnnotatedAst) GetWhereParamMapsEntry(node *sqlparser.Where) (p
 
 func (aa *standardAnnotatedAst) GetAST() sqlparser.Statement {
 	return aa.ast
+}
+
+func (aa *standardAnnotatedAst) IsReadOnly() bool {
+	return false
 }
 
 func (aa *standardAnnotatedAst) GetSelectMetadata(selNode *sqlparser.Select) (selectmetadata.SelectMetadata, bool) {

--- a/internal/stackql/asyncmonitor/asyncmonitor.go
+++ b/internal/stackql/asyncmonitor/asyncmonitor.go
@@ -49,7 +49,7 @@ type AsyncHTTPMonitorPrimitive struct {
 func (pr *AsyncHTTPMonitorPrimitive) SetTxnID(_ int) {
 }
 
-func (pr *AsyncHTTPMonitorPrimitive) IsNotMutating() bool {
+func (pr *AsyncHTTPMonitorPrimitive) IsReadOnly() bool {
 	return false
 }
 

--- a/internal/stackql/bundle/bundle.go
+++ b/internal/stackql/bundle/bundle.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/acid/txn_context"
 	"github.com/stackql/stackql/internal/stackql/datasource/sql_datasource"
 	"github.com/stackql/stackql/internal/stackql/dbmsinternal"
 	"github.com/stackql/stackql/internal/stackql/dto"
@@ -25,6 +26,7 @@ type Bundle interface {
 	GetSQLEngine() sqlengine.SQLEngine
 	GetTxnCounterManager() txncounter.Manager
 	GetTxnStore() kstore.KStore
+	GetTxnCoordinatorContext() txn_context.ITransactionCoordinatorContext
 }
 
 func NewBundle(
@@ -38,34 +40,41 @@ func NewBundle(
 	txnCtrMgr txncounter.Manager,
 	authContexts map[string]*dto.AuthCtx,
 	sqlDataSources map[string]sql_datasource.SQLDataSource,
+	txnCoordintatorContext txn_context.ITransactionCoordinatorContext,
 ) Bundle {
 	return &simpleBundle{
-		garbageCollector:  garbageCollector,
-		namespaces:        namespaces,
-		sqlEngine:         sqlEngine,
-		sqlSystem:         sqlSystem,
-		controlAttributes: controlAttributes,
-		txnStore:          txnStore,
-		txnCtrMgr:         txnCtrMgr,
-		formatter:         sqlSystem.GetASTFormatter(),
-		pgInternalRouter:  pgInternalRouter,
-		authContexts:      authContexts,
-		sqlDataSources:    sqlDataSources,
+		garbageCollector:       garbageCollector,
+		namespaces:             namespaces,
+		sqlEngine:              sqlEngine,
+		sqlSystem:              sqlSystem,
+		controlAttributes:      controlAttributes,
+		txnStore:               txnStore,
+		txnCtrMgr:              txnCtrMgr,
+		formatter:              sqlSystem.GetASTFormatter(),
+		pgInternalRouter:       pgInternalRouter,
+		authContexts:           authContexts,
+		sqlDataSources:         sqlDataSources,
+		txnCoordintatorContext: txnCoordintatorContext,
 	}
 }
 
 type simpleBundle struct {
-	controlAttributes sqlcontrol.ControlAttributes
-	garbageCollector  garbagecollector.GarbageCollector
-	namespaces        tablenamespace.Collection
-	sqlEngine         sqlengine.SQLEngine
-	sqlSystem         sql_system.SQLSystem
-	txnStore          kstore.KStore
-	txnCtrMgr         txncounter.Manager
-	formatter         sqlparser.NodeFormatter
-	pgInternalRouter  dbmsinternal.Router
-	sqlDataSources    map[string]sql_datasource.SQLDataSource
-	authContexts      map[string]*dto.AuthCtx
+	controlAttributes      sqlcontrol.ControlAttributes
+	garbageCollector       garbagecollector.GarbageCollector
+	namespaces             tablenamespace.Collection
+	sqlEngine              sqlengine.SQLEngine
+	sqlSystem              sql_system.SQLSystem
+	txnStore               kstore.KStore
+	txnCtrMgr              txncounter.Manager
+	formatter              sqlparser.NodeFormatter
+	pgInternalRouter       dbmsinternal.Router
+	sqlDataSources         map[string]sql_datasource.SQLDataSource
+	authContexts           map[string]*dto.AuthCtx
+	txnCoordintatorContext txn_context.ITransactionCoordinatorContext
+}
+
+func (sb *simpleBundle) GetTxnCoordinatorContext() txn_context.ITransactionCoordinatorContext {
+	return sb.txnCoordintatorContext
 }
 
 func (sb *simpleBundle) GetSQLDataSources() map[string]sql_datasource.SQLDataSource {

--- a/internal/stackql/cmd/root.go
+++ b/internal/stackql/cmd/root.go
@@ -104,6 +104,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.NamespaceCfgRaw, dto.NamespaceCfgRawKey, "{}", "JSON / YAML string representing namespaces for cacheing, views etc")
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.StoreTxnCfgRaw, dto.StoreTxnCfgRawKey, "{}", "JSON / YAML string representing Txn store config")
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.GCCfgRaw, dto.GCCfgRawKey, "{}", "JSON / YAML string representing GC config")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.ACIDCfgRaw, dto.ACIDCfgRawKey, "{}", "JSON / YAML string representing GC config")
 	rootCmd.PersistentFlags().IntVar(&runtimeCtx.APIRequestTimeout, dto.APIRequestTimeoutKey, 45, "API request timeout in seconds, 0 for no timeout.") //nolint:gomnd // TODO: investigate
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.ColorScheme, dto.ColorSchemeKey, config.GetDefaultColorScheme(), fmt.Sprintf("Color scheme, must be one of {'%s', '%s', '%s'}", dto.DarkColorScheme, dto.LightColorScheme, dto.NullColorScheme))
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CABundle, dto.CABundleKey, "", "Path to CA bundle, if not specified then system defaults used.")

--- a/internal/stackql/driver/aggregation_compute_disks_integration_test.go
+++ b/internal/stackql/driver/aggregation_compute_disks_integration_test.go
@@ -2,7 +2,7 @@ package driver_test
 
 import (
 	"bufio"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logging.GetLogger().SetOutput(ioutil.Discard)
+	logging.GetLogger().SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 

--- a/internal/stackql/driver/driver_integration_test.go
+++ b/internal/stackql/driver/driver_integration_test.go
@@ -1,7 +1,6 @@
 package driver_test
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -246,7 +245,7 @@ func TestK8sTheHardWayAsync(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test failed: %v", err)
 		}
-		megaQueryConcat, err := ioutil.ReadFile(k8sthwRenderedFile)
+		megaQueryConcat, err := os.ReadFile(k8sthwRenderedFile)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}

--- a/internal/stackql/driver/okta_integration_test.go
+++ b/internal/stackql/driver/okta_integration_test.go
@@ -2,7 +2,6 @@ package driver_test
 
 import (
 	"bufio"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -32,7 +31,7 @@ func TestSelectOktaApplicationAppsDriver(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes1, err := ioutil.ReadFile(responseFile1)
+	responseBytes1, err := os.ReadFile(responseFile1)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/internal/stackql/dto/auth_ctx.go
+++ b/internal/stackql/dto/auth_ctx.go
@@ -3,7 +3,6 @@ package dto
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -140,7 +139,7 @@ func (ac *AuthCtx) GetCredentialsBytes() ([]byte, error) {
 	}
 	credentialFile := ac.KeyFilePath
 	if credentialFile != "" {
-		return ioutil.ReadFile(credentialFile)
+		return os.ReadFile(credentialFile)
 	}
 	if ac.getEnvVarBasicCredentials() != "" {
 		return []byte(ac.getEnvVarBasicCredentials()), nil

--- a/internal/stackql/dto/dto.go
+++ b/internal/stackql/dto/dto.go
@@ -52,6 +52,7 @@ const (
 	QueryCacheSizeKey               string = "querycachesize"
 	RegistryRawKey                  string = "registry"
 	GCCfgRawKey                     string = "gc"
+	ACIDCfgRawKey                   string = "acid"
 	NamespaceCfgRawKey              string = "namespaces"
 	SQLBackendCfgRawKey             string = "sqlBackend"
 	DBInternalCfgRawKey             string = "dbInternal"

--- a/internal/stackql/dto/runtime_ctx.go
+++ b/internal/stackql/dto/runtime_ctx.go
@@ -44,6 +44,7 @@ type RuntimeCtx struct {
 	NamespaceCfgRaw              string
 	StoreTxnCfgRaw               string
 	GCCfgRaw                     string
+	ACIDCfgRaw                   string
 	QueryCacheSize               int
 	TemplateCtxFilePath          string
 	TestWithoutAPICalls          bool
@@ -141,6 +142,8 @@ func (rc *RuntimeCtx) Set(key string, val string) error {
 		rc.StoreTxnCfgRaw = val
 	case GCCfgRawKey:
 		rc.GCCfgRaw = val
+	case ACIDCfgRawKey:
+		rc.ACIDCfgRaw = val
 	case OutfilePathKey:
 		rc.OutfilePath = val
 	case OutputFormatKey:

--- a/internal/stackql/dto/txn_coordinator_config.go
+++ b/internal/stackql/dto/txn_coordinator_config.go
@@ -1,0 +1,26 @@
+package dto
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	defaultMaxTxnDepth = -1
+)
+
+type TxnCoordinatorCfg struct {
+	MaxTxnDepth *int `json:"maxTransactionDepth" yaml:"maxTransactionDepth"`
+}
+
+func (t TxnCoordinatorCfg) GetMaxTxnDepth() int {
+	if t.MaxTxnDepth == nil {
+		return defaultMaxTxnDepth
+	}
+	return *t.MaxTxnDepth
+}
+
+func GetTxnCoordinatorCfgCfg(s string) (TxnCoordinatorCfg, error) {
+	rv := TxnCoordinatorCfg{}
+	err := yaml.Unmarshal([]byte(s), &rv)
+	return rv, err
+}

--- a/internal/stackql/internal_data_transfer/primitive_context/primitive_context.go
+++ b/internal/stackql/internal_data_transfer/primitive_context/primitive_context.go
@@ -5,22 +5,22 @@ var (
 )
 
 type IPrimitiveCtx interface {
-	IsNotMutating() bool
-	SetIsNotMutating(bool)
+	IsReadOnly() bool
+	SetIsReadOnly(bool)
 }
 
 type primitiveCtx struct {
-	isNotMutating bool
+	isReadOnly bool
 }
 
 func NewPrimitiveContext() IPrimitiveCtx {
 	return &primitiveCtx{}
 }
 
-func (pc *primitiveCtx) IsNotMutating() bool {
-	return pc.isNotMutating
+func (pc *primitiveCtx) IsReadOnly() bool {
+	return pc.isReadOnly
 }
 
-func (pc *primitiveCtx) SetIsNotMutating(isNotMutating bool) {
-	pc.isNotMutating = isNotMutating
+func (pc *primitiveCtx) SetIsReadOnly(isReadOnly bool) {
+	pc.isReadOnly = isReadOnly
 }

--- a/internal/stackql/logging/logging.go
+++ b/internal/stackql/logging/logging.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -24,6 +24,6 @@ func GetLogger() *logrus.Logger {
 		return logger
 	}
 	tmpLogger := logrus.New()
-	tmpLogger.SetOutput(ioutil.Discard)
+	tmpLogger.SetOutput(io.Discard)
 	return tmpLogger
 }

--- a/internal/stackql/plan/plan.go
+++ b/internal/stackql/plan/plan.go
@@ -16,7 +16,7 @@ type Plan interface {
 
 	// Getters
 	GetType() sqlparser.StatementType
-	GetStatement() sqlparser.Statement
+	GetStatement() (sqlparser.Statement, bool)
 	GetOriginal() string
 	GetInstructions() primitive.IPrimitive
 	GetBindVarNeeds() sqlparser.BindVarNeeds
@@ -32,6 +32,10 @@ type Plan interface {
 	SetBindVarNeeds(bindVarNeeds sqlparser.BindVarNeeds)
 	SetCacheable(isCacheable bool)
 	SetTxnID(txnID int)
+
+	//
+	IsReadOnly() bool
+	SetReadOnly(bool)
 
 	// Size is defined so that Plan can be given to a cache.LRUCache,
 	// which requires its objects to define a Size function.
@@ -51,6 +55,7 @@ type standardPlan struct {
 	Rows         uint64        // Total number of rows
 	Errors       uint64        // Total number of errors
 	isCacheable  bool
+	isReadOnly   bool
 }
 
 func NewPlan(
@@ -62,6 +67,20 @@ func NewPlan(
 	}
 }
 
+func (p *standardPlan) SetReadOnly(isReadOnly bool) {
+	p.isReadOnly = isReadOnly
+}
+
+func (p *standardPlan) IsReadOnly() bool {
+	if p.Instructions == nil {
+		return true
+	}
+	if p.isReadOnly {
+		return true
+	}
+	return p.Instructions.IsReadOnly()
+}
+
 func (p *standardPlan) SetTxnID(txnID int) {
 	p.Instructions.SetTxnID(txnID)
 }
@@ -70,8 +89,8 @@ func (p *standardPlan) GetType() sqlparser.StatementType {
 	return p.Type
 }
 
-func (p *standardPlan) GetStatement() sqlparser.Statement {
-	return p.RewrittenStatement
+func (p *standardPlan) GetStatement() (sqlparser.Statement, bool) {
+	return p.RewrittenStatement, p.RewrittenStatement != nil
 }
 
 func (p *standardPlan) GetOriginal() string {

--- a/internal/stackql/planbuilder/entrypoint.go
+++ b/internal/stackql/planbuilder/entrypoint.go
@@ -85,10 +85,14 @@ func (pb *standardPlanBuilder) BuildPlanFromContext(handlerCtx handler.HandlerCo
 	statementType := earlyPassScreenerAnalyzer.GetStatementType()
 	qPlan.SetType(statementType)
 
+	isReadOnlyFromEarlyPasses := earlyPassScreenerAnalyzer.IsReadOnly()
+	qPlan.SetReadOnly(isReadOnlyFromEarlyPasses)
+
 	qPlan.SetStatement(earlyPassScreenerAnalyzer.GetStatement())
 
 	switch earlyPassScreenerAnalyzer.GetInstructionType() { //nolint:exhaustive // acceptable
 	case earlyanalysis.InternallyRoutableInstruction:
+		qPlan.SetReadOnly(true)
 		createInstructionError := pGBuilder.pgInternal(earlyPassScreenerAnalyzer.GetPlanBuilderInput())
 		if createInstructionError != nil {
 			return nil, createInstructionError
@@ -102,12 +106,19 @@ func (pb *standardPlanBuilder) BuildPlanFromContext(handlerCtx handler.HandlerCo
 			}
 		}
 		return qPlan, err
-	case earlyanalysis.StandardInstruction, earlyanalysis.DummiedPGInstruction:
+	case earlyanalysis.StandardInstruction:
+		createInstructionError := pGBuilder.createInstructionFor(earlyPassScreenerAnalyzer.GetPlanBuilderInput())
+		if createInstructionError != nil {
+			return nil, createInstructionError
+		}
+	case earlyanalysis.DummiedPGInstruction:
+		qPlan.SetReadOnly(true)
 		createInstructionError := pGBuilder.createInstructionFor(earlyPassScreenerAnalyzer.GetPlanBuilderInput())
 		if createInstructionError != nil {
 			return nil, createInstructionError
 		}
 	case earlyanalysis.NopInstruction:
+		qPlan.SetReadOnly(true)
 		createInstructionError := pGBuilder.nop(earlyPassScreenerAnalyzer.GetPlanBuilderInput())
 		if createInstructionError != nil {
 			return nil, createInstructionError

--- a/internal/stackql/planbuilderinput/plan_builder_input.go
+++ b/internal/stackql/planbuilderinput/plan_builder_input.go
@@ -45,8 +45,12 @@ type PlanBuilderInput interface {
 	IsTccSetAheadOfTime() bool
 	SetIsTccSetAheadOfTime(bool)
 
+	GetMessages() []string
+	WithMessages(messages []string) PlanBuilderInput
 	WithParameterRouter(router.ParameterRouter) PlanBuilderInput
 	WithTableRouteVisitor(tableRouteVisitor router.TableRouteAstVisitor) PlanBuilderInput
+	SetReadOnly(bool)
+	IsReadOnly() bool
 }
 
 type StandardPlanBuilderInput struct {
@@ -64,6 +68,8 @@ type StandardPlanBuilderInput struct {
 	onConditionDataFlows   dataflow.Collection
 	onConditionsToRewrite  map[*sqlparser.ComparisonExpr]struct{}
 	tccSetAheadOfTime      bool
+	messages               []string
+	readOnly               bool
 }
 
 func NewPlanBuilderInput(
@@ -133,7 +139,25 @@ func (pbi *StandardPlanBuilderInput) Clone() PlanBuilderInput {
 		pbi.paramsPlaceheld,
 		pbi.tcc,
 	)
+	clonedPbi.SetReadOnly(pbi.IsReadOnly())
 	return clonedPbi
+}
+
+func (pbi *StandardPlanBuilderInput) SetReadOnly(readOnly bool) {
+	pbi.readOnly = readOnly
+}
+
+func (pbi *StandardPlanBuilderInput) IsReadOnly() bool {
+	return pbi.readOnly
+}
+
+func (pbi *StandardPlanBuilderInput) WithMessages(messages []string) PlanBuilderInput {
+	pbi.messages = messages
+	return pbi
+}
+
+func (pbi *StandardPlanBuilderInput) GetMessages() []string {
+	return pbi.messages
 }
 
 func (pbi *StandardPlanBuilderInput) GetOnConditionsToRewrite() map[*sqlparser.ComparisonExpr]struct{} {

--- a/internal/stackql/primitive/http_rest_primitive.go
+++ b/internal/stackql/primitive/http_rest_primitive.go
@@ -16,7 +16,7 @@ type HTTPRestPrimitive struct {
 	Inputs        map[int64]internaldto.ExecutorOutput
 	InputAliases  map[string]int64
 	id            int64
-	isNotMutating bool
+	isReadOnly    bool
 }
 
 func NewHTTPRestPrimitive(
@@ -33,7 +33,7 @@ func NewHTTPRestPrimitive(
 		TxnControlCtr: txnCtrlCtr,
 		Inputs:        make(map[int64]internaldto.ExecutorOutput),
 		InputAliases:  make(map[string]int64),
-		isNotMutating: primitiveCtx.IsNotMutating(),
+		isReadOnly:    primitiveCtx.IsReadOnly(),
 	}
 }
 
@@ -43,8 +43,8 @@ func (pr *HTTPRestPrimitive) SetTxnID(id int) {
 	}
 }
 
-func (pr *HTTPRestPrimitive) IsNotMutating() bool {
-	return pr.isNotMutating
+func (pr *HTTPRestPrimitive) IsReadOnly() bool {
+	return pr.isReadOnly
 }
 
 func (pr *HTTPRestPrimitive) GetRedoLog() (binlog.LogEntry, bool) {

--- a/internal/stackql/primitive/local_primitive.go
+++ b/internal/stackql/primitive/local_primitive.go
@@ -20,7 +20,7 @@ func NewLocalPrimitive(executor func(pc IPrimitiveCtx) internaldto.ExecutorOutpu
 	}
 }
 
-func (pr *LocalPrimitive) IsNotMutating() bool {
+func (pr *LocalPrimitive) IsReadOnly() bool {
 	return false
 }
 

--- a/internal/stackql/primitive/metadata_primitive.go
+++ b/internal/stackql/primitive/metadata_primitive.go
@@ -19,7 +19,7 @@ type MetaDataPrimitive struct {
 func (pr *MetaDataPrimitive) SetTxnID(_ int) {
 }
 
-func (pr *MetaDataPrimitive) IsNotMutating() bool {
+func (pr *MetaDataPrimitive) IsReadOnly() bool {
 	return true
 }
 

--- a/internal/stackql/primitive/pass_through_primitive.go
+++ b/internal/stackql/primitive/pass_through_primitive.go
@@ -30,7 +30,7 @@ func NewPassThroughPrimitive(
 func (pr *PassThroughPrimitive) SetTxnID(_ int) {
 }
 
-func (pr *PassThroughPrimitive) IsNotMutating() bool {
+func (pr *PassThroughPrimitive) IsReadOnly() bool {
 	return true
 }
 

--- a/internal/stackql/primitive/primitive.go
+++ b/internal/stackql/primitive/primitive.go
@@ -23,7 +23,7 @@ type IPrimitive interface {
 
 	SetTxnID(int)
 	//
-	IsNotMutating() bool
+	IsReadOnly() bool
 
 	// Get the redo log entry.
 	GetRedoLog() (binlog.LogEntry, bool)

--- a/internal/stackql/primitivebuilder/nop.go
+++ b/internal/stackql/primitivebuilder/nop.go
@@ -9,11 +9,16 @@ import (
 	"github.com/stackql/stackql/internal/stackql/util"
 )
 
+var (
+	defaultNopMessages []string = []string{"OK"} //nolint:revive,gochecknoglobals // prefer declarative
+)
+
 type NopBuilder struct {
 	graph      primitivegraph.PrimitiveGraph
 	handlerCtx handler.HandlerContext
 	root       primitivegraph.PrimitiveNode
 	sqlEngine  sqlengine.SQLEngine
+	messages   []string
 }
 
 func NewNopBuilder(
@@ -21,11 +26,16 @@ func NewNopBuilder(
 	txnControlCounters internaldto.TxnControlCounters, //nolint:revive // future proofing
 	handlerCtx handler.HandlerContext,
 	sqlEngine sqlengine.SQLEngine,
+	messages []string,
 ) Builder {
+	if len(messages) == 0 {
+		messages = defaultNopMessages
+	}
 	return &NopBuilder{
 		graph:      graph,
 		handlerCtx: handlerCtx,
 		sqlEngine:  sqlEngine,
+		messages:   messages,
 	}
 }
 
@@ -39,7 +49,7 @@ func (nb *NopBuilder) Build() error {
 					nil,
 					nil,
 					nil,
-					internaldto.NewBackendMessages([]string{"nop completed"}), nil),
+					internaldto.NewBackendMessages(nb.messages), nil),
 			)
 		},
 	)

--- a/internal/stackql/primitivebuilder/single_select_acquire.go
+++ b/internal/stackql/primitivebuilder/single_select_acquire.go
@@ -37,7 +37,7 @@ type SingleSelectAcquire struct {
 	rowSort                    func(map[string]map[string]interface{}) []string
 	root                       primitivegraph.PrimitiveNode
 	stream                     streaming.MapStream
-	isNotMutating              bool //nolint:unused // TODO: build out
+	isReadOnly                 bool //nolint:unused // TODO: build out
 }
 
 func NewSingleSelectAcquire(
@@ -329,7 +329,7 @@ func (ss *SingleSelectAcquire) Build() error {
 		return ss.insertPreparedStatementCtx
 	}
 	primitiveCtx := primitive_context.NewPrimitiveContext()
-	primitiveCtx.SetIsNotMutating(true)
+	primitiveCtx.SetIsReadOnly(true)
 	insertPrim := primitive.NewHTTPRestPrimitive(
 		prov,
 		ex,

--- a/internal/stackql/primitivebuilder/sql_data_source_single_select_acquire.go
+++ b/internal/stackql/primitivebuilder/sql_data_source_single_select_acquire.go
@@ -133,7 +133,7 @@ func (ss *sqlDataSourceSingleSelectAcquire) Build() error {
 		return ss.insertPreparedStatementCtx
 	}
 	primitiveCtx := primitive_context.NewPrimitiveContext()
-	primitiveCtx.SetIsNotMutating(true)
+	primitiveCtx.SetIsReadOnly(true)
 	insertPrim := primitive.NewHTTPRestPrimitive(
 		nil,
 		ex,

--- a/internal/stackql/primitivegenerator/statement_analyzer.go
+++ b/internal/stackql/primitivegenerator/statement_analyzer.go
@@ -642,6 +642,7 @@ func (pb *standardPrimitiveGenerator) AnalyzeNop(
 			pb.PrimitiveComposer.GetTxnCtrlCtrs(),
 			handlerCtx,
 			handlerCtx.GetSQLEngine(),
+			pbi.GetMessages(),
 		),
 	)
 	return nil

--- a/internal/stackql/primitivegraph/dag.go
+++ b/internal/stackql/primitivegraph/dag.go
@@ -49,7 +49,7 @@ type standardPrimitiveGraph struct {
 	containsView           bool
 }
 
-func (pg *standardPrimitiveGraph) IsNotMutating() bool {
+func (pg *standardPrimitiveGraph) IsReadOnly() bool {
 	nodes := pg.g.Nodes()
 	for nodes.Next() {
 		node := nodes.Node()
@@ -57,7 +57,7 @@ func (pg *standardPrimitiveGraph) IsNotMutating() bool {
 		if !isPrimNode {
 			continue
 		}
-		if !primNode.GetOperation().IsNotMutating() {
+		if !primNode.GetOperation().IsReadOnly() {
 			return false
 		}
 	}

--- a/internal/stackql/providerconfig/providerconfig.go
+++ b/internal/stackql/providerconfig/providerconfig.go
@@ -1,13 +1,13 @@
 package providerconfig
 
 import (
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
 
 func ReadProviderConfig(filePath string) (map[string]interface{}, error) {
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stackql/querysubmit/querysubmit.go
+++ b/internal/stackql/querysubmit/querysubmit.go
@@ -15,10 +15,11 @@ var (
 )
 
 type QuerySubmitter interface {
-	GetStatement() sqlparser.Statement
+	GetStatement() (sqlparser.Statement, bool)
 	PrepareQuery(handlerCtx handler.HandlerContext) error
 	SubmitQuery() internaldto.ExecutorOutput
 	WithTransactionContext(transactionContext txn_context.ITransactionContext) QuerySubmitter
+	IsReadOnly() bool
 }
 
 func NewQuerySubmitter() QuerySubmitter {
@@ -31,9 +32,16 @@ type basicQuerySubmitter struct {
 	transactionContext txn_context.ITransactionContext
 }
 
-func (qs *basicQuerySubmitter) GetStatement() sqlparser.Statement {
+func (qs *basicQuerySubmitter) IsReadOnly() bool {
 	if qs.queryPlan == nil {
-		return nil
+		return true
+	}
+	return qs.queryPlan.IsReadOnly()
+}
+
+func (qs *basicQuerySubmitter) GetStatement() (sqlparser.Statement, bool) {
+	if qs.queryPlan == nil {
+		return nil, false
 	}
 	return qs.queryPlan.GetStatement()
 }

--- a/internal/stackql/sqlengine/postgres_tcp.go
+++ b/internal/stackql/sqlengine/postgres_tcp.go
@@ -4,7 +4,7 @@ package sqlengine
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/stackql/stackql/internal/stackql/db_util"
@@ -73,7 +73,7 @@ func newPostgresTCPEngine(
 }
 
 func (se *postgresTCPEngine) execFile(fileName string) error {
-	fileContents, err := ioutil.ReadFile(fileName)
+	fileContents, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/internal/stackql/sqlengine/snowflake_tcp.go
+++ b/internal/stackql/sqlengine/snowflake_tcp.go
@@ -4,7 +4,7 @@ package sqlengine
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/stackql/stackql/internal/stackql/db_util"
@@ -73,7 +73,7 @@ func newSnowflakeTCPEngine(
 }
 
 func (se *snowflakeTCPEngine) execFile(fileName string) error {
-	fileContents, err := ioutil.ReadFile(fileName)
+	fileContents, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/internal/stackql/sqlengine/sqlite_embedded.go
+++ b/internal/stackql/sqlengine/sqlite_embedded.go
@@ -3,7 +3,7 @@ package sqlengine
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 
@@ -74,7 +74,7 @@ func newSQLiteEmbeddedEngine(
 }
 
 func (se *sqLiteEmbeddedEngine) execFileSQLite(fileName string) error {
-	fileContents, err := ioutil.ReadFile(fileName)
+	fileContents, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/internal/test/stackqltestutil/locator.go
+++ b/internal/test/stackqltestutil/locator.go
@@ -3,7 +3,7 @@ package stackqltestutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/stackql/stackql/internal/stackql/bundle"
 	"github.com/stackql/stackql/internal/stackql/dto"
@@ -50,7 +50,7 @@ func getBytesFromLocalPath(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(fullPath)
+	return os.ReadFile(fullPath)
 }
 
 func BuildInputBundle(runtimeCtx dto.RuntimeCtx) (bundle.Bundle, error) {

--- a/internal/test/stackqltestutil/setup.go
+++ b/internal/test/stackqltestutil/setup.go
@@ -3,7 +3,7 @@ package stackqltestutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"net/url"
 	"testing"
@@ -34,7 +34,7 @@ func SetupSelectOktaApplicationApps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes1, err := ioutil.ReadFile(responseFile1)
+	responseBytes1, err := os.ReadFile(responseFile1)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -58,7 +58,7 @@ func getDisksSelectExpectations(t *testing.T) map[string]testhttpapi.HTTPRequest
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes, err := ioutil.ReadFile(responseFile)
+	responseBytes, err := os.ReadFile(responseFile)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -79,7 +79,7 @@ func getCloudResourceManagerOrganizationsGetIamPolicyExpectations(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes, err := ioutil.ReadFile(responseFile)
+	responseBytes, err := os.ReadFile(responseFile)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -100,7 +100,7 @@ func getCloudResourceManagerProjectSelectExpectations(t *testing.T) map[string]t
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes, err := ioutil.ReadFile(responseFile)
+	responseBytes, err := os.ReadFile(responseFile)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -134,7 +134,7 @@ func SetupSimpleSelectGoogleComputeDisksPaginated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes1, err := ioutil.ReadFile(responseFile1)
+	responseBytes1, err := os.ReadFile(responseFile1)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -148,7 +148,7 @@ func SetupSimpleSelectGoogleComputeDisksPaginated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes2, err := ioutil.ReadFile(responseFile2)
+	responseBytes2, err := os.ReadFile(responseFile2)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -162,7 +162,7 @@ func SetupSimpleSelectGoogleComputeDisksPaginated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes3, err := ioutil.ReadFile(responseFile3)
+	responseBytes3, err := os.ReadFile(responseFile3)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -536,7 +536,7 @@ func SetupDependentInsertGoogleBQDatasets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes01, err := ioutil.ReadFile(responseFile01)
+	responseBytes01, err := os.ReadFile(responseFile01)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -544,7 +544,7 @@ func SetupDependentInsertGoogleBQDatasets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed: %v", err)
 	}
-	responseBytes02, err := ioutil.ReadFile(responseFile02)
+	responseBytes02, err := os.ReadFile(responseFile02)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/internal/test/testhttpapi/httptestutils.go
+++ b/internal/test/testhttpapi/httptestutils.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -215,11 +214,11 @@ func compareHTTPBodyToExpected(req *http.Request, expectations *HTTPRequestExpec
 	var retVal io.ReadCloser
 	//nolint:govet // apathy on shadowing
 	if expectations.Body != nil {
-		actualBodyBytes, err = ioutil.ReadAll(req.Body)
+		actualBodyBytes, err = io.ReadAll(req.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading actual body")
 		}
-		expectedBodyBytes, err = ioutil.ReadAll(expectations.Body)
+		expectedBodyBytes, err = io.ReadAll(expectations.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading expected body")
 		}
@@ -235,8 +234,8 @@ func compareHTTPBodyToExpected(req *http.Request, expectations *HTTPRequestExpec
 		if !reflect.DeepEqual(actualBodyMap, expectedBodyMap) {
 			return nil, fmt.Errorf("http request body: actual != expected: '%s' != '%s'", string(actualBodyBytes), string(expectedBodyBytes))
 		}
-		expectations.Body = ioutil.NopCloser(bytes.NewReader(expectedBodyBytes))
-		retVal = ioutil.NopCloser(bytes.NewReader(actualBodyBytes))
+		expectations.Body = io.NopCloser(bytes.NewReader(expectedBodyBytes))
+		retVal = io.NopCloser(bytes.NewReader(actualBodyBytes))
 		fmt.Fprintln(os.Stderr, "body check completed successfully!")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, fmt.Sprintf("body = '%s'", string(actualBodyBytes)))
@@ -466,7 +465,7 @@ func (w *PipeResponseWriter) WriteHeader(status int) {
 func ValidateHTTPResponseAndErr(t *testing.T, response *http.Response, err error) {
 	if err == nil {
 		if response.Body != nil {
-			bb, bErr := ioutil.ReadAll(response.Body)
+			bb, bErr := io.ReadAll(response.Body)
 			if bErr != nil {
 				t.Fatalf("could not read body: %v", bErr)
 			}

--- a/internal/test/testutil/testutil.go
+++ b/internal/test/testutil/testutil.go
@@ -2,17 +2,17 @@ package testutil
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
 
 func CreateReadCloserFromString(s string) io.ReadCloser {
-	return ioutil.NopCloser(strings.NewReader(s))
+	return io.NopCloser(strings.NewReader(s))
 }
 
 func StringEqualsFileContents(t *testing.T, s string, filePath string, stringent bool) bool {
-	fileContents, err := ioutil.ReadFile(filePath)
+	fileContents, err := os.ReadFile(filePath)
 	fileContentsString := string(fileContents)
 	if err == nil {
 		t.Logf("file contents for testing = %s", fileContentsString)

--- a/pkg/awssign/aws_sign.go
+++ b/pkg/awssign/aws_sign.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -59,7 +58,7 @@ func (t *standardAwsSignTransport) RoundTrip(req *http.Request) (*http.Response,
 	}
 	var rs io.ReadSeeker
 	if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/preprocessor/preprocessor.go
+++ b/pkg/preprocessor/preprocessor.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"text/template"
 	"unicode"
 
@@ -149,7 +148,7 @@ func NewPreprocessor(declarationBlockStartToken, declarationBlockEndToken string
 }
 
 func (pp *Preprocessor) Render(input io.Reader) (io.Reader, error) {
-	inContents, err := ioutil.ReadAll(input)
+	inContents, err := io.ReadAll(input)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +166,7 @@ func (pp *Preprocessor) Render(input io.Reader) (io.Reader, error) {
 func (pp *Preprocessor) Prepare(infile io.Reader, infileName string) (io.Reader, error) {
 	var outContents []byte
 	var declarationBlocks []DeclarationBlock
-	inContents, err := ioutil.ReadAll(infile)
+	inContents, err := io.ReadAll(infile)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +198,7 @@ func (pp *Preprocessor) Prepare(infile io.Reader, infileName string) (io.Reader,
 }
 
 func (pp *Preprocessor) PrepareExternal(infileType string, infile io.Reader, infileName string) error {
-	inContents, err := ioutil.ReadAll(infile)
+	inContents, err := io.ReadAll(infile)
 	if err != nil {
 		return err
 	}

--- a/stackql/main_test.go
+++ b/stackql/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logging.GetLogger().SetOutput(ioutil.Discard)
+	logging.GetLogger().SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -684,6 +684,32 @@ Digitalocean Insert Droplet
     ...    The operation was despatched successfully
     ...    stdout=${CURDIR}/tmp/Digitalocean-Insert-Droplet.tmp
 
+Transaction Rollback Digitalocean Insert Droplet
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    {"digitalocean": { "username_var": "DUMMY_DIGITALOCEAN_USERNAME", "password_var": "DUMMY_DIGITALOCEAN_PASSWORD", "type": "basic", "valuePrefix": "TOTALLY_CONTRIVED "}}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    begin; INSERT INTO digitalocean.droplets.droplets ( data__name, data__region, data__size, data__image, data__backups, data__ipv6, data__monitoring, data__tags ) SELECT 'some.example.com', 'nyc3', 's-1vcpu-1gb', 'ubuntu-20-04-x64', true, true, true, '["env:prod", "web"]' ; rollback;
+    ...    OK\nmutating statement queued\nRollback OK
+    ...    stdout=${CURDIR}/tmp/Digitalocean-Insert-Droplet.tmp
+
+Transaction Commit Eager Show and Lazy Digitalocean Insert Droplet
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    {"digitalocean": { "username_var": "DUMMY_DIGITALOCEAN_USERNAME", "password_var": "DUMMY_DIGITALOCEAN_PASSWORD", "type": "basic", "valuePrefix": "TOTALLY_CONTRIVED "}}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    begin; INSERT INTO digitalocean.droplets.droplets ( data__name, data__region, data__size, data__image, data__backups, data__ipv6, data__monitoring, data__tags ) SELECT 'some.example.com', 'nyc3', 's-1vcpu-1gb', 'ubuntu-20-04-x64', true, true, true, '["env:prod", "web"]' ; show services in digitalocean like 'droplets'; commit;
+    ...    OK\nmutating${SPACE}statement${SPACE}queued\n|-----------------------|----------|-----------------------------|\n|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}id${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}title${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|\n|-----------------------|----------|-----------------------------|\n|${SPACE}droplets:v23.03.00127${SPACE}|${SPACE}droplets${SPACE}|${SPACE}DigitalOcean${SPACE}API${SPACE}-${SPACE}Droplets${SPACE}|\n|-----------------------|----------|-----------------------------|\nThe${SPACE}operation${SPACE}was${SPACE}despatched${SPACE}successfully\nOK
+    ...    stdout=${CURDIR}/tmp/Digitalocean-Insert-Droplet.tmp
+
 Registry Pull Google Provider Specific Version Prerelease
     Should Stackql Exec Inline Contain
     ...    ${STACKQL_EXE}


### PR DESCRIPTION
## Description

- Transaction machinery in place.
- Removed deprecated `ioutil` lib.
- Simple "lazy mutate, eager read" transactions in place.
- Undo and redo logs **not** in place.
- Two robot tests for transactions: 
    1. `Transaction Rollback Digitalocean Insert Droplet`. 
    2. `Transaction Commit Eager Show and Lazy Digitalocean Insert Droplet`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

Two robot tests for transactions: 
    1. `Transaction Rollback Digitalocean Insert Droplet`. 
    2. `Transaction Commit Eager Show and Lazy Digitalocean Insert Droplet`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

This change does not introduce technical debt.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
