### PR TITLE
in-clause-defects

### DIFF
--- a/internal/stackql/dependencyplanner/dependencyplanner.go
+++ b/internal/stackql/dependencyplanner/dependencyplanner.go
@@ -249,7 +249,6 @@ func (dp *standardDependencyPlanner) Plan() error {
 	if err != nil {
 		return err
 	}
-	dp.primaryTcc = dp.tcc.Clone()
 	v := astvisit.NewQueryRewriteAstVisitor(
 		dp.annotatedAST,
 		dp.handlerCtx,

--- a/internal/stackql/dependencyplanner/dependencyplanner.go
+++ b/internal/stackql/dependencyplanner/dependencyplanner.go
@@ -155,7 +155,7 @@ func (dp *standardDependencyPlanner) Plan() error {
 				return insErr
 			}
 			stream := streaming.NewNopMapStream()
-			err = dp.orchestrate(annotation, insPsc, dp.defaultStream, stream)
+			err = dp.orchestrate(unit.GetEquivalencyGroup(), annotation, insPsc, dp.defaultStream, stream)
 			if err != nil {
 				return err
 			}
@@ -202,7 +202,7 @@ func (dp *standardDependencyPlanner) Plan() error {
 						if streamErr != nil {
 							return streamErr
 						}
-						err = dp.orchestrate(annotation, insPsc, dp.defaultStream, stream)
+						err = dp.orchestrate(-1, annotation, insPsc, dp.defaultStream, stream)
 						if err != nil {
 							return err
 						}
@@ -213,7 +213,7 @@ func (dp *standardDependencyPlanner) Plan() error {
 						if err != nil {
 							return err
 						}
-						err = dp.orchestrate(toAnnotation, insPsc, stream, streaming.NewNopMapStream())
+						err = dp.orchestrate(-1, toAnnotation, insPsc, stream, streaming.NewNopMapStream())
 						if err != nil {
 							return err
 						}
@@ -249,6 +249,7 @@ func (dp *standardDependencyPlanner) Plan() error {
 	if err != nil {
 		return err
 	}
+	dp.primaryTcc = dp.tcc.Clone()
 	v := astvisit.NewQueryRewriteAstVisitor(
 		dp.annotatedAST,
 		dp.handlerCtx,
@@ -337,6 +338,7 @@ func (dp *standardDependencyPlanner) processOrphan(
 }
 
 func (dp *standardDependencyPlanner) orchestrate(
+	equivalencyGroupID int64,
 	annotationCtx taxonomy.AnnotationCtx,
 	insPsc drm.PreparedStatementCtx,
 	inStream streaming.MapStream,
@@ -347,6 +349,16 @@ func (dp *standardDependencyPlanner) orchestrate(
 		dp.handlerCtx.GetSQLEngine(),
 		dp.handlerCtx.GetTxnCounterMgr(),
 	)
+	if equivalencyGroupID > 0 {
+		tcc, ok := dp.equivalencyGroupTCCs[equivalencyGroupID]
+		if ok {
+			tn, _ := rc.GetTableTxnCounters()
+			setErr := rc.SetTableTxnCounters(tn, tcc)
+			if setErr != nil {
+				return setErr
+			}
+		}
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/stackql/drm/prepared_statement_args.go
+++ b/internal/stackql/drm/prepared_statement_args.go
@@ -96,9 +96,6 @@ func (ca *standardPreparedStatementArgs) compose() (childQueryComposition, error
 			return nil, err
 		}
 		childQueryStrings = append(childQueryStrings, childResponse.GetQueryString())
-		if len(ca.GetArgs()) >= k {
-			varArgs = append(varArgs, ca.GetArgs()[j:k]...)
-		}
 		varArgs = append(varArgs, childResponse.GetVarArgs()...)
 		j = k
 	}

--- a/internal/stackql/responsehandler/responsehandler.go
+++ b/internal/stackql/responsehandler/responsehandler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stackql/stackql/internal/stackql/handler"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
-	"github.com/stackql/stackql/internal/stackql/logging"
 	"github.com/stackql/stackql/internal/stackql/output"
 )
 
@@ -24,42 +23,42 @@ func handleEmptyWriter(outputWriter output.IOutputWriter, err error) {
 func HandleResponse(handlerCtx handler.HandlerContext, response internaldto.ExecutorOutput) error {
 	var outputWriter output.IOutputWriter
 	var err error
-	logging.GetLogger().Debugln(fmt.Sprintf("response from query = '%v'", response.GetSQLResult()))
 	if response.GetMessages() != nil {
 		for _, msg := range response.GetMessages() {
 			handlerCtx.GetOutErrFile().Write([]byte(msg + fmt.Sprintln(""))) //nolint:errcheck // outstream write
 		}
 	}
-	//nolint:staticcheck // TODO: review
-	if response.GetSQLResult() != nil && response.GetSQLResult() != nil && response.GetError() == nil {
+	sqlResult := response.GetSQLResult()
+	sqlErr := response.GetError()
+	if sqlResult != nil && sqlErr == nil {
 		outputWriter, err = output.GetOutputWriter(
 			handlerCtx.GetOutfile(),
 			handlerCtx.GetOutErrFile(),
 			internaldto.OutputContext{
 				RuntimeContext: handlerCtx.GetRuntimeContext(),
-				Result:         response.GetSQLResult(),
+				Result:         sqlResult,
 			},
 		)
 		if outputWriter == nil || err != nil {
 			handleEmptyWriter(outputWriter, err)
 			return err
 		}
-		outputWriter.Write(response.GetSQLResult()) //nolint:errcheck // outstream write
-	} else if response.GetError() != nil {
+		outputWriter.Write(sqlResult) //nolint:errcheck // outstream write
+	} else if sqlErr != nil {
 		outputWriter, err = output.GetOutputWriter(
 			handlerCtx.GetOutfile(),
 			handlerCtx.GetOutErrFile(),
 			internaldto.OutputContext{
 				RuntimeContext: handlerCtx.GetRuntimeContext(),
-				Result:         response.GetSQLResult(),
+				Result:         sqlResult,
 			},
 		)
 		if outputWriter == nil || err != nil {
 			handleEmptyWriter(outputWriter, err)
-			return response.GetError()
+			return sqlErr
 		}
-		outputWriter.WriteError(response.GetError(), handlerCtx.GetErrorPresentation()) //nolint:errcheck // outstream write
-		return response.GetError()
+		outputWriter.WriteError(sqlErr, handlerCtx.GetErrorPresentation()) //nolint:errcheck // outstream write
+		return sqlErr
 	}
 	return err
 }

--- a/internal/stackql/router/parameter_router.go
+++ b/internal/stackql/router/parameter_router.go
@@ -242,7 +242,9 @@ func (pr *standardParameterRouter) GetOnConditionDataFlows() (dataflow.Collectio
 			return nil, err
 		}
 	}
+	var tableEquivalencyID int64
 	for k, v := range pr.tableToAnnotationCtx {
+		tableEquivalencyID++ // start at 1 for > 0 logic
 		for k1, param := range v.GetParameters() {
 			switch param := param.(type) { //nolint:gocritic // TODO: review
 			case parserutil.ParameterMetadata:
@@ -267,7 +269,7 @@ func (pr *standardParameterRouter) GetOnConditionDataFlows() (dataflow.Collectio
 							clonedParams,
 						)
 						sourceVertexIteration := dataflow.NewStandardDataFlowVertex(clonedAnnotationCtx, k, rv.GetNextID())
-						sourceVertexIteration.SetEquivalencyGroup(1)
+						sourceVertexIteration.SetEquivalencyGroup(tableEquivalencyID)
 						rv.AddVertex(sourceVertexIteration)
 					}
 					return rv, nil

--- a/test/mockserver/expectations/static-gcp-expectations.json
+++ b/test/mockserver/expectations/static-gcp-expectations.json
@@ -109,6 +109,17 @@
   {
     "httpRequest": {
       "method": "GET",
+      "path": "/v1/projects/empty-project/aggregated/usableSubnetworks"
+    },
+    "httpResponse": {
+      "body": {
+        "subnetworks": []
+      }
+    }
+  }, 
+  {
+    "httpRequest": {
+      "method": "GET",
       "path": "/projects/testing-project/zones/australia-southeast1-a/acceleratorTypes"
     },
     "httpResponse": {

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -2784,6 +2784,63 @@ Select Subquery Join With Path Parameters inside IN Scalars inside WHERE Clause 
     ...    ${outputStr}
     ...    stdout=${CURDIR}/tmp/Select-Subquery-Join-With-Path-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
 
+Select Subquery Join With Path Parameters inside IN Scalars Including Empty inside WHERE Clause Returns Expected Result
+    ${inputStr} =     Catenate
+    ...    select 
+    ...    subnets.subnetwork, 
+    ...    s2.proj 
+    ...    from 
+    ...    ( 
+    ...      select 
+    ...      ipCidrRange, 
+    ...      subnetwork 
+    ...      from google.container."projects.aggregated.usableSubnetworks" 
+    ...      where 
+    ...      projectsId in ('testing-project', 'another-project', 'yet-another-project', 'empty-project') 
+    ...      order by subnetwork desc 
+    ...    ) subnets 
+    ...    inner join 
+    ...    (
+    ...      select 
+    ...      ipCidrRange, 
+    ...      subnetwork, 
+    ...      split_part(subnetwork, '/', 2) as proj 
+    ...      from google.container."projects.aggregated.usableSubnetworks" 
+    ...      where projectsId in ('testing-project', 'another-project', 'yet-another-project', 'empty-project') 
+    ...      order by subnetwork desc 
+    ...    ) s2 
+    ...    on 
+    ...    subnets.subnetwork = s2.subnetwork 
+    ...    order by subnets.subnetwork desc
+    ...    ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}subnetwork${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}proj${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}|${SPACE}yet-another-project${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/yet-another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}|${SPACE}yet-another-project${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}testing-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/testing-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}testing-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}another-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    ...    |${SPACE}projects/another-project/regions/australia-southeast1/subnetworks/sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}another-project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-----------------------------------------------------------------------------|---------------------|
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Select-Subquery-Join-With-Path-Parameters-inside-IN-Scalars-Including-Empty-inside-WHERE-Clause-Returns-Expected-Result.tmp
+
 Select Subquery Join With Parameters inside IN Scalars Plus More inside WHERE Clause Returns Expected Result
     ${inputStr} =     Catenate
     ...    select 


### PR DESCRIPTION
## Description

- Fix defect that caused nil result sets inside `IN` subclause responses to fail most of the time.
- Remove spurious control parameter serialization.
- Expand control parameter equivalency to cover selections.
- Added robot test `Select Subquery Join With Path Parameters inside IN Scalars Including Empty inside WHERE Clause Returns Expected Result`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

#314 

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Select Subquery Join With Path Parameters inside IN Scalars Including Empty inside WHERE Clause Returns Expected Result`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
