### PR TITLE
Unit tests for binlog

### DIFF
--- a/internal/stackql/acid/binlog/log_test.go
+++ b/internal/stackql/acid/binlog/log_test.go
@@ -32,7 +32,11 @@ func TestConcatenate(t *testing.T) {
 
 	humanReadable := entry.GetHumanReadable()
 	if !reflect.DeepEqual(humanReadable, expectedHumanReadable) {
-		t.Fatalf("Human readable representation of combined log is expected to be %+v. Got %+v", expectedHumanReadable, humanReadable)
+		t.Fatalf(
+			"Human readable representation of combined log is expected to be %v. Got %v",
+			expectedHumanReadable,
+			humanReadable,
+		)
 	}
 }
 
@@ -79,6 +83,10 @@ func TestAppend(t *testing.T) {
 		"Undo delete on third_table",
 	}
 	if !reflect.DeepEqual(entry.GetHumanReadable(), expectedHumanReadable) {
-		t.Fatalf("Expected humanReadable field after append operation to be %v, Got %v", expectedHumanReadable, entry.GetHumanReadable())
+		t.Fatalf(
+			"Expected humanReadable field after append operation to be %v, Got %v",
+			expectedHumanReadable,
+			entry.GetHumanReadable(),
+		)
 	}
 }

--- a/internal/stackql/acid/binlog/log_test.go
+++ b/internal/stackql/acid/binlog/log_test.go
@@ -1,0 +1,84 @@
+package binlog_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stackql/stackql/internal/stackql/acid/binlog"
+)
+
+func TestConcatenate(t *testing.T) {
+	entry := binlog.NewSimpleLogEntry(
+		nil,
+		[]string{
+			"Undo the delete on my_table",
+			"Undo the insert on second_table",
+		},
+	)
+	second := binlog.NewSimpleLogEntry([]byte("insert"), nil)
+	third := binlog.NewSimpleLogEntry(
+		[]byte("delete"),
+		[]string{
+			"Undo delete on third_table",
+		},
+	)
+
+	expectedHumanReadable := append(entry.GetHumanReadable(), third.GetHumanReadable()...)
+	entry.Concatenate(second, third)
+	raw := entry.GetRaw()
+	if !reflect.DeepEqual(raw, []byte("insertdelete")) {
+		t.Fatalf("Raw representation of combined log is expected to contain %v. Got %+v", []byte("insertdelete"), raw)
+	}
+
+	humanReadable := entry.GetHumanReadable()
+	if !reflect.DeepEqual(humanReadable, expectedHumanReadable) {
+		t.Fatalf("Human readable representation of combined log is expected to be %+v. Got %+v", expectedHumanReadable, humanReadable)
+	}
+}
+
+func TestClone(t *testing.T) {
+	entry := binlog.NewSimpleLogEntry(
+		[]byte("insert"),
+		[]string{
+			"Undo the delete on my_table",
+			"Undo the insert on second_table",
+		},
+	)
+	cloned := entry.Clone()
+	if &cloned.GetRaw()[0] == &entry.GetRaw()[0] {
+		t.Fatal("Expected 'raw' field of the cloned value to be at a different memory location")
+	}
+
+	if &cloned.GetHumanReadable()[0] == &entry.GetHumanReadable()[0] {
+		t.Fatal("Expected 'humanReadable' field of the cloned value to be at a different memory location")
+	}
+}
+
+func TestAppend(t *testing.T) {
+	entry := binlog.NewSimpleLogEntry(
+		[]byte("insert"),
+		[]string{
+			"Undo the delete on my_table",
+			"Undo the insert on second_table",
+		},
+	)
+	entry.AppendRaw([]byte("delete"))
+	entry.AppendHumanReadable("Undo delete on third_table")
+	expectedRaw := []byte("insertdelete")
+	if entry.Size() != len(expectedRaw) {
+		t.Fatalf("Expected size of the raw field to be %d, Got %d", len(expectedRaw), entry.Size())
+	}
+
+	if !reflect.DeepEqual(entry.GetRaw(), expectedRaw) {
+		t.Fatalf("Expected raw field after append operation to be %v, Got %v", expectedRaw, entry.GetRaw())
+	}
+
+	expectedHumanReadable := []string{
+		"Undo the delete on my_table",
+		"Undo the insert on second_table",
+		"Undo delete on third_table",
+	}
+	if !reflect.DeepEqual(entry.GetHumanReadable(), expectedHumanReadable) {
+		t.Fatalf("Expected humanReadable field after append operation to be %v, Got %v", expectedHumanReadable, entry.GetHumanReadable())
+	}
+}

--- a/internal/stackql/acid/transact/best_effort_coordinator.go
+++ b/internal/stackql/acid/transact/best_effort_coordinator.go
@@ -95,9 +95,7 @@ func (m *basicBestEffortTransactionCoordinator) GetRedoLog() (binlog.LogEntry, b
 	if len(m.redoLogs) == 0 {
 		return nil, false
 	}
-	for _, log := range m.redoLogs {
-		rv = rv.Concatenate(log)
-	}
+	rv.Concatenate(m.redoLogs...)
 	return rv, true
 }
 
