### PR TITLE
transaction-storage-manager-pattern

### DIFF
--- a/cicd/requirements.txt
+++ b/cicd/requirements.txt
@@ -1,5 +1,5 @@
-psycopg2-binary
-psycopg[binary]
+psycopg2-binary==2.9.9
+psycopg[binary]==3.1.14
 PyYaml
 robotframework
 sqlalchemy==1.4.44

--- a/internal/stackql/acid/tsm/tsm.go
+++ b/internal/stackql/acid/tsm/tsm.go
@@ -1,0 +1,12 @@
+package tsm
+
+// Transaction Storage Manager (TSM)
+// A monolith containing:
+//  1. Log Manager.  Write Ahead Logging; WAL.
+//  2. Lock Manager.  2 Phase Locking; 2PL... **not** to be confused with 2 Phase Commit.
+//  3. Access Methods.  In a conventional RDBMS B+-tree index and heap file access primitives, including latches.
+//  4. Buffer Pool.  It is possible to externalise this componsnes as it does not require shared internal
+//     awareness with other components (as oppose to the other 3 components).
+type TSM interface {
+	//
+}

--- a/internal/stackql/acid/tsm_physio/access_methods.go
+++ b/internal/stackql/acid/tsm_physio/access_methods.go
@@ -1,0 +1,13 @@
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
+
+var (
+	_ AccessMethods = (*accessMethods)(nil)
+)
+
+type AccessMethods interface {
+	//
+}
+
+type accessMethods struct {
+	//
+}

--- a/internal/stackql/acid/tsm_physio/best_effort_coordinator.go
+++ b/internal/stackql/acid/tsm_physio/best_effort_coordinator.go
@@ -1,4 +1,4 @@
-package transact
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"
 	"github.com/stackql/stackql/internal/stackql/acid/acid_dto"
 	"github.com/stackql/stackql/internal/stackql/acid/binlog"
+	"github.com/stackql/stackql/internal/stackql/acid/tsm"
 	"github.com/stackql/stackql/internal/stackql/handler"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
 	"github.com/stackql/stackql/internal/stackql/primitivegraph"
