### PR TITLE
postgres-json-views

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,6 +76,9 @@
         "SELECT a.attname FROM pg_attribute a JOIN ( SELECT unnest(ix.indkey) attnum, generate_subscripts(ix.indkey, 1) ord FROM pg_index ix WHERE ix.indrelid = '13420' AND ix.indisprimary ) k ON a.attnum=k.attnum WHERE a.attrelid = '13420'  ORDER BY k.ord ;",
         "select aws_region, volumeId, encrypted, size from aws_ec2_all_volumes ;",
         "select d1.name as n, d1.id, n1.description, s1.description as s1_description from google.compute.disks d1 inner join google.compute.networks n1 on d1.name = n1.name inner join google.compute.subnetworks s1 on d1.name = s1.name where d1.project = 'stackql-demo' and d1.zone = 'australia-southeast1-b' and n1.project = 'stackql-demo' and s1.project = 'stackql-demo' and s1.region = 'australia-southeast1' ;",
+        "select Properties FROM aws.cloud_control.resources WHERE region = 'ap-southeast-1' and data__TypeName = 'AWS::S3::Bucket';",
+        "select bucket_name from vvzz;",
+        "create view vvzz as select json_extract_path_text(Properties, 'BucketName') bucket_name, json_extract_path_text(Properties, 'VersioningConfiguration', 'Status') versioning FROM aws.cloud_control.resources WHERE region = 'ap-southeast-1' and data__TypeName = 'AWS::S3::Bucket' and data__Identifier = 'stackql-registry-artifacts';"
       ],
       "default": "show providers;"
     },

