### PR TITLE
feat(unit-test): add unit test for package logging

### DIFF
--- a/internal/stackql/logging/logging.go
+++ b/internal/stackql/logging/logging.go
@@ -7,21 +7,21 @@ import (
 )
 
 var (
-	logger *logrus.Logger //nolint:gochecknoglobals // This is convenient as a global variable
+	Logger *logrus.Logger //nolint:gochecknoglobals // This is convenient as a global variable
 )
 
 func SetLogger(logLevelStr string) {
-	logger = logrus.StandardLogger()
+	Logger = logrus.StandardLogger()
 	logLevel, err := logrus.ParseLevel(logLevelStr)
 	if err != nil {
-		logger.Fatal(err)
+		Logger.Fatal(err)
 	}
-	logger.SetLevel(logLevel)
+	Logger.SetLevel(logLevel)
 }
 
 func GetLogger() *logrus.Logger {
-	if logger != nil {
-		return logger
+	if Logger != nil {
+		return Logger
 	}
 	tmpLogger := logrus.New()
 	tmpLogger.SetOutput(io.Discard)

--- a/internal/stackql/logging/logging_test.go
+++ b/internal/stackql/logging/logging_test.go
@@ -1,0 +1,42 @@
+package logging_test
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stackql/stackql/internal/stackql/logging"
+)
+
+func TestSetLogger(t *testing.T) {
+	// Test with a valid log level
+	logging.SetLogger("info")
+	if logging.Logger == nil {
+		t.Error("Expected Logger to be set, but it's nil.")
+	}
+	if logging.Logger.GetLevel() != logrus.InfoLevel {
+		t.Errorf("Expected log level to be 'info', but it's %v.", logging.Logger.GetLevel())
+	}
+}
+
+func TestGetLogger(t *testing.T) {
+	// Test when Logger is not set (default)
+	logging.Logger = nil
+	tmpLogger := logging.GetLogger()
+	if tmpLogger == nil {
+		t.Error("Expected Logger to be set, but it's nil.")
+	}
+	if tmpLogger.GetLevel() != logrus.InfoLevel {
+		t.Errorf("Expected log level is info, but it's %v.", tmpLogger.GetLevel())
+	}
+
+	// Test when Logger is set
+	logging.Logger = logrus.New()
+	logging.Logger.SetLevel(logrus.DebugLevel)
+	tmpLogger = logging.GetLogger()
+	if tmpLogger == nil {
+		t.Error("Expected Logger to be set, but it's nil.")
+	}
+	if tmpLogger.GetLevel() != logrus.DebugLevel {
+		t.Errorf("Expected log level is debug, but it's %v.", tmpLogger.GetLevel())
+	}
+}


### PR DESCRIPTION
## Description

Added unit testing for ```internal/stackql/logging``` package

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [X] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change). 

## Issues referenced.

Fix issue [#240](https://github.com/stackql/stackql/issues/240)

## Evidence

![image](https://github.com/stackql/stackql/assets/75016595/e2cc4533-7ade-4dd3-920a-08f6dfa6c072)

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [X] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [X] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
