### PR TITLE
table-lifecycle-simple

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -114,6 +114,10 @@
         "create materialized view mv_one as select 1 as one; refresh materialized view mv_one;",
         "create materialized view silly_mv as select * from google.compute.firewalls where project = 'stackql-demo'; refresh materialized view silly_mv; select * from silly_mv;",
         "refresh materialized view stackql_gossip;",
+        "insert into stackql_notes(note, priority) values ('this is a test', 2000); select note from stackql_notes order by priority desc;",
+        "insert into stackql_notes(note, priority) select name from google.compute.firewalls where project = 'stackql-demo'; select * from silly_mv;",
+        "select gossip, 3000 from stackql_gossip;",
+        "create table my_silly_table(id int, name text, magnitude numeric); insert into my_silly_table(id, name, magnitude) values (1, 'one', 1.0); insert into my_silly_table(id, name, magnitude) values (2, 'two', 2.0); insert into my_silly_table(id, name, magnitude) values (3, 'three', 3.0); select name, magnitude from my_silly_table order by magnitude desc;",
       ],
       "default": "show providers;"
     },

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stackql/go-sqlite3 v0.0.3-stackqlalpha02
 	github.com/stackql/go-suffix-map v0.0.1-alpha01
 	github.com/stackql/psql-wire v0.1.1-alpha04
-	github.com/stackql/stackql-parser v0.0.13-beta24
+	github.com/stackql/stackql-parser v0.0.13-beta25
 	github.com/xo/dburl v0.12.4
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ github.com/stackql/psql-wire v0.1.1-alpha04 h1:dUrForykNZEvB7u6tIlQ/xGYElRtfMPRE
 github.com/stackql/psql-wire v0.1.1-alpha04/go.mod h1:a44Wd8kDC3irFLpGutarKDBqhJ/aqXlj1aMzO5bVJYg=
 github.com/stackql/readline v0.0.2-alpha05 h1:ID4QzGdplFBsrSnTuz8pvKzWw96JbrJg8fsLry2UriU=
 github.com/stackql/readline v0.0.2-alpha05/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
-github.com/stackql/stackql-parser v0.0.13-beta24 h1:XmKvrVgos7lFJ8XtHXonZdiVK65fs+lrEb1iQuTo7kw=
-github.com/stackql/stackql-parser v0.0.13-beta24/go.mod h1:iyB47SvRS+Fvpn7joF7mHAkeiWSq83TbUhglRmLzPLQ=
+github.com/stackql/stackql-parser v0.0.13-beta25 h1:rZ8WBSMXJAQ9IFgAZ3GHFVpkw7wITs6qjvM2NeA6vzE=
+github.com/stackql/stackql-parser v0.0.13-beta25/go.mod h1:iyB47SvRS+Fvpn7joF7mHAkeiWSq83TbUhglRmLzPLQ=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01 h1:3XorfaYEhGpuvEeQK04EmpZUCr42hZ/a4Nh3wE25LF0=
 github.com/stackql/stackql-provider-registry v0.0.1-rc01/go.mod h1:D0WFWa7HOXS+PQAmvN0Nm1E6dMdUkUFtAzRH8cXxg88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/stackql/astanalysis/earlyanalysis/ast_expand.go