@@ -16,6 +17,7 @@ var (
 )
 
 type basicBestEffortTransactionCoordinator struct {
+	tsmInstance       tsm.TSM
 	handlerCtx        handler.HandlerContext
 	parent            Coordinator
 	statementSequence []Statement
@@ -30,11 +32,13 @@ type basicBestEffortTransactionCoordinator struct {
 }
 
 func newBasicBestEffortTransactionCoordinator(
+	tsmInstance tsm.TSM,
 	handlerCtx handler.HandlerContext,
 	parent Coordinator,
 	maxTxnDepth int,
 ) Coordinator {
 	return &basicBestEffortTransactionCoordinator{
+		tsmInstance: tsmInstance,
 		handlerCtx:  handlerCtx,
 		parent:      parent,
 		maxTxnDepth: maxTxnDepth,
@@ -171,7 +175,7 @@ func (m *basicBestEffortTransactionCoordinator) Begin() (Coordinator, error) {
 	if m.maxTxnDepth >= 0 && m.Depth() >= m.maxTxnDepth {
 		return nil, fmt.Errorf("cannot begin nested transaction of depth = %d", m.Depth()+1)
 	}
-	return newBasicBestEffortTransactionCoordinator(m.handlerCtx, m, m.maxTxnDepth), nil
+	return newBasicBestEffortTransactionCoordinator(m.tsmInstance, m.handlerCtx, m, m.maxTxnDepth), nil
 }
 
 func (m *basicBestEffortTransactionCoordinator) Commit() acid_dto.CommitCoDomain {

--- a/internal/stackql/acid/tsm_physio/best_effort_orchestrator.go
+++ b/internal/stackql/acid/tsm_physio/best_effort_orchestrator.go
@@ -1,10 +1,11 @@
-package transact
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
 
 import (
 	"fmt"
 	"strings"
 
 	"github.com/stackql/stackql/internal/stackql/acid/binlog"
+	"github.com/stackql/stackql/internal/stackql/acid/tsm"
 	"github.com/stackql/stackql/internal/stackql/acid/txn_context"
 	"github.com/stackql/stackql/internal/stackql/handler"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
@@ -22,6 +23,7 @@ var (
 //
 //nolint:unused // TODO: fix this.
 type bestEffortOrchestrator struct {
+	tsmInstance    tsm.TSM
 	txnCoordinator Coordinator
 	undoLogs       []binlog.LogEntry
 	redoLogs       []binlog.LogEntry

--- a/internal/stackql/acid/tsm_physio/buffer_pool.go
+++ b/internal/stackql/acid/tsm_physio/buffer_pool.go
@@ -1,0 +1,11 @@
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
+
+var (
+	_ BufferPool = (*bufferPool)(nil)
+)
+
+type BufferPool interface {
+	//
+}
+
+type bufferPool struct{}

--- a/internal/stackql/acid/tsm_physio/coordinator.go
+++ b/internal/stackql/acid/tsm_physio/coordinator.go
@@ -1,20 +1,21 @@
-package transact
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
 
 import (
 	"github.com/stackql/stackql/internal/stackql/acid/acid_dto"
+	"github.com/stackql/stackql/internal/stackql/acid/tsm"
 	"github.com/stackql/stackql/internal/stackql/constants"
 	"github.com/stackql/stackql/internal/stackql/handler"
 )
 
-func NewCoordinator(handlerCtx handler.HandlerContext, maxTxnDepth int) Coordinator {
+func newCoordinator(tsmInstance tsm.TSM, handlerCtx handler.HandlerContext, maxTxnDepth int) Coordinator {
 	rollbackType := handlerCtx.GetRollbackType()
 	switch rollbackType {
 	case constants.NopRollback:
-		return newBasicLazyTransactionCoordinator(nil, maxTxnDepth)
+		return newBasicLazyTransactionCoordinator(tsmInstance, nil, maxTxnDepth)
 	case constants.EagerRollback:
-		return newBasicBestEffortTransactionCoordinator(handlerCtx, nil, maxTxnDepth)
+		return newBasicBestEffortTransactionCoordinator(tsmInstance, handlerCtx, nil, maxTxnDepth)
 	default:
-		return newBasicLazyTransactionCoordinator(nil, maxTxnDepth)
+		return newBasicLazyTransactionCoordinator(tsmInstance, nil, maxTxnDepth)
 	}
 }
 

--- a/internal/stackql/acid/tsm_physio/lazy_coordinator.go
+++ b/internal/stackql/acid/tsm_physio/lazy_coordinator.go
@@ -1,4 +1,4 @@
-package transact
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"
 	"github.com/stackql/stackql/internal/stackql/acid/acid_dto"
 	"github.com/stackql/stackql/internal/stackql/acid/binlog"
+	"github.com/stackql/stackql/internal/stackql/acid/tsm"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
 	"github.com/stackql/stackql/internal/stackql/primitivegraph"
 )
@@ -15,6 +16,7 @@ var (
 )
 
 type basicLazyTransactionCoordinator struct {
+	tsmInstance       tsm.TSM
 	parent            Coordinator
 	statementSequence []Statement
 	undoLogs          []binlog.LogEntry
@@ -24,8 +26,9 @@ type basicLazyTransactionCoordinator struct {
 	isExecuted        bool
 }
 
-func newBasicLazyTransactionCoordinator(parent Coordinator, maxTxnDepth int) Coordinator {
+func newBasicLazyTransactionCoordinator(tsmInstance tsm.TSM, parent Coordinator, maxTxnDepth int) Coordinator {
 	return &basicLazyTransactionCoordinator{
+		tsmInstance: tsmInstance,
 		parent:      parent,
 		maxTxnDepth: maxTxnDepth,
 	}
@@ -161,7 +164,7 @@ func (m *basicLazyTransactionCoordinator) Begin() (Coordinator, error) {
 	if m.maxTxnDepth >= 0 && m.Depth() >= m.maxTxnDepth {
 		return nil, fmt.Errorf("cannot begin nested transaction of depth = %d", m.Depth()+1)
 	}
-	return newBasicLazyTransactionCoordinator(m, m.maxTxnDepth), nil
+	return newBasicLazyTransactionCoordinator(m.tsmInstance, m, m.maxTxnDepth), nil
 }
 
 func (m *basicLazyTransactionCoordinator) Commit() acid_dto.CommitCoDomain {

--- a/internal/stackql/acid/tsm_physio/lock_manager.go
+++ b/internal/stackql/acid/tsm_physio/lock_manager.go
@@ -1,0 +1,11 @@
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
+
+var (
+	_ LockManager = (*lockManager)(nil)
+)
+
+type LockManager interface {
+	//
+}
+
+type lockManager struct{}

--- a/internal/stackql/acid/tsm_physio/log_manager.go
+++ b/internal/stackql/acid/tsm_physio/log_manager.go
@@ -1,0 +1,33 @@
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
+import (
+	"sync"
+
+	"github.com/stackql/stackql/internal/stackql/handler"
+)
+
+var (
+	_ LogManager = (*walManager)(nil)
+)
+
+//nolint:gochecknoglobals // singleton pattern
+var (
+	walOnce      sync.Once
+	walSingleton LogManager
+)
+
+type LogManager interface {
+	//
+}
+
+type walManager struct{}
+
+func getWalManager(_ handler.HandlerContext) (LogManager, error) {
+	var err error
+	walOnce.Do(func() {
+		if err != nil {
+			return
+		}
+		walSingleton = &walManager{}
+	})
+	return walSingleton, err
+}

--- a/internal/stackql/acid/tsm_physio/statement.go
+++ b/internal/stackql/acid/tsm_physio/statement.go
@@ -1,4 +1,4 @@
-package transact
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
 
 import (
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"

--- a/internal/stackql/acid/tsm_physio/tsm_implementation.go
+++ b/internal/stackql/acid/tsm_physio/tsm_implementation.go
@@ -1,0 +1,24 @@
+package tsm_physio //nolint:revive,stylecheck // prefer this nomenclature
+
+import (
+	"github.com/stackql/stackql/internal/stackql/acid/tsm"
+	"github.com/stackql/stackql/internal/stackql/handler"
+)
+
+//nolint:unused // TODO: finalise pattern
+type tsmImplementation struct {
+	accessMethods AccessMethods
+	bufferPool    BufferPool
+	lockManager   LockManager
+	logManager    LogManager
+}
+
+func GetTSM(handlerCtx handler.HandlerContext) (tsm.TSM, error) {
+	walManager, walErr := getWalManager(handlerCtx)
+	if walErr != nil {
+		return nil, walErr
+	}
+	return &tsmImplementation{
+		logManager: walManager,
+	}, nil
+}

--- a/internal/stackql/driver/driver.go
+++ b/internal/stackql/driver/driver.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/stackql/psql-wire/pkg/sqldata"
-	"github.com/stackql/stackql/internal/stackql/acid/transact"
+	"github.com/stackql/stackql/internal/stackql/acid/tsm_physio"
 	"github.com/stackql/stackql/internal/stackql/handler"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
 	"github.com/stackql/stackql/internal/stackql/logging"
@@ -44,7 +44,7 @@ func (sdf *basicStackQLDriverFactory) newSQLDriver() (StackQLDriver, error) {
 	if err != nil {
 		return nil, err
 	}
-	txnProvider, txnProviderErr := transact.GetProviderInstance(sdf.handlerCtx.GetTxnCoordinatorCtx())
+	txnProvider, txnProviderErr := tsm_physio.GetProviderInstance(sdf.handlerCtx.GetTxnCoordinatorCtx())
 	if txnProviderErr != nil {
 		return nil, txnProviderErr
 	}
@@ -52,6 +52,11 @@ func (sdf *basicStackQLDriverFactory) newSQLDriver() (StackQLDriver, error) {
 	if orcErr != nil {
 		return nil, orcErr
 	}
+	tsmInstance, walError := tsm_physio.GetTSM(sdf.handlerCtx)
+	if walError != nil {
+		return nil, walError
+	}
+	sdf.handlerCtx.SetTSM(tsmInstance)
 	clonedCtx := sdf.handlerCtx.Clone()
 	clonedCtx.SetTxnCounterMgr(txCtr)
 	rv := &basicStackQLDriver{
@@ -117,7 +122,7 @@ func (dr *basicStackQLDriver) ProcessQuery(query string) {
 
 type basicStackQLDriver struct {
 	handlerCtx      handler.HandlerContext
-	txnOrchestrator transact.Orchestrator
+	txnOrchestrator tsm_physio.Orchestrator
 }
 
 func (dr *basicStackQLDriver) CloneSQLBackend() sqlbackend.ISQLBackend {
@@ -164,7 +169,7 @@ func (dr *basicStackQLDriver) SplitCompoundQuery(s string) ([]string, error) {
 }
 
 func NewStackQLDriver(handlerCtx handler.HandlerContext) (StackQLDriver, error) {
-	txnProvider, txnProviderErr := transact.GetProviderInstance(
+	txnProvider, txnProviderErr := tsm_physio.GetProviderInstance(
 		handlerCtx.GetTxnCoordinatorCtx())
 	if txnProviderErr != nil {
 		return nil, txnProviderErr
@@ -173,6 +178,11 @@ func NewStackQLDriver(handlerCtx handler.HandlerContext) (StackQLDriver, error) 
 	if orcErr != nil {
 		return nil, orcErr
 	}
+	tsmInstance, walError := tsm_physio.GetTSM(handlerCtx)
+	if walError != nil {
+		return nil, walError
+	}
+	handlerCtx.SetTSM(tsmInstance)
 	return &basicStackQLDriver{
 		handlerCtx:      handlerCtx,
 		txnOrchestrator: txnOrchestrator,

--- a/internal/stackql/handler/handler.go
+++ b/internal/stackql/handler/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stackql/any-sdk/anysdk"
 	"github.com/stackql/any-sdk/pkg/nomenclature"
+	"github.com/stackql/stackql/internal/stackql/acid/tsm"
 	"github.com/stackql/stackql/internal/stackql/acid/txn_context"
 	"github.com/stackql/stackql/internal/stackql/bundle"
 	"github.com/stackql/stackql/internal/stackql/constants"
@@ -85,6 +86,9 @@ type HandlerContext interface { //nolint:revive // don't mind stuttering this on
 
 	GetRollbackType() constants.RollbackType
 	UpdateRollbackType(rollbackTypeStr string) error
+
+	GetTSM() (tsm.TSM, bool)
+	SetTSM(tsm.TSM)
 }
 
 type standardHandlerContext struct {
@@ -118,6 +122,15 @@ type standardHandlerContext struct {
 	txnCoordinatorCtx   txn_context.ITransactionCoordinatorContext
 	typCfg              typing.Config
 	sessionContext      dto.SessionContext
+	walInstance         tsm.TSM
+}
+
+func (hc *standardHandlerContext) GetTSM() (tsm.TSM, bool) {
+	return hc.walInstance, hc.walInstance != nil
+}
+
+func (hc *standardHandlerContext) SetTSM(w tsm.TSM) {
+	hc.walInstance = w
 }
 
 func (hc *standardHandlerContext) GetTxnCoordinatorCtx() txn_context.ITransactionCoordinatorContext {

--- a/internal/stackql/httpmiddleware/httpmiddleware.go
+++ b/internal/stackql/httpmiddleware/httpmiddleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackql/any-sdk/anysdk"
 	"github.com/stackql/any-sdk/pkg/requesttranslate"
 	"github.com/stackql/stackql/internal/stackql/handler"
+	"github.com/stackql/stackql/internal/stackql/logging"
 	"github.com/stackql/stackql/internal/stackql/provider"
 )
 
@@ -70,6 +71,8 @@ func HTTPApiCallFromRequest(
 			handlerCtx.GetOutErrFile().Write([]byte(fmt.Sprintf("http request body = '%s'\n", bodyStr)))
 		}
 	}
+	walObj, _ := handlerCtx.GetTSM()
+	logging.GetLogger().Debugf("Proof of invariant: walObj = %v", walObj)
 	r, err := httpClient.Do(translatedRequest)
 	if handlerCtx.GetRuntimeContext().HTTPLogEnabled { //nolint:nestif // acceptable
 		if r != nil {

--- a/test/mockserver/README.md
+++ b/test/mockserver/README.md
@@ -4,7 +4,7 @@
 
 ## Mock Server
 
-We are using the java [mockserver](https://www.mock-server.com/) tool.
+We are using the java [mockserver](https://www.mock-server.com/) tool.  As of now, this requires `java 11` and **not** some newer version; otherwise consequences are errors in the `BouncyCastle` TLS library.
 
 Some doco on creating expectations [here](https://www.mock-server.com/mock_server/creating_expectations.html#button_match_request_by_query_parameter_name_regex).
 


### PR DESCRIPTION
## Description

- This is a technical change, function unchanged, interfaces altered to support upcoming functions.
- Added Transaction Storage Manager (TSM) placeholder with access to sites of mutation.
- Separate interface from implementation to avoid import cycles.
- ACID ideation based upon ARIES and canonical RDBMSs.
- Updated linter.
- Pin `psycopg` versions due to OS runner error on some regression in `psycopg[binary]==3.1.15`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Explanation**: This is a technical change, function unchanged, interfaces altered to support upcoming functions.

## Issues referenced.

#212 

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

New TSM interface is stable in `stackql`; all automated tests pass.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
