### PR TITLE
mixed-in-subclause-parameter-routing

### DIFF
--- a/internal/stackql/router/parameter_router.go
+++ b/internal/stackql/router/parameter_router.go
@@ -254,7 +254,8 @@ func (pr *standardParameterRouter) GetOnConditionDataFlows() (dataflow.Collectio
 						clonedParams := make(map[string]interface{})
 						for k2, v2 := range v.GetParameters() {
 							if k2 != k1 {
-								clonedParams[k1] = v2
+								val2 := v2
+								clonedParams[k2] = val2
 							}
 						}
 

--- a/test/mockserver/expectations/static-gcp-expectations.json
+++ b/test/mockserver/expectations/static-gcp-expectations.json
@@ -160,6 +160,61 @@
         "selfLink": "https://www.googleapis.com/compute/beta/projects/testing-project/zones/australia-southeast1-a/acceleratorTypes"
       }
     }
+  },  
+  {
+    "httpRequest": {
+      "method": "GET",
+      "path": "/projects/another-project/zones/australia-southeast1-a/acceleratorTypes"
+    },
+    "httpResponse": {
+      "body": {
+        "kind": "compute#acceleratorTypeList",
+        "id": "projects/another-project/zones/australia-southeast1-a/acceleratorTypes",
+        "items": [
+          {
+            "kind": "compute#acceleratorType",
+            "id": "11010",
+            "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+            "name": "nvidia-tesla-p4",
+            "description": "NVIDIA Tesla P4",
+            "zone": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a",
+            "selfLink": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a/acceleratorTypes/nvidia-tesla-p4",
+            "maximumCardsPerInstance": 4
+          },
+          {
+            "kind": "compute#acceleratorType",
+            "id": "11012",
+            "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+            "name": "nvidia-tesla-p4-vws",
+            "description": "NVIDIA Tesla P4 Virtual Workstation",
+            "zone": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a",
+            "selfLink": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a/acceleratorTypes/nvidia-tesla-p4-vws",
+            "maximumCardsPerInstance": 4
+          },
+          {
+            "kind": "compute#acceleratorType",
+            "id": "11019",
+            "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+            "name": "nvidia-tesla-t4",
+            "description": "NVIDIA Tesla T4",
+            "zone": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a",
+            "selfLink": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a/acceleratorTypes/nvidia-tesla-t4",
+            "maximumCardsPerInstance": 4
+          },
+          {
+            "kind": "compute#acceleratorType",
+            "id": "11020",
+            "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+            "name": "nvidia-tesla-t4-vws",
+            "description": "NVIDIA Tesla T4 Virtual Workstation",
+            "zone": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a",
+            "selfLink": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a/acceleratorTypes/nvidia-tesla-t4-vws",
+            "maximumCardsPerInstance": 4
+          }
+        ],
+        "selfLink": "https://www.googleapis.com/compute/beta/projects/another-project/zones/australia-southeast1-a/acceleratorTypes"
+      }
+    }
   },
   {
     "httpRequest": {

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -2684,6 +2684,189 @@ Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expect
     ...    ${outputStr}
     ...    stdout=${CURDIR}/tmp/Select-With-Path-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
 
+Select With Path Parameters inside IN Scalars Mixed With an Equals Parameter all inside WHERE Clause Returns Expected Result
+    ${inputStr} =     Catenate
+    ...    select 
+    ...    id, 
+    ...    name  
+    ...    from google.compute.acceleratorTypes 
+    ...    where 
+    ...    project in ('testing-project', 'another-project') 
+    ...    and zone = 'australia-southeast1-a' 
+    ...    order by id desc
+    ...    ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |-------|---------------------|
+    ...    |${SPACE}${SPACE}id${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}11020${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}11019${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}11012${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}11010${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}10020${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}10019${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}10012${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|
+    ...    |-------|---------------------|
+    ...    |${SPACE}10010${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------|---------------------|
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Select-With-Path-Parameters-inside-IN-Scalars-Mixed-With-an-Equals-Parameter-all-inside-WHERE-Clause-Returns-Expected-Result.tmp
+
+Select Subquery Join With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result
+    ${inputStr} =     Catenate
+    ...    select 
+    ...    subnets.subnetwork, 
+    ...    s2.proj 
+    ...    from 
+    ...    ( 
+    ...      select 
+    ...      ipCidrRange, 
+    ...      subnetwork 
+    ...      from google.container."projects.aggregated.usableSubnetworks" 
+    ...      where 
+    ...      projectsId in ('testing-project', 'another-project', 'yet-another-project') 
+    ...      order by subnetwork desc 
+    ...    ) subnets 
+    ...    inner join 
+    ...    (
+    ...      select 
+    ...      ipCidrRange, 
+    ...      subnetwork, 
+    ...      split_part(subnetwork, '/', 2) as proj 
+    ...      from google.container."projects.aggregated.usableSubnetworks" 
+    ...      where projectsId in ('testing-project', 'another-project', 'yet-another-project') 
+    ...      order by subnetwork desc 
+    ...    ) s2 
+    ...    on 
+    ...    subnets.subnetwork = s2.subnetwork 
+    ...    order by subnets.subnetwork desc
+    ...    ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}subnetwork${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}proj${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}yet-another-project${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}yet-another-project${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}testing-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}testing-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}another-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}another-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Select-Subquery-Join-With-Path-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
+
+Select Subquery Join With Parameters inside IN Scalars Plus More inside WHERE Clause Returns Expected Result
+    ${inputStr} =     Catenate
+    ...    select 
+    ...    subnets.subnetwork, 
+    ...    subnets.proj, 
+    ...    accels.name as accelerator_name 
+    ...    from
+    ...    (
+    ...    select 
+    ...    ipCidrRange, 
+    ...    subnetwork,
+    ...    split_part(subnetwork, '/', 2) as proj
+    ...    from google.container."projects.aggregated.usableSubnetworks"
+    ...    where 
+    ...    projectsId in ('testing-project', 'another-project', 'yet-another-project') 
+    ...    order by subnetwork desc
+    ...    ) as subnets
+    ...    inner join
+    ...    (
+    ...    select 
+    ...    id, 
+    ...    name,
+    ...    split_part(selfLink, '/', 7) as proj,
+    ...    split_part(selfLink, '/', -3) as "zone"
+    ...    from google.compute.acceleratorTypes 
+    ...    where 
+    ...    project in ('testing-project', 'another-project') 
+    ...    and zone = 'australia-southeast1-a' 
+    ...    order by id desc
+    ...    ) as accels
+    ...    on subnets.proj = accels.proj
+    ...    order by 
+    ...    subnets.subnetwork desc,
+    ...    accels.name desc
+    ...    ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}subnetwork${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}proj${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}accelerator_name${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}testing-project${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}another-project${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------------------------------------------------|-----------------|---------------------|
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Select-Subquery-Join-With-Path-Parameters-inside-IN-Scalars-Plus-More-inside-WHERE-Clause-Returns-Expected-Result.tmp
+
 # This also tests passing integers in request body parameters
 Select Projection of CloudWatch Log Events Returns Expected Result
     Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test likely due to case sensitivity and incorrect XML property aliasing


### PR DESCRIPTION
## Description

- Fixed parameter cloning defect.
- Now support joins on `IN` subclause relations via subqueries.
- Added robot test `Select With Path Parameters inside IN Scalars Mixed With an Equals Parameter all inside WHERE Clause Returns Expected Result`.
- Added robot test `Select Subquery Join With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.
- Added robot test `Select Subquery Join With Parameters inside IN Scalars Plus More inside WHERE Clause Returns Expected Result`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

Closes #329 

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Select With Path Parameters inside IN Scalars Mixed With an Equals Parameter all inside WHERE Clause Returns Expected Result`.
- Added robot test `Select Subquery Join With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.
- Added robot test `Select Subquery Join With Parameters inside IN Scalars Plus More inside WHERE Clause Returns Expected Result`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

The function`bodgePrepStmt` from `internal/stackql/sqlengine/postgres_tcp.go` represents technical debt, and has been added to the remiation ticket: https://github.com/stackql/stackql/issues/337

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