+++ b/internal/stackql/astanalysis/earlyanalysis/ast_expand.go
@@ -850,7 +850,7 @@ func (v *indirectExpandAstVisitor) Visit(node sqlparser.SQLNode) error {
 		// END OPTIMISTIC DOC PERSISTENCE AND VIEW DEFINITION
 		viewDTO, isView := v.sqlSystem.GetViewByName(node.GetRawVal())
 		materializedViewDTO, isMaterializedView := v.sqlSystem.GetMaterializedViewByName(node.GetRawVal())
-		tableDTO, isTable := v.sqlSystem.GetTableByName(node.GetRawVal(), v.tcc)
+		tableDTO, isTable := v.sqlSystem.GetPhysicalTableByName(node.GetRawVal())
 		if isView { //nolint:nestif,gocritic // acceptable
 			indirect, newErr := astindirect.NewViewIndirect(viewDTO)
 			if newErr != nil {

--- a/internal/stackql/astindirect/indirect.go
+++ b/internal/stackql/astindirect/indirect.go
@@ -27,6 +27,9 @@ const (
 	CTEType
 	MaterializedViewType
 	PhysicalTableType
+	SelectType
+	ExecType
+	InsertRowsType
 )
 
 func NewViewIndirect(viewDTO internaldto.RelationDTO) (Indirect, error) {
@@ -42,6 +45,33 @@ func NewMaterializedViewIndirect(viewDTO internaldto.RelationDTO, sqlSystem sql_
 		viewDTO:               viewDTO,
 		underlyingSymbolTable: symtab.NewHashMapTreeSymTab(),
 		sqlSystem:             sqlSystem,
+	}
+	return rv, nil
+}
+
+func NewParserSelectIndirect(selectObj *sqlparser.Select, selCtx drm.PreparedStatementCtx) (Indirect, error) {
+	rv := &parserSelectionIndirect{
+		selCtx:                selCtx,
+		selectObj:             selectObj,
+		underlyingSymbolTable: symtab.NewHashMapTreeSymTab(),
+	}
+	return rv, nil
+}
+
+func NewInsertRowsIndirect(insertObj *sqlparser.Insert, selCtx drm.PreparedStatementCtx) (Indirect, error) {
+	rv := &parserSelectionIndirect{
+		selCtx:                selCtx,
+		insertObj:             insertObj,
+		underlyingSymbolTable: symtab.NewHashMapTreeSymTab(),
+	}
+	return rv, nil
+}
+
+func NewParserExecIndirect(execObj *sqlparser.Exec, selCtx drm.PreparedStatementCtx) (Indirect, error) {
+	rv := &parserSelectionIndirect{
+		selCtx:                selCtx,
+		execObj:               execObj,
+		underlyingSymbolTable: symtab.NewHashMapTreeSymTab(),
 	}
 	return rv, nil
 }

--- a/internal/stackql/astindirect/materialized_view_indirect.go
+++ b/internal/stackql/astindirect/materialized_view_indirect.go
@@ -1,4 +1,3 @@
-//nolint:dupl // TODO: refactor
 package astindirect
 
 import (
@@ -59,7 +58,7 @@ func (v *materializedView) GetRelationalColumnByIdentifier(name string) (typing.
 		if col.GetName() == name {
 			return col, true
 		}
-		if col.GetAlias() == name {
+		if col.GetAlias() != "" && col.GetAlias() == name {
 			return col, true
 		}
 	}

--- a/internal/stackql/astindirect/physical_table_indirect.go
+++ b/internal/stackql/astindirect/physical_table_indirect.go
@@ -1,4 +1,4 @@
-package astindirect //nolint:dupl // TODO: refactor
+package astindirect
 
 import (
 	"fmt"

--- a/internal/stackql/astindirect/select_indirect.go
+++ b/internal/stackql/astindirect/select_indirect.go
@@ -1,0 +1,108 @@
+package astindirect
+
+import (
+	"github.com/stackql/go-openapistackql/openapistackql"
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/drm"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stackql/stackql/internal/stackql/symtab"
+	"github.com/stackql/stackql/internal/stackql/typing"
+)
+
+type parserSelectionIndirect struct {
+	selectObj             *sqlparser.Select
+	execObj               *sqlparser.Exec
+	insertObj             *sqlparser.Insert
+	selCtx                drm.PreparedStatementCtx
+	paramCollection       internaldto.TableParameterCollection
+	underlyingSymbolTable symtab.SymTab
+}
+
+func (v *parserSelectionIndirect) GetType() IndirectType {
+	isExec := v.execObj != nil
+	if isExec {
+		return ExecType
+	}
+	return SelectType
+}
+
+func (v *parserSelectionIndirect) GetAssignedParameters() (internaldto.TableParameterCollection, bool) {
+	return v.paramCollection, v.paramCollection != nil
+}
+
+func (v *parserSelectionIndirect) SetAssignedParameters(paramCollection internaldto.TableParameterCollection) {
+	v.paramCollection = paramCollection
+}
+
+func (v *parserSelectionIndirect) GetRelationalColumns() []typing.RelationalColumn {
+	return nil
+}
+
+func (v *parserSelectionIndirect) GetRelationalColumnByIdentifier(_ string) (typing.RelationalColumn, bool) {
+	return nil, false
+}
+
+func (v *parserSelectionIndirect) GetUnderlyingSymTab() symtab.SymTab {
+	return v.underlyingSymbolTable
+}
+
+func (v *parserSelectionIndirect) SetUnderlyingSymTab(symbolTable symtab.SymTab) {
+	v.underlyingSymbolTable = symbolTable
+}
+
+func (v *parserSelectionIndirect) GetName() string {
+	return ""
+}
+
+func (v *parserSelectionIndirect) GetColumns() []typing.ColumnMetadata {
+	return v.selCtx.GetNonControlColumns()
+}
+
+func (v *parserSelectionIndirect) GetOptionalParameters() map[string]openapistackql.Addressable {
+	return nil
+}
+
+func (v *parserSelectionIndirect) GetRequiredParameters() map[string]openapistackql.Addressable {
+	return nil
+}
+
+func (v *parserSelectionIndirect) GetColumnByName(name string) (typing.ColumnMetadata, bool) {
+	for _, col := range v.selCtx.GetNonControlColumns() {
+		if col.GetIdentifier() == name {
+			return col, true
+		}
+	}
+	return nil, false
+}
+
+func (v *parserSelectionIndirect) SetSelectContext(selCtx drm.PreparedStatementCtx) {
+	v.selCtx = selCtx
+}
+
+func (v *parserSelectionIndirect) GetSelectContext() drm.PreparedStatementCtx {
+	return v.selCtx
+}
+
+func (v *parserSelectionIndirect) GetTables() sqlparser.TableExprs {
+	return nil
+}
+
+func (v *parserSelectionIndirect) GetSelectAST() sqlparser.SelectStatement {
+	return v.selectObj
+}
+
+func (v *parserSelectionIndirect) GetSelectionCtx() (drm.PreparedStatementCtx, error) {
+	return v.selCtx, nil
+}
+
+func (v *parserSelectionIndirect) Parse() error {
+	return nil
+}
+
+func (v *parserSelectionIndirect) GetTranslatedDDL() (string, bool) {
+	return "", false
+}
+
+func (v *parserSelectionIndirect) GetLoadDML() (string, bool) {
+	return "", false
+}

--- a/internal/stackql/astvisit/query_rewriting.go
+++ b/internal/stackql/astvisit/query_rewriting.go
@@ -626,11 +626,15 @@ func (v *standardQueryRewriteAstVisitor) Visit(node sqlparser.SQLNode) error {
 
 			relationalCol, ok := indirect.GetRelationalColumnByIdentifier(col.Name)
 			if !ok {
-				r, ok := indirect.GetColumnByName(col.Name)
-				if !ok {
-					return fmt.Errorf("query rewriting for indirection: cannot find col = '%s'", col.Name)
+				if col.Val != nil {
+					relationalCol = typing.NewRelationalColumn(col.Name, v.getTypeFromParserType(col.Type)).WithDecorated(col.DecoratedColumn)
+				} else {
+					r, ok := indirect.GetColumnByName(col.Name)
+					if !ok {
+						return fmt.Errorf("query rewriting for indirection: cannot find col = '%s'", col.Name)
+					}
+					relationalCol = typing.NewRelationalColumn(col.Name, r.GetType()).WithDecorated(col.DecoratedColumn)
 				}
-				relationalCol = typing.NewRelationalColumn(col.Name, r.GetType()).WithDecorated(col.DecoratedColumn)
 			}
 			v.relationalColumns = append(v.relationalColumns, relationalCol)
 			return nil

--- a/internal/stackql/internal_data_transfer/builder_input/builder_input.go
+++ b/internal/stackql/internal_data_transfer/builder_input/builder_input.go
@@ -47,6 +47,8 @@ type BuilderInput interface {
 	Clone() BuilderInput
 	GetHTTPPreparatorStream() (http_preparator_stream.HttpPreparatorStream, bool)
 	SetHTTPPreparatorStream(prepStream http_preparator_stream.HttpPreparatorStream)
+	IsTargetPhysicalTable() bool
+	SetIsTargetPhysicalTable(isPhysical bool)
 }
 
 type builderInput struct {
@@ -66,6 +68,7 @@ type builderInput struct {
 	op                openapistackql.OperationStore
 	prov              provider.IProvider
 	annotatedAst      annotatedast.AnnotatedAst
+	isTargetPhysical  bool
 }
 
 func NewBuilderInput(
@@ -80,6 +83,14 @@ func NewBuilderInput(
 		commentDirectives: sqlparser.CommentDirectives{},
 		inputAlias:        "", // this default is explicit for emphasisis
 	}
+}
+
+func (bi *builderInput) IsTargetPhysicalTable() bool {
+	return bi.isTargetPhysical
+}
+
+func (bi *builderInput) SetIsTargetPhysicalTable(isPhysical bool) {
+	bi.isTargetPhysical = isPhysical
 }
 
 func (bi *builderInput) SetAnnotatedAST(annotatedAST annotatedast.AnnotatedAst) {
@@ -223,5 +234,7 @@ func (bi *builderInput) Clone() BuilderInput {
 		verb:              bi.verb,
 		inputAlias:        bi.inputAlias,
 		isUndo:            bi.isUndo,
+		isTargetPhysical:  bi.isTargetPhysical,
+		annotatedAst:      bi.annotatedAst,
 	}
 }

--- a/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
+++ b/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
@@ -34,6 +34,8 @@ type HeirarchyIdentifiers interface {
 	WithProviderStr(string) HeirarchyIdentifiers
 	WithResponseSchemaStr(rss string) HeirarchyIdentifiers
 	IsPgInternalObject() bool
+	IsPhysicalTable() bool
+	SetIsPhysicalTable(isPhysical bool)
 }
 
 type standardHeirarchyIdentifiers struct {
@@ -46,6 +48,15 @@ type standardHeirarchyIdentifiers struct {
 	subqueryDTO       SubqueryDTO
 	viewAST           sqlparser.Statement
 	containsDBMSTable bool
+	isPhysicalTable   bool
+}
+
+func (hi *standardHeirarchyIdentifiers) IsPhysicalTable() bool {
+	return hi.isPhysicalTable
+}
+
+func (hi *standardHeirarchyIdentifiers) SetIsPhysicalTable(isPhysical bool) {
+	hi.isPhysicalTable = isPhysical
 }
 
 func (hi *standardHeirarchyIdentifiers) IsPgInternalObject() bool {

--- a/internal/stackql/parserutil/parser_util.go
+++ b/internal/stackql/parserutil/parser_util.go
@@ -712,6 +712,15 @@ func IsDropMaterializedView(stmt sqlparser.Statement) bool {
 	}
 }
 
+func IsDropPhysicalTable(stmt sqlparser.Statement) bool {
+	switch st := stmt.(type) {
+	case *sqlparser.DDL:
+		return isDropPhysicalTable(st)
+	default:
+		return false
+	}
+}
+
 func isCreateMaterializedView(ddl *sqlparser.DDL) bool {
 	switch ddl.Action {
 	case sqlparser.CreateStr:
@@ -731,6 +740,20 @@ func isDropMaterializedView(ddl *sqlparser.DDL) bool {
 	case sqlparser.DropStr:
 		switch strings.ToLower(ddl.Modifier) {
 		case "materialized":
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func isDropPhysicalTable(ddl *sqlparser.DDL) bool {
+	switch ddl.Action {
+	case sqlparser.DropStr:
+		switch strings.ToLower(ddl.Modifier) {
+		case "table":
 			return true
 		default:
 			return false
@@ -782,6 +805,15 @@ func isCreatePhysicalTable(ddl *sqlparser.DDL) bool {
 	default:
 		return false
 	}
+}
+
+func RenderDDLStmt(ddl *sqlparser.DDL) string {
+	return renderDDLStmt(ddl)
+}
+
+func renderDDLStmt(ddl *sqlparser.DDL) string {
+	return strings.ReplaceAll(
+		astformat.String(ddl, astformat.DefaultSelectExprsFormatter), `"`, "")
 }
 
 func RenderDDLSelectStmt(ddl *sqlparser.DDL) string {

--- a/internal/stackql/primitivebuilder/insert_into_physical_table.go
+++ b/internal/stackql/primitivebuilder/insert_into_physical_table.go
@@ -1,0 +1,123 @@
+package primitivebuilder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/astanalysis/annotatedast"
+	"github.com/stackql/stackql/internal/stackql/astformat"
+	"github.com/stackql/stackql/internal/stackql/drm"
+	"github.com/stackql/stackql/internal/stackql/handler"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/builder_input"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stackql/stackql/internal/stackql/primitive"
+	"github.com/stackql/stackql/internal/stackql/primitivegraph"
+	"github.com/stackql/stackql/internal/stackql/util"
+)
+
+type insertIntoPhysicalTable struct {
+	graph        primitivegraph.PrimitiveGraphHolder
+	insertObject *sqlparser.Insert
+	handlerCtx   handler.HandlerContext
+	root, tail   primitivegraph.PrimitiveNode
+	annotatedAst annotatedast.AnnotatedAst
+	bldrInput    builder_input.BuilderInput
+}
+
+func (ddo *insertIntoPhysicalTable) Build() error {
+	sqlSystem := ddo.handlerCtx.GetSQLSystem()
+	if sqlSystem == nil {
+		return fmt.Errorf("cannot proceed DDL execution with nil sql system object")
+	}
+	parserInsertObj := ddo.insertObject
+	if sqlSystem == nil {
+		return fmt.Errorf("cannot proceed DDL execution with nil insertIntoPhysicalTable object")
+	}
+	refreshEx := func(pc primitive.IPrimitiveCtx) internaldto.ExecutorOutput {
+		tableName := strings.Trim(astformat.String(parserInsertObj.Table, sqlSystem.GetASTFormatter()), `"`)
+		indirect, indirectExists := ddo.annotatedAst.GetInsertRowsIndirect(ddo.insertObject)
+		if !indirectExists {
+			return internaldto.NewErroneousExecutorOutput(fmt.Errorf("cannot find indirect object for materialized view"))
+		}
+		insertColumnsString := astformat.String(parserInsertObj.Columns, sqlSystem.GetASTFormatter())
+		drmCfg := ddo.handlerCtx.GetDrmConfig()
+		selCtx := indirect.GetSelectContext()
+		materializedViewRefreshError := drmCfg.InsertIntoPhysicalTable(
+			tableName,
+			insertColumnsString,
+			drm.NewPreparedStatementParameterized(selCtx, nil, true),
+		)
+		if materializedViewRefreshError != nil {
+			return internaldto.NewErroneousExecutorOutput(materializedViewRefreshError)
+		}
+
+		return util.PrepareResultSet(
+			internaldto.NewPrepareResultSetPlusRawDTO(
+				nil,
+				map[string]map[string]interface{}{},
+				[]string{},
+				nil,
+				nil,
+				internaldto.NewBackendMessages(
+					[]string{"insert into table completed"},
+				),
+				nil,
+				ddo.handlerCtx.GetTypingConfig(),
+			),
+		)
+	}
+	graph := ddo.graph
+	ddlGraphNode := graph.CreatePrimitiveNode(primitive.NewLocalPrimitive(refreshEx))
+
+	ddo.root = ddlGraphNode
+	ddo.tail = ddlGraphNode
+	dependencyNode, dependencyNodeExists := ddo.bldrInput.GetDependencyNode()
+	if dependencyNodeExists {
+		//nolint:errcheck // TODO: fix this
+		ddlGraphNode.SetInputAlias("", dependencyNode.ID())
+		ddo.graph.NewDependency(dependencyNode, ddlGraphNode, 1.0)
+		ddo.root = dependencyNode
+	}
+	return nil
+}
+
+func newInsertIntoPhysicalTable(
+	bldrInput builder_input.BuilderInput,
+) (Builder, error) {
+	graphHolder, graphHolderExists := bldrInput.GetGraphHolder()
+	if !graphHolderExists {
+		return nil, fmt.Errorf("DDL builder cannot accomodate nil graph holder")
+	}
+	handlerCtx, handlerCtxExists := bldrInput.GetHandlerContext()
+	if !handlerCtxExists {
+		return nil, fmt.Errorf("DDL builder cannot accomodate nil handler context")
+	}
+	node, nodeExists := bldrInput.GetParserNode()
+	if !nodeExists {
+		return nil, fmt.Errorf("DDL builder cannot accomodate nil node")
+	}
+	insertObject, isDDLObject := node.(*sqlparser.Insert)
+	if !isDDLObject {
+		return nil, fmt.Errorf("DDL builder cannot accomodate nil or non-DDL object")
+	}
+	annotatedAst, annotatedASTExists := bldrInput.GetAnnotatedAST()
+	if !annotatedASTExists {
+		return nil, fmt.Errorf("DDL builder cannot accomodate nil annotated AST")
+	}
+	return &insertIntoPhysicalTable{
+		graph:        graphHolder,
+		handlerCtx:   handlerCtx,
+		insertObject: insertObject,
+		annotatedAst: annotatedAst,
+		bldrInput:    bldrInput,
+	}, nil
+}
+
+func (ddo *insertIntoPhysicalTable) GetRoot() primitivegraph.PrimitiveNode {
+	return ddo.root
+}
+
+func (ddo *insertIntoPhysicalTable) GetTail() primitivegraph.PrimitiveNode {
+	return ddo.tail
+}

--- a/internal/stackql/primitivebuilder/insert_or_update.go
+++ b/internal/stackql/primitivebuilder/insert_or_update.go
@@ -43,19 +43,25 @@ func (ss *InsertOrUpdate) Build() error {
 	default:
 		return fmt.Errorf("mutation executor: cannnot accomodate node of type '%T'", node)
 	}
+	var genericBldr Builder
+	var genericBldrSetupErr error
+	if mutableInput.IsTargetPhysicalTable() {
+		genericBldr, genericBldrSetupErr = newInsertIntoPhysicalTable(
+			mutableInput,
+		)
+	} else {
+		genericBldr, genericBldrSetupErr = newGenericHTTPStreamInput(
+			mutableInput,
+		)
+	}
 
-	genericBldr, genericBldrSetupErr := newGenericHTTPStreamInput(
-		mutableInput,
-	)
 	if genericBldrSetupErr != nil {
 		return genericBldrSetupErr
 	}
-
 	genericBldrErr := genericBldr.Build()
 	if genericBldrErr != nil {
 		return genericBldrErr
 	}
-
 	ss.root = genericBldr.GetRoot()
 
 	return nil

--- a/internal/stackql/sql_system/sql_system.go
+++ b/internal/stackql/sql_system/sql_system.go
@@ -89,17 +89,23 @@ type SQLSystem interface {
 	QueryMaterializedView(colzString, actualRelationName, whereClause string) (*sql.Rows, error)
 
 	// Tables, both permanent and temp
-	CreateTable(
-		tableName string, rawDDL string, translatedDDL string, loadDML string, ifNotExists bool,
-		tcc internaldto.TxnControlCounters,
+	CreatePhysicalTable(
+		relationName string,
+		colz []typing.RelationalColumn,
+		rawDDL string,
+		ifNotExists bool,
 	) error
-	DropTable(tableName string,
+	DropPhysicalTable(
+		tableName string,
 		ifExists bool,
-		tcc internaldto.TxnControlCounters,
 	) error
-	GetTableByName(
-		tableName string, tcc internaldto.TxnControlCounters,
+	GetPhysicalTableByName(
+		tableName string,
 	) (internaldto.RelationDTO, bool)
+	InsertIntoPhysicalTable(tableName string,
+		insertClause string,
+		selectQuery string,
+		varargs ...any) error
 
 	// External SQL data sources
 	RegisterExternalTable(connectionName string, tableDetails openapistackql.SQLExternalTable) error

--- a/internal/stackql/tablemetadata/extended_table_metadata.go
+++ b/internal/stackql/tablemetadata/extended_table_metadata.go
@@ -59,6 +59,7 @@ type ExtendedTableMetadata interface {
 	IsPGInternalObject() bool
 	SetIsOnClauseHoistable(bool)
 	IsOnClauseHoistable() bool
+	IsPhysicalTable() bool
 }
 
 type standardExtendedTableMetadata struct {
@@ -73,6 +74,13 @@ type standardExtendedTableMetadata struct {
 	indirect            astindirect.Indirect
 	sqlDataSource       sql_datasource.SQLDataSource
 	isOnClauseHoistable bool
+}
+
+func (ex *standardExtendedTableMetadata) IsPhysicalTable() bool {
+	if ex.heirarchyObjects == nil || ex.heirarchyObjects.GetHeirarchyIds() == nil {
+		return false
+	}
+	return ex.heirarchyObjects.GetHeirarchyIds().IsPhysicalTable()
 }
 
 func (ex *standardExtendedTableMetadata) SetIsOnClauseHoistable(isOnClauseHoistable bool) {

--- a/internal/stackql/taxonomy/hierarchy.go
+++ b/internal/stackql/taxonomy/hierarchy.go
@@ -87,8 +87,9 @@ func getHids(handlerCtx handler.HandlerContext, node sqlparser.SQLNode) (interna
 		hIds = hIds.WithView(materializedViewDTO)
 	}
 	// TODO: pass in current counters
-	physicalTableDTO, isPhysicalTable := handlerCtx.GetSQLSystem().GetTableByName(hIds.GetTableName(), nil)
+	physicalTableDTO, isPhysicalTable := handlerCtx.GetSQLSystem().GetPhysicalTableByName(hIds.GetTableName())
 	if isPhysicalTable {
+		hIds.SetIsPhysicalTable(true)
 		hIds = hIds.WithView(physicalTableDTO)
 	}
 	isInternallyRoutable := handlerCtx.GetPGInternalRouter().ExprIsRoutable(node)

--- a/internal/stackql/typing/generic_typing_config.go
+++ b/internal/stackql/typing/generic_typing_config.go
@@ -248,6 +248,7 @@ func (tc *genericTypingConfig) getScannableObjectForNativeResult(colSchema *sql.
 		return new(sql.NullInt64)
 	case "int64", "bigint":
 		return new(sql.NullInt64)
+	//nolint:goconst // let it ride
 	case "numeric", "decimal", "float", "float32", "float64":
 		return new(sql.NullFloat64)
 	case "bool":

--- a/internal/stackql/typing/standard_column_metadata.go
+++ b/internal/stackql/typing/standard_column_metadata.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lib/pq/oid"
 	"github.com/stackql/go-openapistackql/openapistackql"
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
 	"github.com/stackql/stackql/internal/stackql/parserutil"
 )
 
@@ -46,6 +47,31 @@ func (cd *standardColumnMetadata) getOidForSchema(colSchema openapistackql.Schem
 
 func GetOidForSchema(colSchema openapistackql.Schema) oid.Oid {
 	return getOidForSchema(colSchema)
+}
+
+func GetOidForParserColType(col sqlparser.ColumnType) oid.Oid {
+	return getOidForParserColType(col)
+}
+
+func getOidForParserColType(col sqlparser.ColumnType) oid.Oid {
+	switch col.Type {
+	case "int", "integer", "int2", "int4", "int8", "smallint",
+		"bigint", "numeric", "decimal", "real", "float", "float4",
+		"float8", "double", "double precision", "serial", "bigserial":
+		return oid.T_numeric
+	case "bool", "boolean":
+		return oid.T_bool
+	case "text", "varchar", "char", "character", "character varying", "string":
+		return oid.T_text
+	case "date", "timestamp", "timestamp with time zone",
+		"timestamp without time zone", "time", "time with time zone",
+		"time without time zone":
+		return oid.T_timestamp
+	case "json", "jsonb":
+		return oid.T_text
+	default:
+		return oid.T_text
+	}
 }
 
 func getOidForSchema(colSchema openapistackql.Schema) oid.Oid {

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -529,7 +529,7 @@ Create Table Scenario Working
     ${inputStr} =    Catenate
     ...    create table phystab_one(t_id int, z text);
     ${outputStr} =    Catenate    SEPARATOR=\n
-    ...    create table is not supported
+    ...    DDL Execution Completed
     Should Stackql Exec Inline Equal Both Streams
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
@@ -2029,6 +2029,122 @@ Function Expression And Where Clause Function Expression Predicate Alongside Pro
     ...    ${inputStr}
     ...    ${outputStr}
     ...    stdout=${CURDIR}/tmp/Function-Expression-And-Where-Clause-Function-Expression-Predicate-Alongside-Projection-Returns-Expected-Results.tmp
+
+Insert All Simple Patterns Into Embedded Table Then Projection Returns Expected Results
+    ${inputStr} =    Catenate
+    ...    insert into stackql_notes(note, priority) values ('this is a test', 2000);
+    ...    insert into stackql_notes(note, priority) select gossip, 3000 from stackql_gossip;
+    ...    insert into stackql_notes(note, priority) select name, 1000 as pr from google.compute.firewalls where project = 'testing-project';
+    ...    select note from stackql_notes order by priority desc, note desc;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |--------------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}note${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}stackql${SPACE}wants${SPACE}to${SPACE}hear${SPACE}from${SPACE}you${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}stackql${SPACE}is${SPACE}open${SPACE}to${SPACE}extension${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}stackql${SPACE}is${SPACE}not${SPACE}opinionated${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}this${SPACE}is${SPACE}a${SPACE}test${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}v0.5.418${SPACE}introduced${SPACE}table${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |${SPACE}valued${SPACE}functions,${SPACE}for${SPACE}example${SPACE}${SPACE}|
+    ...    |${SPACE}json_each.${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}selected-allow-rdesk${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}default-allow-ssh${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}default-allow-rdp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}default-allow-internal${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}default-allow-icmp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}default-allow-https${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}default-allow-http${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}allow-spark-ui${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    ...    |${SPACE}stackql${SPACE}supports${SPACE}the${SPACE}postgres${SPACE}${SPACE}|
+    ...    |${SPACE}wire${SPACE}protocol.${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------|
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Insert-All-Simple-Patterns-Into-Embedded-Table-Then-Projection-Returns-Expected-Results.tmp
+
+Table Lifecycle Returns Expected Results
+    ${inputStr} =    Catenate
+    ...    create table my_silly_table(id int, name text, magnitude numeric);
+    ...    insert into my_silly_table(id, name, magnitude) values (1, 'one', 1.0); 
+    ...    insert into my_silly_table(id, name, magnitude) values (2, 'two', 2.0); 
+    ...    insert into my_silly_table(id, name, magnitude) values (3, 'three', 3.0); 
+    ...    select name, magnitude from my_silly_table order by magnitude desc;
+    ...    drop table my_silly_table;
+    ...    select name, magnitude from my_silly_table order by magnitude desc;
+    ...    create table my_silly_table(id int, name text, magnitude numeric);
+    ...    insert into my_silly_table(id, name, magnitude) values (11, 'eleven', 11.0); 
+    ...    insert into my_silly_table(id, name, magnitude) values (12, 'twelve', 12.0); 
+    ...    insert into my_silly_table(id, name, magnitude) values (13, 'thirteen', 13.0);
+    ...    select name, magnitude from my_silly_table order by magnitude desc;
+    ...    drop table my_silly_table;
+    ...    select name, magnitude from my_silly_table order by magnitude desc;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |-------|-----------|
+    ...    |${SPACE}name${SPACE}${SPACE}|${SPACE}magnitude${SPACE}|
+    ...    |-------|-----------|
+    ...    |${SPACE}three${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}3${SPACE}|
+    ...    |-------|-----------|
+    ...    |${SPACE}two${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2${SPACE}|
+    ...    |-------|-----------|
+    ...    |${SPACE}one${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |-------|-----------|
+    ...    |----------|-----------|
+    ...    |${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}|${SPACE}magnitude${SPACE}|
+    ...    |----------|-----------|
+    ...    |${SPACE}thirteen${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}13${SPACE}|
+    ...    |----------|-----------|
+    ...    |${SPACE}twelve${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}12${SPACE}|
+    ...    |----------|-----------|
+    ...    |${SPACE}eleven${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}11${SPACE}|
+    ...    |----------|-----------|
+    ${stdErrStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ...    insert into table completed
+    ...    insert into table completed
+    ...    insert into table completed
+    ...    DDL Execution Completed
+    ...    could not locate table 'my_silly_table'
+    ...    DDL Execution Completed
+    ...    insert into table completed
+    ...    insert into table completed
+    ...    insert into table completed
+    ...    DDL Execution Completed
+    ...    could not locate table 'my_silly_table'
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${stdErrStr}
+    ...    stdout=${CURDIR}/tmp/Table-Lifecycle-Returns-Expected-Results.tmp
+    ...    stderr=${CURDIR}/tmp/Table-Lifecycle-Returns-Expected-Results-stderr.tmp
+
 
 Basic View of Union Returns Results
     Should Stackql Exec Inline Contain


### PR DESCRIPTION
## Description

- Support for `CREATE TABLE`.
- Support for `INSERT INTO` physical tables.
- Support for `DROP TABLE`.
- Added robot test `Insert All Simple Patterns Into Embedded Table Then Projection Returns Expected Results`.
- Added robot test `Table Lifecycle Returns Expected Results`.
- Updated robot test `Create Table Scenario Working`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

https://github.com/stackql/stackql/issues/207

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Insert All Simple Patterns Into Embedded Table Then Projection Returns Expected Results`.
- Added robot test `Table Lifecycle Returns Expected Results`.
- Updated robot test `Create Table Scenario Working`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
