### PR TITLE
simplest-possible-in-subclauses

### DIFF
--- a/internal/stackql/astvisit/param_extract.go
+++ b/internal/stackql/astvisit/param_extract.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackql/stackql-parser/go/sqltypes"
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"
 	"github.com/stackql/stackql/internal/stackql/astanalysis/annotatedast"
+	"github.com/stackql/stackql/internal/stackql/logging"
 	"github.com/stackql/stackql/internal/stackql/parserutil"
 )
 
@@ -728,7 +729,17 @@ func (v *standardParserParamAstVisitor) Visit(node sqlparser.SQLNode) error {
 					node,
 					lt,
 				))
+			case sqlparser.ValTuple:
+				k, err := parserutil.NewUnknownTypeColumnarReference(lt)
+				if err != nil {
+					return err
+				}
+				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
+					node,
+					rt,
+				))
 			default:
+				logging.GetLogger().Debugf("unhandled type: %T", rt)
 			}
 		default:
 			switch rt := node.Right.(type) {

--- a/internal/stackql/dataflow/collection.go
+++ b/internal/stackql/dataflow/collection.go
@@ -96,6 +96,9 @@ func (dc *standardDataFlowCollection) AddOrUpdateEdge(
 func (dc *standardDataFlowCollection) AddVertex(v Vertex) {
 	_, ok := dc.verticesForTableExprs[v.GetTableExpr()]
 	if ok {
+		if v.GetEquivalencyGroup() > 0 {
+			dc.g.AddNode(v) // TODO: change to acceptable idion
+		}
 		return
 	}
 	dc.vertices[v] = struct{}{}

--- a/internal/stackql/dataflow/vertex.go
+++ b/internal/stackql/dataflow/vertex.go
@@ -10,13 +10,16 @@ type Vertex interface {
 	graph.Node
 	Unit
 	GetAnnotation() taxonomy.AnnotationCtx
+	GetEquivalencyGroup() int64
+	SetEquivalencyGroup(id int64)
 	GetTableExpr() sqlparser.TableExpr
 }
 
 type standardDataFlowVertex struct {
-	id         int64
-	annotation taxonomy.AnnotationCtx
-	tableExpr  sqlparser.TableExpr
+	id                 int64
+	equiValencyGroupID int64
+	annotation         taxonomy.AnnotationCtx
+	tableExpr          sqlparser.TableExpr
 }
 
 func NewStandardDataFlowVertex(
@@ -34,6 +37,14 @@ func (dv *standardDataFlowVertex) iDataFlowUnit() {}
 
 func (dv *standardDataFlowVertex) ID() int64 {
 	return dv.id
+}
+
+func (dv *standardDataFlowVertex) GetEquivalencyGroup() int64 {
+	return dv.equiValencyGroupID
+}
+
+func (dv *standardDataFlowVertex) SetEquivalencyGroup(id int64) {
+	dv.equiValencyGroupID = id
 }
 
 func (dv *standardDataFlowVertex) GetAnnotation() taxonomy.AnnotationCtx {

--- a/internal/stackql/parserutil/parameter_metadata.go
+++ b/internal/stackql/parserutil/parameter_metadata.go
@@ -6,6 +6,11 @@ import (
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"
 )
 
+var (
+	_ ParameterMetadata = (*StandardComparisonParameterMetadata)(nil)
+	_ ParameterMetadata = (*PlaceholderParameterMetadata)(nil)
+)
+
 type ParameterMetadata interface {
 	iParameterMetadata()
 	GetParent() *sqlparser.ComparisonExpr

--- a/internal/stackql/primitivegenerator/statement_analyzer.go
+++ b/internal/stackql/primitivegenerator/statement_analyzer.go
@@ -431,10 +431,14 @@ func (pb *standardPrimitiveGenerator) whereComparisonExprCopyAndReWrite(
 			}, colName, nil
 		}
 	}
+	rewrittenOperator := expr.Operator
+	if strings.ToUpper(expr.Operator) == "IN" {
+		rewrittenOperator = "="
+	}
 	return &sqlparser.ComparisonExpr{
 		Left:     &sqlparser.SQLVal{Type: sqlparser.IntVal, Val: []byte("1")},
 		Right:    &sqlparser.SQLVal{Type: sqlparser.IntVal, Val: []byte("1")},
-		Operator: expr.Operator,
+		Operator: rewrittenOperator,
 		Escape:   expr.Escape,
 	}, colName, nil
 }

--- a/internal/stackql/tablemetadata/extended_table_metadata.go
+++ b/internal/stackql/tablemetadata/extended_table_metadata.go
@@ -62,6 +62,7 @@ type ExtendedTableMetadata interface {
 	IsOnClauseHoistable() bool
 	IsPhysicalTable() bool
 	GetServerVariables() (map[string]*openapi3.ServerVariable, bool)
+	Clone() ExtendedTableMetadata
 }
 
 type standardExtendedTableMetadata struct {
@@ -76,6 +77,22 @@ type standardExtendedTableMetadata struct {
 	indirect            astindirect.Indirect
 	sqlDataSource       sql_datasource.SQLDataSource
 	isOnClauseHoistable bool
+}
+
+func (ex *standardExtendedTableMetadata) Clone() ExtendedTableMetadata {
+	return &standardExtendedTableMetadata{
+		tableFilter:         ex.tableFilter,
+		colsVisited:         ex.colsVisited,
+		heirarchyObjects:    ex.heirarchyObjects,
+		isLocallyExecutable: ex.isLocallyExecutable,
+		getHTTPArmoury:      ex.getHTTPArmoury,
+		selectItemsKey:      ex.selectItemsKey,
+		alias:               ex.alias,
+		inputTableName:      ex.inputTableName,
+		indirect:            ex.indirect,
+		sqlDataSource:       ex.sqlDataSource,
+		isOnClauseHoistable: ex.isOnClauseHoistable,
+	}
 }
 
 func (ex *standardExtendedTableMetadata) GetServerVariables() (map[string]*openapi3.ServerVariable, bool) {

--- a/test/mockserver/expectations/static-gcp-expectations.json
+++ b/test/mockserver/expectations/static-gcp-expectations.json
@@ -61,6 +61,50 @@
         ]
       }
     }
+  },
+  {
+    "httpRequest": {
+      "method": "GET",
+      "path": "/v1/projects/another-project/aggregated/usableSubnetworks"
+    },
+    "httpResponse": {
+      "body": {
+        "subnetworks": [
+          {
+            "subnetwork": "projects/another-project/regions/australia-southeast1/subnetworks/sn-02",
+            "network": "projects/another-project/global/networks/vpc-01",
+            "ipCidrRange": "10.0.1.0/24"
+          },
+          {
+            "subnetwork": "projects/another-project/regions/australia-southeast1/subnetworks/sn-01",
+            "network": "projects/another-project/global/networks/vpc-01",
+            "ipCidrRange": "10.0.0.0/24"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "GET",
+      "path": "/v1/projects/yet-another-project/aggregated/usableSubnetworks"
+    },
+    "httpResponse": {
+      "body": {
+        "subnetworks": [
+          {
+            "subnetwork": "projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-02",
+            "network": "projects/yet-another-project/global/networks/vpc-01",
+            "ipCidrRange": "10.0.1.0/24"
+          },
+          {
+            "subnetwork": "projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-01",
+            "network": "projects/yet-another-project/global/networks/vpc-01",
+            "ipCidrRange": "10.0.0.0/24"
+          }
+        ]
+      }
+    }
   }, 
   {
     "httpRequest": {

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -2585,6 +2585,105 @@ Select Star of EC2 Instances Returns Expected Result
     ...    vol-1234567890abcdef0
     ...    stdout=${CURDIR}/tmp/Select-Star-of-EC2-Instances-Returns-Expected-Result.tmp
 
+Select With IN Scalars inside WHERE Clause Returns Expected Result
+    ${inputStr} =    Catenate
+    ...              select 
+    ...              instanceId, ipAddress 
+    ...              from aws.ec2.instances 
+    ...              where 
+    ...              region = 'ap-southeast-2'
+    ...              and instanceId not in ('some-silly-id') 
+    ...              and ipAddress in ('54.194.252.215')
+    ...              and region in ('ap-southeast-2')
+    ...              ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...               |---------------------|----------------|
+    ...               |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}instanceId${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}ipAddress${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |---------------------|----------------|
+    ...               |${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215${SPACE}|
+    ...               |---------------------|----------------|
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}    
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Select-With-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
+
+
+Select With Server Parameters inside IN Scalars inside WHERE Clause Returns Expected Result
+    ${inputStr} =    Catenate
+    ...              select 
+    ...              instanceId, 
+    ...              ipAddress 
+    ...              from aws.ec2.instances 
+    ...              where 
+    ...              instanceId not in ('some-silly-id')  
+    ...              and region in ('ap-southeast-2', 'ap-southeast-1')
+    ...              ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...               |---------------------|----------------|
+    ...               |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}instanceId${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}ipAddress${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |---------------------|----------------|
+    ...               |${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215${SPACE}|
+    ...               |---------------------|----------------|
+    ...               |${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215${SPACE}|
+    ...               |---------------------|----------------|
+
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}    
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Select-With-Server-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
+
+Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result
+    ${inputStr} =     Catenate
+    ...               select 
+    ...               ipCidrRange, 
+    ...               subnetwork 
+    ...               from google.container."projects.aggregated.usableSubnetworks"
+    ...               where 
+    ...               projectsId in ('testing-project', 'another-project', 'yet-another-project') 
+    ...               order by subnetwork desc
+    ...               ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...               |-------------|-----------------------------------------------------------------------------|
+    ...               |${SPACE}ipCidrRange${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}subnetwork${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |-------------|-----------------------------------------------------------------------------|
+    ...               |${SPACE}10.0.1.0/24${SPACE}|${SPACE}projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|
+    ...               |-------------|-----------------------------------------------------------------------------|
+    ...               |${SPACE}10.0.0.0/24${SPACE}|${SPACE}projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|
+    ...               |-------------|-----------------------------------------------------------------------------|
+    ...               |${SPACE}10.0.1.0/24${SPACE}|${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |-------------|-----------------------------------------------------------------------------|
+    ...               |${SPACE}10.0.0.0/24${SPACE}|${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |-------------|-----------------------------------------------------------------------------|
+    ...               |${SPACE}10.0.1.0/24${SPACE}|${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |-------------|-----------------------------------------------------------------------------|
+    ...               |${SPACE}10.0.0.0/24${SPACE}|${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |-------------|-----------------------------------------------------------------------------|
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Select-With-Path-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
+
 # This also tests passing integers in request body parameters
 Select Projection of CloudWatch Log Events Returns Expected Result
     Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing


### PR DESCRIPTION
## Description

- Support for scalare `IN` subclauses inside `WHERE` clause, for filtering and parameters.
- Added robot test `Select With IN Scalars inside WHERE Clause Returns Expected Result`.
- Added robot test `Select With Server Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.
- Added robot test `Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.
- Distributed hack to suppress contol paramater expansion.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

#329 

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Select With IN Scalars inside WHERE Clause Returns Expected Result`.
- Added robot test `Select With Server Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.
- Added robot test `Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

The above mentioned hack to prevent unwanted control parameter expansion represents technical debt.  The `TODO` entries in this change are useful anchors to the issue.  This technical debt is assigned to an upcoming ticket: https://github.com/stackql/stackql/issues/337

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
