### PR TITLE
cardinality-expansion-function

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -97,6 +97,11 @@
         "select * from google.compute.firewalls where project = 'stackql-demo' and JSON_EXTRACT(sourceRanges, '$[0]') = '0.0.0.0/0';",
         "select *, JSON_EXTRACT(sourceRanges, '$[0]') sr  from google.compute.firewalls where project = 'stackql-demo' and sr = '0.0.0.0/0';",
         "select *, json_extract_path_text(sourceRanges, '0') as sr from google.compute.firewalls where project = 'stackql-demo' and json_extract_path_text(sourceRanges, '0') = '0.0.0.0/0';",
+        "select *, JSON_EXTRACT(sourceRanges, '$[0]') sr  from google.compute.firewalls, json_each(sourceRanges) where project = 'stackql-demo' and JSON_EXTRACT(sourceRanges, '$[0]') = '0.0.0.0/0';",
+        "select count(*) from stackql_repositories;",
+        "select *, JSON_EXTRACT(sourceRanges, '$[0]') sr  from google.compute.firewalls, json_each(sourceRanges) where project = 'stackql-demo';",
+        "select fw.id, JSON_EXTRACT(fw.sourceRanges, '$[0]') sr  from google.compute.firewalls fw, json_each(sourceRanges) where project = 'stackql-demo';",
+        "select fw.id, JSON_EXTRACT(fw.sourceRanges, '$[0]') sr, json_each.value as source_range  from google.compute.firewalls fw, json_each(sourceRanges) where project = 'stackql-demo';",
       ],
       "default": "show providers;"
     },

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stackql/go-sqlite3 v0.0.2-stackqlbeta04
 	github.com/stackql/go-suffix-map v0.0.1-alpha01
 	github.com/stackql/psql-wire v0.1.1-alpha04
-	github.com/stackql/stackql-parser v0.0.13-beta08
+	github.com/stackql/stackql-parser v0.0.13-beta18
 	github.com/xo/dburl v0.12.4
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ github.com/stackql/psql-wire v0.1.1-alpha04 h1:dUrForykNZEvB7u6tIlQ/xGYElRtfMPRE
 github.com/stackql/psql-wire v0.1.1-alpha04/go.mod h1:a44Wd8kDC3irFLpGutarKDBqhJ/aqXlj1aMzO5bVJYg=
 github.com/stackql/readline v0.0.2-alpha05 h1:ID4QzGdplFBsrSnTuz8pvKzWw96JbrJg8fsLry2UriU=
 github.com/stackql/readline v0.0.2-alpha05/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
-github.com/stackql/stackql-parser v0.0.13-beta08 h1:zSftZ6nxmI+t9PNWgiL5OXnaiCShOCjtipXMEjJJwzc=
-github.com/stackql/stackql-parser v0.0.13-beta08/go.mod h1:iyB47SvRS+Fvpn7joF7mHAkeiWSq83TbUhglRmLzPLQ=
+github.com/stackql/stackql-parser v0.0.13-beta18 h1:p4cEMYpBX2uHw4CAofnae3pFcB3O4UQ8vDAIF752mHo=
+github.com/stackql/stackql-parser v0.0.13-beta18/go.mod h1:iyB47SvRS+Fvpn7joF7mHAkeiWSq83TbUhglRmLzPLQ=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01 h1:3XorfaYEhGpuvEeQK04EmpZUCr42hZ/a4Nh3wE25LF0=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01/go.mod h1:D0WFWa7HOXS+PQAmvN0Nm1E6dMdUkUFtAzRH8cXxg88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/stackql/parserutil/parser_util.go
+++ b/internal/stackql/parserutil/parser_util.go
@@ -672,3 +672,24 @@ func TableFromSelectNode(sel *sqlparser.Select) (sqlparser.TableName, error) {
 	}
 	return tableName, nil
 }
