### PR TITLE
jsonnet-external-variables

### DIFF
--- a/internal/stackql/cmd/root.go
+++ b/internal/stackql/cmd/root.go
@@ -149,6 +149,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.PGSrvRawTLSCfg, dto.PgSrvRawTLSCfgKey, "", "tls config for server, for server mode only")
 	rootCmd.PersistentFlags().IntVar(&runtimeCtx.PGSrvPort, dto.PgSrvPortKey, 5466, "TCP server port, for server mode only") //nolint:gomnd // TODO: investigate
 
+	rootCmd.PersistentFlags().StringSliceVar(&runtimeCtx.VarList, dto.VarListKey, []string{}, "list of variables to be used in queries")
+
 	rootCmd.PersistentFlags().MarkHidden(dto.TestWithoutAPICallsKey) //nolint:errcheck // TODO: investigate
 	rootCmd.PersistentFlags().MarkHidden(dto.ViperCfgFileNameKey)    //nolint:errcheck // TODO: investigate
 	rootCmd.PersistentFlags().MarkHidden(dto.ErrorPresentationKey)   //nolint:errcheck // TODO: investigate

--- a/internal/stackql/dto/dto.go
+++ b/internal/stackql/dto/dto.go
@@ -60,6 +60,7 @@ const (
 	TemplateCtxFilePathKey          string = "iqldata"
 	TestWithoutAPICallsKey          string = "TestWithoutAPICalls"
 	UseNonPreferredAPIsKEy          string = "usenonpreferredapis"
+	VarListKey                      string = "var"
 	VerboseFlagKey                  string = "verbose"
 	ViperCfgFileNameKey             string = "viperconfigfilename"
 	WorkOfflineKey                  string = "offline"

--- a/internal/stackql/dto/runtime_ctx.go
+++ b/internal/stackql/dto/runtime_ctx.go
@@ -49,6 +49,7 @@ type RuntimeCtx struct {
 	TemplateCtxFilePath          string
 	TestWithoutAPICalls          bool
 	UseNonPreferredAPIs          bool
+	VarList                      []string
 	VerboseFlag                  bool
 	ViperCfgFileName             string
 	WorkOffline                  bool
@@ -170,6 +171,8 @@ func (rc *RuntimeCtx) Set(key string, val string) error {
 		retVal = setBool(&rc.TestWithoutAPICalls, val)
 	case UseNonPreferredAPIsKEy:
 		retVal = setBool(&rc.UseNonPreferredAPIs, val)
+	case VarListKey:
+		rc.VarList = append(rc.VarList, val)
 	case VerboseFlagKey:
 		retVal = setBool(&rc.VerboseFlag, val)
 	case ViperCfgFileNameKey:

--- a/internal/stackql/entryutil/entryutil.go
+++ b/internal/stackql/entryutil/entryutil.go
@@ -193,7 +193,7 @@ func assemblePreprocessor(runtimeCtx dto.RuntimeCtx, rdr io.Reader) ([]byte, err
 		return nil, fmt.Errorf("preprocessor error")
 	}
 	if runtimeCtx.TemplateCtxFilePath == "" {
-		prepRd, err = pp.Prepare(rdr, runtimeCtx.InfilePath)
+		prepRd, err = pp.Prepare(rdr, runtimeCtx.InfilePath, runtimeCtx.VarList)
 		if err != nil {
 			return nil, err
 		}
@@ -207,7 +207,9 @@ func assemblePreprocessor(runtimeCtx dto.RuntimeCtx, rdr io.Reader) ([]byte, err
 			strings.Trim(
 				strings.ToLower(filepath.Ext(runtimeCtx.TemplateCtxFilePath)), "."),
 			externalTmplRdr,
-			runtimeCtx.TemplateCtxFilePath)
+			runtimeCtx.TemplateCtxFilePath,
+			runtimeCtx.VarList,
+		)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/test/stackqltestutil/locator.go
+++ b/internal/test/stackqltestutil/locator.go
@@ -42,6 +42,7 @@ func GetRuntimeCtx(providerStr string, outputFmtStr string, testName string) (*d
 		OutputFormat:              outputFmtStr,
 		SQLBackendCfgRaw:          fmt.Sprintf(`{ "dbInitFilepath": "%s", "dsn": "file:%s?mode=memory&cache=shared" }`, dbInitFilePath, testName),
 		ExecutionConcurrencyLimit: 1,
+		VarList:                   []string{"test_var=test_value"},
 	}, nil
 }
 

--- a/pkg/preprocessor/preprocessor.go
+++ b/pkg/preprocessor/preprocessor.go
@@ -76,6 +76,7 @@ type DeclarationBlock struct {
 	Contents map[string]interface{}
 }
 
+//nolint:gomnd //these invariants are ad-hoc
 func parseVarList(varList []string) (map[string]string, error) {
 	vars := make(map[string]string)
 	for _, v := range varList {
@@ -87,8 +88,8 @@ func parseVarList(varList []string) (map[string]string, error) {
 			return nil, fmt.Errorf("invalid variable declaration '%s'", v)
 		}
 		k := parts[0]
-		v := parts[1]
-		vars[k] = v
+		val := parts[1]
+		vars[k] = val
 	}
 	return vars, nil
 }

--- a/pkg/preprocessor/preprocessor.go
+++ b/pkg/preprocessor/preprocessor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"text/template"
 	"unicode"
 
@@ -75,18 +76,45 @@ type DeclarationBlock struct {
 	Contents map[string]interface{}
 }
 
-func NewDeclarationBlock(blockType string, contents []byte, filename string) (*DeclarationBlock, error) {
+func parseVarList(varList []string) (map[string]string, error) {
+	vars := make(map[string]string)
+	for _, v := range varList {
+		if v == "" {
+			return nil, fmt.Errorf("invalid empty variable declaration")
+		}
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid variable declaration '%s'", v)
+		}
+		k := parts[0]
+		v := parts[1]
+		vars[k] = v
+	}
+	return vars, nil
+}
+
+func newDeclarationBlock(
+	blockType string,
+	contents []byte,
+	filename string,
+	varList []string,
+) (*DeclarationBlock, error) {
 	ct := make(map[string]interface{})
-	var err error
 	switch blockType {
 	case JSONBlockType:
-
-		err = json.Unmarshal(bytes.TrimSpace(contents), &ct)
+		err := json.Unmarshal(bytes.TrimSpace(contents), &ct)
 		if err != nil {
 			return nil, err
 		}
 	case JsonnetBlockType:
+		vars, err := parseVarList(varList)
+		if err != nil {
+			return nil, err
+		}
 		vm := jsonnet.MakeVM()
+		for k, v := range vars {
+			vm.ExtVar(k, v)
+		}
 		var jsonStr string
 		jsonStr, err = vm.EvaluateAnonymousSnippet(filename, string(bytes.TrimSpace(contents)))
 		if err != nil {
@@ -111,7 +139,7 @@ type Preprocessor struct {
 	contents                   printableMap
 }
 
-func (pp *Preprocessor) inferBlock(block []byte, filename string) (*DeclarationBlock, error) {
+func (pp *Preprocessor) inferBlock(block []byte, filename string, varList []string) (*DeclarationBlock, error) {
 	var typeStr string
 	var i int
 	for j, b := range block {
@@ -121,7 +149,7 @@ func (pp *Preprocessor) inferBlock(block []byte, filename string) (*DeclarationB
 		i = j
 		typeStr += string(b)
 	}
-	return NewDeclarationBlock(typeStr, block[i+1:], filename)
+	return newDeclarationBlock(typeStr, block[i+1:], filename, varList)
 }
 
 func (pp *Preprocessor) mergeContents(declarationBlocks []DeclarationBlock) {
@@ -163,7 +191,7 @@ func (pp *Preprocessor) Render(input io.Reader) (io.Reader, error) {
 	return bytes.NewReader(tplWr.Bytes()), nil
 }
 
-func (pp *Preprocessor) Prepare(infile io.Reader, infileName string) (io.Reader, error) {
+func (pp *Preprocessor) Prepare(infile io.Reader, infileName string, varList []string) (io.Reader, error) {
 	var outContents []byte
 	var declarationBlocks []DeclarationBlock
 	inContents, err := io.ReadAll(infile)
@@ -185,7 +213,7 @@ func (pp *Preprocessor) Prepare(infile io.Reader, infileName string) (io.Reader,
 			return nil, fmt.Errorf("declaration block delimiters improperly placed")
 		}
 		var db *DeclarationBlock
-		db, err = pp.inferBlock(inContents[startIdx:blockTermIdx], infileName)
+		db, err = pp.inferBlock(inContents[startIdx:blockTermIdx], infileName, varList)
 		if err != nil {
 			return nil, err
 		}
@@ -197,12 +225,17 @@ func (pp *Preprocessor) Prepare(infile io.Reader, infileName string) (io.Reader,
 	return bytes.NewReader(outContents), err
 }
 
-func (pp *Preprocessor) PrepareExternal(infileType string, infile io.Reader, infileName string) error {
+func (pp *Preprocessor) PrepareExternal(
+	infileType string,
+	infile io.Reader,
+	infileName string,
+	varList []string,
+) error {
 	inContents, err := io.ReadAll(infile)
 	if err != nil {
 		return err
 	}
-	db, err := NewDeclarationBlock(infileType, inContents, infileName)
+	db, err := newDeclarationBlock(infileType, inContents, infileName, varList)
 	if err != nil {
 		return err
 	}

--- a/test/assets/expected/env-var-input/env-var-input-expected.iql
+++ b/test/assets/expected/env-var-input/env-var-input-expected.iql
@@ -1,0 +1,36 @@
+--
+-- create VPC 
+--
+
+INSERT /*+ AWAIT  */ INTO google.compute.networks
+(
+ project,
+ data__name,
+ data__autoCreateSubnetworks,
+ data__routingConfig
+) 
+SELECT
+'stackql-demo',
+'env-var-input-demo-vpc',
+false,
+'{"routingMode":"REGIONAL"}';
+
+--
+-- create subnetwork
+--
+INSERT /*+ AWAIT  */ INTO google.compute.subnetworks
+(
+ project,
+ region,
+ data__name,
+ data__network,
+ data__ipCidrRange,
+ data__privateIpGoogleAccess
+) 
+SELECT
+'stackql-demo',
+'australia-southeast1',
+'env-var-input-demo-subnet',
+'https://compute.googleapis.com/compute/v1/projects/stackql-demo/global/networks/env-var-input-demo-vpc',
+'10.240.0.0/24',
+ false;

--- a/test/assets/input/env-var-input/env-var-input.iql
+++ b/test/assets/input/env-var-input/env-var-input.iql
@@ -1,0 +1,37 @@
+--
+-- create VPC 
+--
+
+INSERT /*+ AWAIT  */ INTO google.compute.networks
+(
+ project,
+ data__name,
+ data__autoCreateSubnetworks,
+ data__routingConfig
+) 
+SELECT
+'{{ .global.project }}',
+'{{ .network.name }}',
+{{ .network.autoCreateSubnetworks }},
+'{{ .network.routingConfig }}';
+
+--
+-- create subnetwork
+--
+INSERT /*+ AWAIT  */ INTO google.compute.subnetworks
+(
+ project,
+ region,
+ data__name,
+ data__network,
+ data__ipCidrRange,
+ data__privateIpGoogleAccess
+) 
+SELECT
+'{{ .global.project }}',
+'{{ .global.region }}',
+'{{ .subnetwork.name }}',
+'{{ .subnetwork.network }}',
+'{{ .subnetwork.ipCidrRange }}',
+ {{ .subnetwork.privateIpGoogleAccess }};
+

--- a/test/assets/input/env-var-input/vars.jsonnet
+++ b/test/assets/input/env-var-input/vars.jsonnet
@@ -1,0 +1,30 @@
+// variables
+local name = 'env-var-input-demo';
+local project = std.extVar("project");
+local region = std.extVar("region");
+local self_link_base = 'https://compute.googleapis.com/compute/v1/projects/' + project + '/';
+local self_link_global = self_link_base + 'global/';
+local nw_name = name + '-vpc';
+local sourceImage = 'https://compute.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts';
+local diskSizeGb = '10';
+
+{
+  // global config
+  global: {
+    project: project,
+    region: region
+  },
+  // network
+  network: {
+    autoCreateSubnetworks: false,
+    name: name + '-vpc',
+    routingConfig: {routingMode: 'REGIONAL'}
+  },
+  // subnet
+  subnetwork: {
+    ipCidrRange: '10.240.0.0/24',
+    name: name + '-subnet',
+    network: self_link_global + 'networks/' + nw_name,
+    privateIpGoogleAccess: false
+  }
+}

--- a/test/robot/functional/stackql_from_cmd_line.robot
+++ b/test/robot/functional/stackql_from_cmd_line.robot
@@ -41,6 +41,18 @@ Show Insert Google Container Clusters
     ...    ${SHOW_INSERT_GOOGLE_CONTAINER_CLUSTERS} 
     ...    stackql_H=True
     ...    stdout=${CURDIR}/tmp/Show-Insert-Google-Container-Clusters.tmp
+    
+JSONNET Plus Env Vars
+    ${varList}=    Create List    project=stackql-demo    region=australia-southeast1
+    Should StackQL Exec Equal    
+    ...    ""
+    ...    ${JSONNET_PLUS_ENV_VARS_EXPECTED} 
+    ...    stackql_H=True 
+    ...    stackql_dryrun=True
+    ...    stackql_i=${JSONNET_PLUS_ENV_VARS_QUERY_FILE}
+    ...    stackql_vars=${varList}
+    ...    stackql_iqldata=${JSONNET_PLUS_ENV_VARS_VAR_FILE}
+    ...    stdout=${CURDIR}/tmp/JSONNET-Plus-Env-Vars.tmp
 
 Show Extended Insert Google BQ Datasets
     Should StackQL Exec Contain    

--- a/test/robot/lib/stackql_context.py
+++ b/test/robot/lib/stackql_context.py
@@ -564,6 +564,13 @@ SELECT_HSTORE_DETAILS_TUPLES_EXPECTED = []
 
 SELECT_POSTGRES_CATALOG_JOIN_TUPLE_EXPECTED = ("__iql__.control.gc.rings",)
 
+
+_JSONNET_PLUS_ENV_VARS_QUERY_FILE = os.path.join(REPOSITORY_ROOT_UNIX, 'test', 'assets', 'input', 'env-var-input', 'env-var-input.iql')
+_JSONNET_PLUS_ENV_VARS_VAR_FILE = os.path.join(REPOSITORY_ROOT_UNIX, 'test', 'assets', 'input', 'env-var-input', 'vars.jsonnet')
+_JSONNET_PLUS_ENV_VARS_QUERY_FILE_DOCKER = os.path.join('/opt', 'stackql', 'input', 'env-var-input', 'env-var-input.iql')
+_JSONNET_PLUS_ENV_VARS_VAR_FILE_DOCKER = os.path.join('/opt', 'stackql', 'input', 'env-var-input', 'vars.jsonnet')
+_JSONNET_PLUS_ENV_VARS_EXPECTED = get_output_from_local_file(os.path.join('test', 'assets', 'expected', 'env-var-input', 'env-var-input-expected.iql'))
+
 SELECT_AZURE_COMPUTE_PUBLIC_KEYS_EXPECTED = get_output_from_local_file(os.path.join('test', 'assets', 'expected', 'azure', 'compute', 'ssh-public-keys-list.txt'))
 SELECT_AZURE_COMPUTE_VIRTUAL_MACHINES_EXPECTED = get_output_from_local_file(os.path.join('test', 'assets', 'expected', 'azure', 'compute', 'vm-list.txt'))
 
@@ -798,6 +805,9 @@ def get_variables(execution_env :str, sql_backend_str :str):
     'GC_CFG_EAGER':                                   _GC_CFG_EAGER,
     'GITHUB_SECRET_STR':                              GITHUB_SECRET_STR,
     'IS_WINDOWS':                                     IS_WINDOWS,
+    'JSONNET_PLUS_ENV_VARS_EXPECTED':                 _JSONNET_PLUS_ENV_VARS_EXPECTED,
+    'JSONNET_PLUS_ENV_VARS_QUERY_FILE':               _JSONNET_PLUS_ENV_VARS_QUERY_FILE,
+    'JSONNET_PLUS_ENV_VARS_VAR_FILE':                 _JSONNET_PLUS_ENV_VARS_VAR_FILE,
     'K8S_SECRET_STR':                                 K8S_SECRET_STR,
     'MOCKSERVER_JAR':                                 MOCKSERVER_JAR,
     'MOCKSERVER_PORT_AWS':                            MOCKSERVER_PORT_AWS,
@@ -1016,6 +1026,8 @@ def get_variables(execution_env :str, sql_backend_str :str):
     rv['JSON_INIT_FILE_PATH_OKTA']                      = JSON_INIT_FILE_PATH_OKTA
     rv['JSON_INIT_FILE_PATH_REGISTRY']                  = JSON_INIT_FILE_PATH_REGISTRY
     rv['JSON_INIT_FILE_PATH_SUMOLOGIC']                 = JSON_INIT_FILE_PATH_SUMOLOGIC
+    rv['JSONNET_PLUS_ENV_VARS_QUERY_FILE']              = _JSONNET_PLUS_ENV_VARS_QUERY_FILE_DOCKER
+    rv['JSONNET_PLUS_ENV_VARS_VAR_FILE']                = _JSONNET_PLUS_ENV_VARS_VAR_FILE_DOCKER
     rv['PG_SRV_MTLS_CFG_STR']                           = PG_SRV_MTLS_CFG_STR
     rv['PSQL_MTLS_CONN_STR']                            = PSQL_MTLS_CONN_STR_DOCKER
     rv['PSQL_MTLS_CONN_STR_UNIX']                       = PSQL_MTLS_CONN_STR_DOCKER


### PR DESCRIPTION
## Description

- Support for JSONNET external variables.
- Robot test added `JSONNET Plus Env Vars`.

You can run this manually from the repository root with:

```bash
/path/to/stackql exec -i $(pwd)/test/assets/input/env-var-input/env-var-input.iql  --var project=stackql-demo --var region=australia-southeast1 --iqldata $(pwd)/test/assets/input/env-var-input/vars.jsonnet --dryrun -o text -H
```

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Robot test added `JSONNET Plus Env Vars`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debit is added in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->