### PR TITLE
feat: add goreleaser

### DIFF
--- a/.github/goreleaser/.goreleaser-for-darwin.yaml
+++ b/.github/goreleaser/.goreleaser-for-darwin.yaml
@@ -1,0 +1,46 @@
+---
+project_name: stackql
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+    - go mod verify
+
+builds:
+  - id: stackql-darwin
+    binary: stackql
+    main: ./stackql/
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=1
+    flags:
+      - -trimpath
+    ldflags: >-
+      -s -w
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildMajorVersion={{.Major}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildMinorVersion={{.Minor}}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildPatchVersion={{.Patch}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildCommitSHA={{.FullCommit}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildShortCommitSHA={{.ShortCommit}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildDate={{.Date}}
+      -X stackql/internal/stackql/planbuilder.PlanCacheEnabled=true
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform={{.Os}}
+
+archives:
+  - format: tar.gz
+    name_template: "stackql_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    files:
+      - LICENSE
+      - README.md
+
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+checksum:
+  name_template: "stackql_darwin_checksums.txt"

--- a/.github/goreleaser/.goreleaser-for-linux.yaml
+++ b/.github/goreleaser/.goreleaser-for-linux.yaml
@@ -1,0 +1,65 @@
+---
+project_name: stackql
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+    - go mod verify
+
+builds:
+  - id: stackql-linux
+    binary: stackql
+    main: ./stackql/
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - >-
+        {{- if eq .Arch "amd64"}}CC=x86_64-linux-gnu-gcc{{- end }}
+        {{- if eq .Arch "arm64"}}CC=aarch64-linux-gnu-gcc{{- end }}
+      - >-
+        {{- if eq .Arch "amd64"}}CXX=x86_64-linux-gnu-g++{{- end }}
+        {{- if eq .Arch "arm64"}}CXX=aarch64-linux-gnu-gcc{{- end }}
+    flags:
+      - -trimpath
+    ldflags: >-
+      -s -w
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildMajorVersion={{.Major}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildMinorVersion={{.Minor}}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildPatchVersion={{.Patch}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildCommitSHA={{.FullCommit}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildShortCommitSHA={{.ShortCommit}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildDate={{.Date}}
+      -X stackql/internal/stackql/planbuilder.PlanCacheEnabled=true
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform={{.Os}}
+
+archives:
+  - format: tar.gz
+    name_template: "stackql_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    files:
+      - LICENSE
+      - README.md
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+checksum:
+  name_template: "stackql_linux_checksums.txt"
+
+nfpms:
+  - id: stackql-nfpms
+    file_name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    homepage: https://stackql.io/
+    maintainer: "StackQL Team <stackql-team@users.noreply.github.com>" # optional
+    description: "Cloud asset management and automation using SQL"
+    license: MIT
+    section: golang
+    formats:
+      - deb
+      - rpm
+      - apk
+      - archlinux

--- a/.github/goreleaser/.goreleaser-for-windows.yaml
+++ b/.github/goreleaser/.goreleaser-for-windows.yaml
@@ -1,0 +1,46 @@
+---
+project_name: stackql
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+    - go mod verify
+
+builds:
+  - id: stackql-windows
+    binary: stackql
+    main: ./stackql/
+    goos:
+      - windows
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    flags:
+      - -trimpath
+    ldflags: >-
+      -s -w
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildMajorVersion={{.Major}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildMinorVersion={{.Minor}}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildPatchVersion={{.Patch}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildCommitSHA={{.FullCommit}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildShortCommitSHA={{.ShortCommit}}
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildDate={{.Date}}
+      -X stackql/internal/stackql/planbuilder.PlanCacheEnabled=true
+      -X github.com/stackql/stackql/internal/stackql/cmd.BuildPlatform={{.Os}}
+
+archives:
+  - format: zip
+    name_template: "stackql_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    files:
+      - LICENSE
+      - README.md
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+checksum:
+  name_template: "stackql_windows_checksums.txt"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     tags:
-      - 'v*'
+      - 'testing-v*'
 
 env:
   GH_ACCESS_TOKEN: ${{ secrets.ACTIONS_PRIVATE_PACKAGE_SECRET }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,69 @@
+name: build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  GH_ACCESS_TOKEN: ${{ secrets.ACTIONS_PRIVATE_PACKAGE_SECRET }}
+
+jobs:
+  build-linux-binary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ^1.19
+      - name: Install cross-compiler for linux/arm64
+        run: sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      - name: Run Goreleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean --config .github/goreleaser/.goreleaser-for-linux.yaml --verbose
+        env:
+          GITHUB_TOKEN: ${{env.GH_ACCESS_TOKEN}}
+
+  build-macos-binary:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ^1.19
+      - name: Run Goreleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean --config .github/goreleaser/.goreleaser-for-darwin.yaml --verbose
+        env:
+          GITHUB_TOKEN: ${{env.GH_ACCESS_TOKEN}}
+
+  build-windows-binary:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ^1.19
+      - name: Run Goreleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean --config .github/goreleaser/.goreleaser-for-windows.yaml --verbose
+        env:
+          GITHUB_TOKEN: ${{env.GH_ACCESS_TOKEN}}


### PR DESCRIPTION
## Description

<!-- Please provide a description of the change(s) implemented. -->
**Added Goreleaser**

- This build uses three different files (each for a different platform) because, as mentioned in [this comment](https://github.com/stackql/stackql/issues/224#issuecomment-1817294807), StackQL needs to enable CGO. To avoid issues with cross-compiling and CGO, the binary needs to be built with different compilers (`CC` and `CXX`) for each platform.
- Utilizes [goreleaser-action](https://github.com/goreleaser/goreleaser-action) in `build.yaml` to build the binary.
- Triggered by the `tags` event and hasn't affected the main workflows.

Goreleaser build includes:
- Windows AMD64
- Darwin universal binary ARM64 and AMD64
- Linux AMD64 and ARM64
- Linux packages `.deb`, `.rpm`, `.apk`, and Archlinux packages

Excluded:
- Docker images
- Chocolatey Windows packages

The reason for exclusions:
- For Docker images, Goreleaser encounters difficulties accessing environment variables from the host/runner (refer to [this issue](https://github.com/goreleaser/goreleaser/issues/985)). To use `env`, it should be executed [like this](https://goreleaser.com/customization/builds/#passing-environment-variables-to-ldflags). However, since this build uses [goreleaser-action](https://github.com/goreleaser/goreleaser-action), the run cannot be executed.
- Consistently encountering errors when attempting to build for Chocolatey, coupled with a lack of sufficient documentation.

## Type of Change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [x] Breaking change.
- [x] Other (**Workflows change**).

## Issues Referenced

[Feat] Issue: [https://github.com/stackql/stackql/issues/224](https://github.com/stackql/stackql/issues/224)

## Evidence

![image](https://github.com/stackql/stackql/assets/75016595/56f60ef5-d854-4096-8d0b-ea3625c44286)
![image](https://github.com/stackql/stackql/assets/75016595/8119ac6a-c1ae-4645-8c5f-8349bab205a8)

See more on this [release](https://github.com/Iqbalabdi/stackql/releases/tag/v0.1.6).

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [ ] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [ ] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->
- As mentioned before, this build uses [goreleaser-action](https://github.com/goreleaser/goreleaser-action), so the `ldflags` for the binary use [field templates](https://goreleaser.com/customization/templates/#common-fields) from Goreleaser, not using environment variables from runner/host.

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here. If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify. Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section. This should be done prior to merge. -->
- Incorporate a testing workflow before executing Goreleaser.