+
+func IsFromExprSimple(from sqlparser.TableExprs) bool {
+	for i, node := range from {
+		if i == 0 {
+			switch node.(type) {
+			case *sqlparser.JoinTableExpr, *sqlparser.AliasedTableExpr:
+				continue
+			default:
+				return false
+			}
+		} else {
+			switch node.(type) {
+			case *sqlparser.TableValuedFuncTableExpr:
+				continue
+			default:
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/test/mockserver/expectations/static-gcp-expectations.json
+++ b/test/mockserver/expectations/static-gcp-expectations.json
@@ -5503,6 +5503,39 @@
             },
             "disabled": false,
             "selfLink": "https://www.googleapis.com/compute/v1/projects/testing-project/global/firewalls/default-allow-ssh"
+          },
+          {
+            "kind": "compute#firewall",
+            "id": "8888888888888",
+            "creationTimestamp": "2022-02-08T15:05:18.476-08:00",
+            "name": "selected-allow-rdesk",
+            "description": "Allow RDESK from selected address spaces",
+            "network": "https://www.googleapis.com/compute/v1/projects/testing-project/global/networks/default",
+            "priority": 65534,
+            "sourceRanges": [
+              "10.128.0.0/9",
+              "10.0.0.0/16"
+            ],
+            "allowed": [
+              {
+                "IPProtocol": "tcp",
+                "ports": [
+                  "3389"
+                ]
+              },
+              {
+                "IPProtocol": "udp",
+                "ports": [
+                  "3389"
+                ]
+              }
+            ],
+            "direction": "INGRESS",
+            "logConfig": {
+              "enable": false
+            },
+            "disabled": false,
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/testing-project/global/firewalls/selected-allow-rdesk"
           }
         ],
         "selfLink": "https://www.googleapis.com/compute/v1/projects/testing-project/global/firewalls"

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -1385,6 +1385,47 @@ Select Expression Function Expression Alias Reference Alongside Projection Retur
     ...    ${outputStr}
     ...    stdout=${CURDIR}/tmp/Select-Expression-Function-Expression-Alias-Reference-Alongside-Projection-Returns-Results.tmp
 
+SQLite Table Valued Function Plus Projection Returns Expected Results
+    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    This is for sqlite table valued finctions only. This is a genuine case of difference.
+    ${inputStr} =    Catenate
+    ...    select fw.id, fw.name, json_each.value as source_range, json_each.value = '0.0.0.0/0' as is_entire_network 
+    ...    from google.compute.firewalls fw, json_each(sourceRanges) 
+    ...    where project = 'testing-project' 
+    ...    order by name desc, source_range desc;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}id${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}source_range${SPACE}|${SPACE}is_entire_network${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}8888888888888${SPACE}|${SPACE}selected-allow-rdesk${SPACE}${SPACE}${SPACE}|${SPACE}10.128.0.0/9${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}0${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}8888888888888${SPACE}|${SPACE}selected-allow-rdesk${SPACE}${SPACE}${SPACE}|${SPACE}10.0.0.0/16${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}0${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}${SPACE}777777777777${SPACE}|${SPACE}default-allow-ssh${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}0.0.0.0/0${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}6666666666${SPACE}|${SPACE}default-allow-rdp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}0.0.0.0/0${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}5555555555555${SPACE}|${SPACE}default-allow-internal${SPACE}|${SPACE}10.128.0.0/9${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}0${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}4444444444444${SPACE}|${SPACE}default-allow-icmp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}0.0.0.0/0${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}33333333${SPACE}|${SPACE}default-allow-https${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}0.0.0.0/0${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}${SPACE}${SPACE}22222222222${SPACE}|${SPACE}default-allow-http${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}0.0.0.0/0${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    ...    |${SPACE}${SPACE}111111111111${SPACE}|${SPACE}allow-spark-ui${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}0.0.0.0/0${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |---------------|------------------------|--------------|-------------------|
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/SQLite-Table-Valued-Function-Plus-Projection-Returns-Expected-Results.tmp
+
 Function Expression And Where Clause Function Expression Predicate Alongside Wildcard Returns Results
     ${sqliteInputStr} =    CATENATE    select *, JSON_EXTRACT(sourceRanges, '$[0]') sr from google.compute.firewalls where project = 'testing-project' and JSON_EXTRACT(sourceRanges, '$[0]') = '0.0.0.0/0';
     ${postgresInputStr} =    CATENATE    select *, json_extract_path_text(sourceRanges, '0') sr from google.compute.firewalls where project = 'testing-project' and json_extract_path_text(sourceRanges, '0') = '0.0.0.0/0';


### PR DESCRIPTION
## Description

- Parser support for sqlite table valued (cardinality expansion) function `json_each`.
- Parser support for view and table modifiers.
- Added robot test `SQLite Table Valued Function Plus Projection Returns Expected Results`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `SQLite Table Valued Function Plus Projection Returns Expected Results`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.  However, the existing flawed approach in [the from clause rewriter](https://github.com/stackql/stackql/blob/4f67f7fc004636740aa8a75cae7110e422c484c7/internal/stackql/astvisit/from_rewrite.go#L634) is accentuated and, accordingly, a `//TODO` has been added.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
