### PR TITLE
changed-python-client-behaviour

### DIFF
--- a/examples/scripts/python/sqlalchemy_scratchpad.py
+++ b/examples/scripts/python/sqlalchemy_scratchpad.py
@@ -18,7 +18,7 @@ curs.execute("show transaction isolation level")
 # rv = curs.fetchall()
 
 if curs.rowcount > 0:
-    rv = curs.fetchall()
+    rv = curs.fetchall() # throws error on empty result set, so this all relies on rowcount being accurate
     e1 = None
     for entry in rv:
         dir(entry)

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -90,6 +90,50 @@ PG Session Azure Compute Table Nomenclature Mutation Guard
     ...    stdout=${CURDIR}/tmp/PG-Session-Azure-Compute-Table-Nomenclature-Mutation-Guard.tmp
     [Teardown]    NONE
 
+PG Session Materialized View Lifecycle
+    ${inputStr} =    Catenate
+    ...    [
+    ...    "create materialized view vw_aws_usr as select Arn, UserName, UserId, region from aws.iam.users where region = 'us-east-1';",
+    ...    "select u1.UserName, u2.UserId, u2.Arn, u1.region from aws.iam.users u1 inner join vw_aws_usr u2 on u1.Arn = u2.Arn where u1.region = 'us-east-1' and u2.region = 'us-east-1' order by u1.UserName desc;",
+    ...    "drop materialized view vw_aws_usr;"
+    ...    ]
+    ${inputList} =    Evaluate    ${inputStr}
+    ${outputStr} =    Catenate
+    ...    [
+    ...    { "UserName":  "Jackie", "UserId": "AIDIODR4TAW7CSEXAMPLE", "Arn": "arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie", "region": "us-east-1" },
+    ...    { "UserName":  "Andrew", "UserId": "AID2MAB8DPLSRHEXAMPLE", "Arn": "arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew", "region": "us-east-1" }
+    ...    ]
+    ${outputList} =    Evaluate    ${outputStr}
+    Should PG Client Session Inline Equal
+    ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
+    ...    ${inputList}
+    ...    ${outputList}
+    ...    stdout=${CURDIR}/tmp/PG-Session-Materialized-View-Lifecycle.tmp
+    ...    stderr=${CURDIR}/tmp/PG-Session-Materialized-View-Lifecycle-stderr.tmp
+    [Teardown]    NONE
+
+PG Session V2 Materialized View Lifecycle
+    ${inputStr} =    Catenate
+    ...    [
+    ...    "create materialized view vw_aws_usr as select Arn, UserName, UserId, region from aws.iam.users where region = 'us-east-1';",
+    ...    "select u1.UserName, u2.UserId, u2.Arn, u1.region from aws.iam.users u1 inner join vw_aws_usr u2 on u1.Arn = u2.Arn where u1.region = 'us-east-1' and u2.region = 'us-east-1' order by u1.UserName desc;",
+    ...    "drop materialized view vw_aws_usr;"
+    ...    ]
+    ${inputList} =    Evaluate    ${inputStr}
+    ${outputStr} =    Catenate
+    ...    [
+    ...    { "UserName":  "Jackie", "UserId": "AIDIODR4TAW7CSEXAMPLE", "Arn": "arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie", "region": "us-east-1" },
+    ...    { "UserName":  "Andrew", "UserId": "AID2MAB8DPLSRHEXAMPLE", "Arn": "arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew", "region": "us-east-1" }
+    ...    ]
+    ${outputList} =    Evaluate    ${outputStr}
+    Should PG Client V2 Session Inline Equal
+    ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
+    ...    ${inputList}
+    ...    ${outputList}
+    ...    stdout=${CURDIR}/tmp/PG-Session-v2-Materialized-View-Lifecycle.tmp
+    ...    stderr=${CURDIR}/tmp/PG-Session-v2-Materialized-View-Lifecycle-stderr.tmp
+    [Teardown]    NONE
+
 PG Session Wrongly Named Column error recovery Azure Compute Table Nomenclature
     Should PG Client Session Inline Contain
     ...    ${PSQL_MTLS_CONN_STR_UNIX}

--- a/test/robot/functional/stackql_sessions_postgres.robot
+++ b/test/robot/functional/stackql_sessions_postgres.robot
@@ -39,3 +39,20 @@ SQLAlchemy Session Postgres Intel Views Exist
     ...    12
     ...    stdout=${CURDIR}/tmp/SQLAlchemy-Session-Postgres-Intel-Views-Exist.tmp
     [Teardown]    NONE