@@ -106,9 +104,7 @@ func (m *basicBestEffortTransactionCoordinator) GetUndoLog() (binlog.LogEntry, b
 	if len(m.undoLogs) == 0 {
 		return nil, false
 	}
-	for _, log := range m.undoLogs {
-		rv = rv.Concatenate(log)
-	}
+	rv.Concatenate(m.undoLogs...)
 	return rv, true
 }
 

--- a/internal/stackql/acid/transact/lazy_coordinator.go
+++ b/internal/stackql/acid/transact/lazy_coordinator.go
@@ -81,9 +81,7 @@ func (m *basicLazyTransactionCoordinator) GetRedoLog() (binlog.LogEntry, bool) {
 	if len(m.redoLogs) == 0 {
 		return nil, false
 	}
-	for _, log := range m.redoLogs {
-		rv = rv.Concatenate(log)
-	}
+	rv.Concatenate(m.redoLogs...)
 	return rv, true
 }
 
@@ -92,9 +90,7 @@ func (m *basicLazyTransactionCoordinator) GetUndoLog() (binlog.LogEntry, bool) {
 	if len(m.undoLogs) == 0 {
 		return nil, false
 	}
-	for _, log := range m.undoLogs {
-		rv = rv.Concatenate(log)
-	}
+	rv.Concatenate(m.undoLogs...)
 	return rv, true
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Please explain**.

## Issues referenced.
Closes #291 

## Evidence

```
$ go test -cover -tags json1,sqleanall  ./...
?       github.com/stackql/stackql/internal/stackql/acid/acid_dto       [no test files]
ok      github.com/stackql/stackql/internal/stackql/acid/binlog 0.002s  coverage: 100.0% of statements
?       github.com/stackql/stackql/internal/stackql/acid/operation      [no test files]
?       github.com/stackql/stackql/internal/stackql/acid/transact       [no test files]
?       github.com/stackql/stackql/internal/stackql/acid/txn_context    [no test files]
?       github.com/stackql/stackql/internal/stackql/astanalysis/annotatedast    [no test files]
?       github.com/stackql/stackql/internal/stackql/astanalysis/earlyanalysis   [no test files]
?       github.com/stackql/stackql/internal/stackql/astanalysis/routeanalysis   [no test files]
?       github.com/stackql/stackql/internal/stackql/astanalysis/selectmetadata  [no test files]
?       github.com/stackql/stackql/internal/stackql/astformat   [no test files]
?       github.com/stackql/stackql/internal/stackql/astfuncrewrite      [no test files]
?       github.com/stackql/stackql/internal/stackql/astindirect [no test files]
?       github.com/stackql/stackql/internal/stackql/astvisit    [no test files]
?       github.com/stackql/stackql/internal/stackql/asyncmonitor        [no test files]
?       github.com/stackql/stackql/internal/stackql/bundle      [no test files]
?       github.com/stackql/stackql/internal/stackql/cmd [no test files]
?       github.com/stackql/stackql/internal/stackql/color       [no test files]
?       github.com/stackql/stackql/internal/stackql/config      [no test files]
?       github.com/stackql/stackql/internal/stackql/constants   [no test files]
?       github.com/stackql/stackql/internal/stackql/data_staging/input_data_staging     [no test files]
?       github.com/stackql/stackql/internal/stackql/data_staging/output_data_staging    [no test files]
?       github.com/stackql/stackql/internal/stackql/dataflow    [no test files]
?       github.com/stackql/stackql/internal/stackql/datasource/sql_datasource   [no test files]
?       github.com/stackql/stackql/internal/stackql/db_util     [no test files]
?       github.com/stackql/stackql/internal/stackql/dbmsinternal        [no test files]
?       github.com/stackql/stackql/internal/stackql/dependencyplanner   [no test files]
?       github.com/stackql/stackql/internal/stackql/discovery   [no test files]
?       github.com/stackql/stackql/internal/stackql/docparser   [no test files]
ok      github.com/stackql/stackql/internal/stackql/datasource/sqltable 0.008s  coverage: 100.0% of statements
?       github.com/stackql/stackql/internal/stackql/drm [no test files]
?       github.com/stackql/stackql/internal/stackql/dto [no test files]
?       github.com/stackql/stackql/internal/stackql/entryutil   [no test files]
?       github.com/stackql/stackql/internal/stackql/garbagecollector    [no test files]
?       github.com/stackql/stackql/internal/stackql/gcexec      [no test files]
?       github.com/stackql/stackql/internal/stackql/google_sdk  [no test files]
?       github.com/stackql/stackql/internal/stackql/handler     [no test files]
?       github.com/stackql/stackql/internal/stackql/httpmiddleware      [no test files]
?       github.com/stackql/stackql/internal/stackql/internal_data_transfer/builder_input        [no test files]
?       github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto  [no test files]
?       github.com/stackql/stackql/internal/stackql/internal_data_transfer/primitive_context    [no test files]
?       github.com/stackql/stackql/internal/stackql/internal_data_transfer/relationaldto        [no test files]
?       github.com/stackql/stackql/internal/stackql/kstore      [no test files]
?       github.com/stackql/stackql/internal/stackql/netutils    [no test files]
?       github.com/stackql/stackql/internal/stackql/output      [no test files]
?       github.com/stackql/stackql/internal/stackql/parser      [no test files]
?       github.com/stackql/stackql/internal/stackql/parserutil  [no test files]
?       github.com/stackql/stackql/internal/stackql/plan        [no test files]
?       github.com/stackql/stackql/internal/stackql/planbuilder [no test files]
?       github.com/stackql/stackql/internal/stackql/metadatavisitors    [no test files]
?       github.com/stackql/stackql/internal/stackql/primitive   [no test files]
?       github.com/stackql/stackql/internal/stackql/primitivebuilder    [no test files]
?       github.com/stackql/stackql/internal/stackql/primitivecomposer   [no test files]
?       github.com/stackql/stackql/internal/stackql/primitivegenerator  [no test files]
?       github.com/stackql/stackql/internal/stackql/primitivegraph      [no test files]
?       github.com/stackql/stackql/internal/stackql/provider    [no test files]
?       github.com/stackql/stackql/internal/stackql/methodselect        [no test files]
?       github.com/stackql/stackql/internal/stackql/iqlerror    [no test files]
?       github.com/stackql/stackql/internal/stackql/logging     [no test files]
?       github.com/stackql/stackql/internal/stackql/planbuilderinput    [no test files]
?       github.com/stackql/stackql/internal/stackql/iqlutil     [no test files]
?       github.com/stackql/stackql/internal/stackql/nativedb    [no test files]
?       github.com/stackql/stackql/internal/stackql/providerconfig      [no test files]
?       github.com/stackql/stackql/internal/stackql/relational  [no test files]
?       github.com/stackql/stackql/internal/stackql/sql_system  [no test files]
?       github.com/stackql/stackql/internal/stackql/sqlcontrol  [no test files]
?       github.com/stackql/stackql/internal/stackql/sqlengine   [no test files]
?       github.com/stackql/stackql/internal/stackql/requests    [no test files]
?       github.com/stackql/stackql/internal/stackql/sqlrewrite  [no test files]
?       github.com/stackql/stackql/internal/stackql/sqlstream   [no test files]
?       github.com/stackql/stackql/internal/stackql/streaming   [no test files]
?       github.com/stackql/stackql/internal/stackql/streaming/http_preparator_stream.go [no test files]
?       github.com/stackql/stackql/internal/stackql/suffix      [no test files]
?       github.com/stackql/stackql/internal/stackql/symtab      [no test files]
?       github.com/stackql/stackql/internal/stackql/tableinsertioncontainer     [no test files]
?       github.com/stackql/stackql/internal/stackql/tablemetadata       [no test files]
?       github.com/stackql/stackql/internal/stackql/tablenamespace      [no test files]
?       github.com/stackql/stackql/internal/stackql/taxonomy    [no test files]
?       github.com/stackql/stackql/internal/stackql/templatenamespace   [no test files]
?       github.com/stackql/stackql/internal/stackql/typing      [no test files]
?       github.com/stackql/stackql/internal/stackql/util        [no test files]
?       github.com/stackql/stackql/internal/stackql/writer      [no test files]
?       github.com/stackql/stackql/internal/test/stackqltestutil        [no test files]
?       github.com/stackql/stackql/internal/test/testhttpapi    [no test files]
?       github.com/stackql/stackql/internal/test/testobjects    [no test files]
?       github.com/stackql/stackql/internal/test/testutil       [no test files]
?       github.com/stackql/stackql/pkg/awssign  [no test files]
?       github.com/stackql/stackql/pkg/azureauth        [no test files]
?       github.com/stackql/stackql/pkg/preprocessor     [no test files]
?       github.com/stackql/stackql/pkg/prettyprint      [no test files]
?       github.com/stackql/stackql/pkg/sqltypeutil      [no test files]
?       github.com/stackql/stackql/pkg/textutil [no test files]
?       github.com/stackql/stackql/pkg/txncounter       [no test files]
?       github.com/stackql/stackql/internal/stackql/responsehandler     [no test files]
?       github.com/stackql/stackql/internal/stackql/router      [no test files]
?       github.com/stackql/stackql/internal/stackql/session     [no test files]
?       github.com/stackql/stackql/internal/stackql/router/obtain_context       [no test files]
?       github.com/stackql/stackql/internal/stackql/sqlmachinery        [no test files]
ok      github.com/stackql/stackql/internal/stackql/driver      40.725s coverage: 24.6% of statements
ok      github.com/stackql/stackql/internal/stackql/psqlwire    0.003s  coverage: 0.0% of statements
ok      github.com/stackql/stackql/internal/stackql/querysubmit 0.658s  coverage: 29.4% of statements
ok      github.com/stackql/stackql/stackql      31.020s coverage: 50.0% of statements
```

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.

### Variations

None

## Tech Debt

None
