### PR TITLE
star-agg-on-views

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -89,6 +89,8 @@
         "select nw.name as network_name, split_part(sn.network, '/', 10) as sn_fuzz  from google.compute.networks nw LEFT OUTER JOIN google.compute.subnetworks sn  on lower(nw.name) = lower(split_part(sn.network, '/', 10))    where nw.project = 'testing-project' and sn.region = 'australia-southeast1' and sn.project = 'testing-project' order by network_name; commit;",
         "begin; insert into googleadmin.directory.users(data__primaryEmail) values ('somejimbo@grubit.com'); rollback;",
         "begin; insert into googleadmin.directory.users(data__primaryEmail) values ('joeblow@grubit.com'); rollback;",
+        "select count(*) from stackql_repositories;",
+        "select count(*) as repository_count from stackql_repositories;",
       ],
       "default": "show providers;"
     },

--- a/internal/stackql/parserutil/column_handle.go
+++ b/internal/stackql/parserutil/column_handle.go
@@ -11,6 +11,7 @@ type ColumnHandle struct {
 	Qualifier       string
 	DecoratedColumn string
 	IsColumn        bool
+	IsAggregateExpr bool
 	Type            sqlparser.ValType
 	Val             *sqlparser.SQLVal
 }

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -1189,6 +1189,44 @@ Basic View Returns Results
     ...    dummyapp.io
     ...    stdout=${CURDIR}/tmp/Basic-View-Returns-Results.tmp
 
+Basic Count Star From View Returns Expected Result
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |----------|
+    ...    |${SPACE}count(*)${SPACE}|
+    ...    |----------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}3${SPACE}|
+    ...    |----------|
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    SELECT count(*) FROM stackql_repositories ;
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Basic-Count-Star-From-View-Returns-Expected-Result.tmp
+
+Basic Aliased Count Star From View Returns Expected Result
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------------|
+    ...    |${SPACE}repository_count${SPACE}|
+    ...    |------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}3${SPACE}|
+    ...    |------------------|
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    SELECT count(*) as repository_count FROM stackql_repositories ;
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Basic-Aliased-Count-Star-From-View-Returns-Expected-Result.tmp
+
 Basic Subquery Returns Results
     Should Stackql Exec Inline Contain
     ...    ${STACKQL_EXE}


### PR DESCRIPTION
## Description

- Aggregation of star on views.
- `COUNT(*)` supported.
- Added robot test `Basic Count Star From View Returns Expected Result`.
- Added robot test `Basic Aliased Count Star From View Returns Expected Result`.

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Basic Count Star From View Returns Expected Result`.
- Added robot test `Basic Aliased Count Star From View Returns Expected Result`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