+
+SQLAlchemy Session Materialized View Lifecycle
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    This is a postgres only test
+    ${inputStr} =    Catenate
+    ...    [
+    ...    "create materialized view vw_aws_usr as select Arn, UserName, UserId, region from aws.iam.users where region = 'us-east-1';",
+    ...    "select u1.UserName, u2.UserId, u2.Arn, u1.region from aws.iam.users u1 inner join vw_aws_usr u2 on u1.Arn = u2.Arn where u1.region = 'us-east-1' and u2.region = 'us-east-1' order by u1.UserName desc;",
+    ...    "drop materialized view vw_aws_usr;"
+    ...    ]
+    ${inputList} =    Evaluate    ${inputStr}
+    Should SQLALchemy Raw Session Inline Have Length
+    ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
+    ...    ${inputList}
+    ...    2
+    ...    stdout=${CURDIR}/tmp/SQLAlchemy-Session-v2-Materialized-View-Lifecycle.tmp
+    ...    stderr=${CURDIR}/tmp/SQLAlchemy-Session-v2-Materialized-View-Lifecycle-stderr.tmp
+    [Teardown]    NONE

--- a/test/robot/lib/psycopg2_client.py
+++ b/test/robot/lib/psycopg2_client.py
@@ -16,9 +16,15 @@ class PsycoPG2Client(object):
 
 
   def _exec_query(self, query :str) -> typing.List[typing.Dict]:
-    cur = self._connection.cursor(cursor_factory=RealDictCursor)
-    cur.execute(query)
-    return [ dict(b) for b in cur.fetchall() ]
+    with self._connection.cursor(cursor_factory=RealDictCursor) as cur:
+      cur.execute(query)
+      rv = []
+      try:
+        for r in cur:
+          rv.append(dict(r))
+      except Exception as err:
+        pass
+      return rv
 
 
   def _run_queries(self, queries :typing.List[str]) -> typing.List[typing.Dict]:

--- a/test/robot/lib/psycopg_client.py
+++ b/test/robot/lib/psycopg_client.py
@@ -16,17 +16,23 @@ class PsycoPGClient(object):
     )
 
 
-  def _exec_query(self, query :str) -> typing.List[typing.Dict]:  
+  def _exec_query(self, query :str) -> typing.List[typing.Dict]: 
+    rv = [] 
     try:
-      r = self._connection.execute(query)
-      return r.fetchall()
+      with self._connection.execute(query) as r:
+        for row in r:
+          rv.append(row)
+        return rv
     except Exception as err:
       return []
 
-  def _exec_query_strict(self, query :str) -> typing.List[typing.Dict]:  
+  def _exec_query_strict(self, query :str) -> typing.List[typing.Dict]:
+    rv = []
     try:
-      r = self._connection.execute(query)
-      return r.fetchall()
+      with self._connection.execute(query) as r:
+        for row in r:
+          rv.append(row)
+        return rv
     except Exception as err:
       print(err)
       raise err

--- a/test/robot/lib/sqlalchemy_client.py
+++ b/test/robot/lib/sqlalchemy_client.py
@@ -11,10 +11,14 @@ class SQLAlchemyClient(object):
 
 
   def _exec_raw_query(self, query :str) -> typing.List[typing.Dict]:
-    conn = self._eng.raw_connection()
-    curs = conn.cursor()
     r = self._eng.execute(query)
-    return [ b for b in r.fetchall() ]
+    rv = []
+    try:
+      for row in r:
+        rv.append(row)
+    except Exception as err:
+      pass
+    return rv
 
 
   def _run_raw_queries(self, queries :typing.List[str]) -> typing.List[typing.Dict]:


### PR DESCRIPTION
## Description

- Changed `psycopg3` client to support queries that do not return results.
- Changed `psycopg2` client to support queries that do not return results.
- Changed `sqlalchemy` client to support queries that do not return results.
- Added robot test `PG Session Materialized View Lifecycle`.
- Added robot test `PG Session V2 Materialized View Lifecycle`.
- Added robot test `SQLAlchemy Session Materialized View Lifecycle`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Explanation**:  
    - This change adds extra capabilities to the python testing client libs, which are *de facto* reference implementations for third party tooling to emulate.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `PG Session Materialized View Lifecycle`.
- Added robot test `PG Session V2 Materialized View Lifecycle`.
- Added robot test `SQLAlchemy Session Materialized View Lifecycle`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduded in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
