### PR TITLE
aggressive-dependency-versioning

### DIFF
--- a/cicd/requirements.txt
+++ b/cicd/requirements.txt
@@ -1,5 +1,5 @@
-psycopg2-binary==2.9.9
-psycopg[binary]==3.1.14
-PyYaml
-robotframework
+psycopg2-binary>=2.9.9
+psycopg[binary]>=3.1.16
+PyYaml>=6.0.1
+robotframework>=6.1.1
 sqlalchemy==1.4.44


### PR DESCRIPTION
## Description

- Following on from buggy `psycopg` version `3.1.15` failures, we will resume a protected aggressive track.

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

All automated tests pass, whereas when `psycopg` was set to version `3.1.15`, the `MacOS Build` .

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
