### PR TITLE
[294] Add unit testing for package txn_context

### DIFF
--- a/internal/stackql/acid/txn_context/txn_context_test.go
+++ b/internal/stackql/acid/txn_context/txn_context_test.go
@@ -1,0 +1,15 @@
+package txn_context_test
+
+import (
+	"testing"
+
+	. "github.com/stackql/stackql/internal/stackql/acid/txn_context"
+)
+
+func TestNewTransactionContext(t *testing.T) {
+	expectedDepth := 1
+	tc := NewTransactionContext(expectedDepth)
+	if tc.GetStackDepth() != expectedDepth {
+		t.Fatal("test failed, mismatch stack depth for txn coordinator context")
+	}
+}

--- a/internal/stackql/acid/txn_context/txn_coordinator_context_test.go
+++ b/internal/stackql/acid/txn_context/txn_coordinator_context_test.go
@@ -1,0 +1,15 @@
+package txn_context_test
+
+import (
+	"testing"
+
+	. "github.com/stackql/stackql/internal/stackql/acid/txn_context"
+)
+
+func TestNewTransactionCoordinatorContext(t *testing.T) {
+	expectedMaxDepth := 1
+	tcc := NewTransactionCoordinatorContext(expectedMaxDepth)
+	if tcc.GetMaxStackDepth() != expectedMaxDepth {
+		t.Fatal("test failed, mismatch max stack depth for txn context")
+	}
+}


### PR DESCRIPTION
## Description

We are adding basic unit tests to cover function definitions in package `txn_context`
We are keeping test files under package name `txn_package_test` on the lines on `driver_test` package

NOTE for reviewers: This contribution is for hactoberfest credit please label it so. Thanks!
<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  Unit test coverage

## Issues referenced.
fixes #294 
<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->
```go
(base) ➜  txn_context git:(main) pwd              
/Users/i332719/work/git/github.com/stackql/internal/stackql/acid/txn_context
(base) ➜  txn_context git:(main) go test -v -cover
=== RUN   TestNewTransactionContext
--- PASS: TestNewTransactionContext (0.00s)
=== RUN   TestNewTransactionCoordinatorContext
--- PASS: TestNewTransactionCoordinatorContext (0.00s)
PASS
        github.com/stackql/stackql/internal/stackql/acid/txn_context    coverage: 100.0% of statements
ok      github.com/stackql/stackql/internal/stackql/acid/txn_context    0.262s
```
## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [ ] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

Zero technical debt
<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
