### PR TITLE
Add unit testing for `garbagecollector` package

### DIFF
--- a/internal/stackql/garbagecollector/garbagecollector_test.go
+++ b/internal/stackql/garbagecollector/garbagecollector_test.go
@@ -1,0 +1,191 @@
+package garbagecollector //nolint:testpackage // to test unexported methods
+
+import (
+	"testing"
+
+	"github.com/stackql/stackql/internal/stackql/dto"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type GarbageCollectorExecutorMock struct {
+	mock.Mock
+}
+
+func (m *GarbageCollectorExecutorMock) Purge() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *GarbageCollectorExecutorMock) PurgeCache() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *GarbageCollectorExecutorMock) PurgeControlTables() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *GarbageCollectorExecutorMock) PurgeEphemeral() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *GarbageCollectorExecutorMock) Update(tableName string, parentTcc, tcc internaldto.TxnControlCounters) error {
+	args := m.Called(tableName, parentTcc, tcc)
+	return args.Error(0)
+}
+
+func (m *GarbageCollectorExecutorMock) Collect() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func TestNewGarbageCollector(t *testing.T) {
+	t.Run("NewGarbageCollector", func(t *testing.T) {
+		gcExecutorMock := new(GarbageCollectorExecutorMock)
+
+		gc := NewGarbageCollector(gcExecutorMock, dto.GCCfg{}, nil)
+
+		assert.NotNil(t, gc)
+	})
+}
+
+func TestNewStandardGarbageCollector(t *testing.T) {
+	t.Run("NewStandardGarbageCollector", func(t *testing.T) {
+		gcExecutorMock := new(GarbageCollectorExecutorMock)
+
+		gc := newStandardGarbageCollector(gcExecutorMock, dto.GCCfg{}, nil)
+
+		assert.NotNil(t, gc)
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	t.Run("Update", func(t *testing.T) {
+		gcExecutorMock := new(GarbageCollectorExecutorMock)
+		gcExecutorMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecutorMock,
+		}
+
+		err := gc.Update("tableName", nil, nil)
+
+		assert.NoError(t, err)
+		gcExecutorMock.AssertExpectations(t)
+	})
+}
+
+func TestClose(t *testing.T) {
+	t.Run("Close with isEager true", func(t *testing.T) {
+		gcExecutorMock := new(GarbageCollectorExecutorMock)
+		gcExecutorMock.On("Collect").Return(nil)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecutorMock,
+			isEager:    true,
+		}
+
+		err := gc.Close()
+
+		assert.NoError(t, err)
+		gcExecutorMock.AssertExpectations(t)
+	})
+
+	t.Run("Close with isEager false", func(t *testing.T) {
+		gcExecutorMock := new(GarbageCollectorExecutorMock)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecutorMock,
+			isEager:    false,
+		}
+
+		err := gc.Close()
+
+		assert.NoError(t, err)
+		gcExecutorMock.AssertExpectations(t)
+	})
+}
+
+func TestCollect(t *testing.T) {
+	t.Run("Collect", func(t *testing.T) {
+		gcExecutorMock := new(GarbageCollectorExecutorMock)
+		gcExecutorMock.On("Collect").Return(nil)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecutorMock,
+		}
+
+		err := gc.Collect()
+
+		assert.NoError(t, err)
+		gcExecutorMock.AssertExpectations(t)
+	})
+}
+
+func TestPurge(t *testing.T) {
+	t.Run("Purge", func(t *testing.T) {
+		gcExecuterMock := new(GarbageCollectorExecutorMock)
+		gcExecuterMock.On("Purge").Return(nil)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecuterMock,
+		}
+
+		err := gc.Purge()
+
+		assert.NoError(t, err)
+		gcExecuterMock.AssertExpectations(t)
+	})
+}
+
+func TestPurgeEphemeral(t *testing.T) {
+	t.Run("PurgeEphemeral", func(t *testing.T) {
+		gcExecuterMock := new(GarbageCollectorExecutorMock)
+		gcExecuterMock.On("PurgeEphemeral").Return(nil)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecuterMock,
+		}
+
+		err := gc.PurgeEphemeral()
+
+		assert.NoError(t, err)
+		gcExecuterMock.AssertExpectations(t)
+	})
+}
+
+func TestPurgeCache(t *testing.T) {
+	t.Run("PurgeCache", func(t *testing.T) {
+		gcExecuterMock := new(GarbageCollectorExecutorMock)
+		gcExecuterMock.On("PurgeCache").Return(nil)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecuterMock,
+		}
+
+		err := gc.PurgeCache()
+
+		assert.NoError(t, err)
+		gcExecuterMock.AssertExpectations(t)
+	})
+}
+
+func TestPurgeControlTables(t *testing.T) {
+	t.Run("PurgeControlTables", func(t *testing.T) {
+		gcExecuterMock := new(GarbageCollectorExecutorMock)
+		gcExecuterMock.On("PurgeControlTables").Return(nil)
+
+		gc := &standardGarbageCollector{
+			gcExecutor: gcExecuterMock,
+		}
+
+		err := gc.PurgeControlTables()
+
+		assert.NoError(t, err)
+		gcExecuterMock.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
## Description

<!-- Please provide a description of the change(s) implemented. -->
Added unit testing for `internal/stackql/garbagecollector` pacakge

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->
Fixes #230 

## Evidence

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->
<img width="836" alt="2023-10-30 193037" src="https://github.com/stackql/stackql/assets/63947554/67c1366d-b09f-4973-9af5-898c3d20d9c3">

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