--- a/internal/stackql/astanalysis/earlyanalysis/first_passes.go
+++ b/internal/stackql/astanalysis/earlyanalysis/first_passes.go
@@ -178,7 +178,7 @@ func (sp *standardInitialPasses) initialPasses(
 		annotatedAST,
 		sp.primitiveGenerator,
 		handlerCtx.GetSQLSystem(),
-		handlerCtx.GetASTFormatter(),
+		nil, // minimal formatting prior to view storage
 		handlerCtx.GetNamespaceCollection(),
 		whereParams,
 		tcc,

--- a/internal/stackql/astformat/ast_format_postgres.go
+++ b/internal/stackql/astformat/ast_format_postgres.go
@@ -27,18 +27,17 @@ func PostgresSelectExprsFormatter(buf *sqlparser.TrackedBuffer, node sqlparser.S
 		formatColIdent(node, buf)
 		return
 	case *sqlparser.FuncExpr:
-		if strings.ToLower(node.Name.GetRawVal()) == constants.SQLFuncJSONExtractPostgres {
+		if strings.ToLower(node.Name.GetRawVal()) == constants.SQLFuncJSONExtractPostgres && len(node.Exprs) > 1 {
 			sb := sqlparser.NewTrackedBuffer(PostgresSelectExprsFormatter)
-			sb.AstPrintf(node, "%s(%v::json, %v)", constants.SQLFuncJSONExtractPostgres, node.Exprs[0], node.Exprs[1])
+			lhsSuffix := "::json"
+			sb.AstPrintf(node, "%s(%v%s, %v", constants.SQLFuncJSONExtractPostgres, node.Exprs[0], lhsSuffix, node.Exprs[1])
+			for _, val := range node.Exprs[2:] {
+				sb.AstPrintf(node, ", %v", val)
+			}
+			sb.AstPrintf(node, ")")
 			buf.WriteString(sb.String())
 			return
 		}
-		// if strings.ToLower(node.Name.GetRawVal()) == constants.SQLFuncGroupConcatConformed {
-		// 	sb := sqlparser.NewTrackedBuffer(PostgresSelectExprsFormatter)
-		// 	sb.AstPrintf(node, "%s(%v, %s)", constants.SQLFuncGroupConcatPostgres, node.Exprs[0], "','")
-		// 	buf.WriteString(sb.String())
-		// 	return
-		// }
 		node.Format(buf)
 		return
 	case *sqlparser.GroupConcatExpr:

--- a/internal/stackql/primitivebuilder/ddl.go
+++ b/internal/stackql/primitivebuilder/ddl.go
@@ -34,7 +34,8 @@ func (un *ddl) Build() error {
 		switch actionLowered {
 		case "create":
 			tableName := strings.Trim(astformat.String(unionObj.Table, sqlSystem.GetASTFormatter()), `"`)
-			viewDDL := strings.ReplaceAll(astformat.String(unionObj.SelectStatement, sqlSystem.GetASTFormatter()), `"`, "")
+			viewDDL := strings.ReplaceAll(
+				astformat.String(unionObj.SelectStatement, astformat.DefaultSelectExprsFormatter), `"`, "")
 			err := sqlSystem.CreateView(tableName, viewDDL)
 			if err != nil {
 				return internaldto.NewErroneousExecutorOutput(err)

--- a/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
+++ b/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
@@ -44,5 +44,24 @@ components:
                 FROM aws.cloud_control.resources WHERE region = ''ap-southeast-1'' and data__TypeName = ''AWS::S3::Bucket''
                 ;
                 '
+              fallback:
+                predicate: sqlDialect == "postgres"
+                ddl: '
+                  SELECT 
+                  json_extract_path_text(Properties, ''Arn'') as Arn,
+                  json_extract_path_text(Properties, ''BucketName'') as BucketName,
+                  json_extract_path_text(Properties, ''DomainName'') as DomainName,
+                  json_extract_path_text(Properties, ''RegionalDomainName'') as RegionalDomainName,
+                  json_extract_path_text(Properties, ''DualStackDomainName'') as DualStackDomainName,
+                  json_extract_path_text(Properties, ''WebsiteURL'') as WebsiteURL,
+                  json_extract_path_text(Properties, ''OwnershipControls'', ''Rules'', ''0'', ''ObjectOwnership'') as ObjectOwnership,
+                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''RestrictPublicBuckets'') = ''0'' THEN ''false'' ELSE ''true'' END as RestrictPublicBuckets,
+                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''BlockPublicPolicy'') = ''0'' THEN ''false'' ELSE ''true'' END as BlockPublicPolicy,
+                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''BlockPublicAcls'') = ''0'' THEN ''false'' ELSE ''true'' END as BlockPublicAcls,
+                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''IgnorePublicAcls'') = ''0'' THEN ''false'' ELSE ''true'' END as IgnorePublicAcls,
+                  json_extract_path_text(Properties, ''Tags'') as Tags
+                  FROM aws.cloud_control.resources WHERE region = ''ap-southeast-1'' and data__TypeName = ''AWS::S3::Bucket''
+                  ;
+                  '
 security:
   - hmac: []

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -1093,7 +1093,6 @@ Star of Resource Level View of Cloud Control Resource Returns Expected Result
     ...    ${CURDIR}/tmp/Star-of-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
 Filtered Projection Resource Level View of Cloud Control Resource Returns Expected Result
-    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should Horrid Query StackQL Inline Equal
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
@@ -1107,7 +1106,6 @@ Filtered Projection Resource Level View of Cloud Control Resource Returns Expect
     ...    ${CURDIR}/tmp/Filtered-Projection-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
 Filtered Star Resource Level View of Cloud Control Resource Returns Expected Result
-    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should Horrid Query StackQL Inline Equal
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
@@ -1121,7 +1119,6 @@ Filtered Star Resource Level View of Cloud Control Resource Returns Expected Res
     ...    ${CURDIR}/tmp/Filtered-Star-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
 Filtered and Parameterised Projection Resource Level View of Cloud Control Resource Returns Expected Result
-    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should Horrid Query StackQL Inline Equal
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
@@ -1135,7 +1132,6 @@ Filtered and Parameterised Projection Resource Level View of Cloud Control Resou
     ...    ${CURDIR}/tmp/Filtered-and-Parameterised-Projection-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
 Filtered and Parameterised Star Resource Level View of Cloud Control Resource Returns Expected Result
-    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should Horrid Query StackQL Inline Equal
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
@@ -1149,7 +1145,6 @@ Filtered and Parameterised Star Resource Level View of Cloud Control Resource Re
     ...    ${CURDIR}/tmp/Filtered-and-Parameterised-Star-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
 Describe View of Cloud Control Resource Returns Expected Result
-    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing
     Should StackQL Exec Inline Contain
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}


### PR DESCRIPTION
## Description

- Support for `json_extract_path_text` function inside views for `postgres` backend.
- Robot test `Filtered Projection Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Filtered Star Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Filtered and Parameterised Projection Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Filtered and Parameterised Star Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Describe View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Robot test `Filtered Projection Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Filtered Star Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Filtered and Parameterised Projection Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Filtered and Parameterised Star Resource Level View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.
- Robot test `Describe View of Cloud Control Resource Returns Expected Result` now runs against `postgres` backend.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
