### PR TITLE
intelligent-bench

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -322,6 +322,7 @@ jobs:
         echo "##### Comparing to max threshold #####"
         echo ""
         benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
+        # shellcheck disable=SC2002
         nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
           | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \
           | grep '[+-][0-9][0-9]\.[0-9][0-9]*[%]' \

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -322,7 +322,6 @@ jobs:
         echo "##### Comparing to max threshold #####"
         echo ""
         benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
-        # shellcheck disable=SC2002,SC2062
         nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
           | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \
           | grep [+-][0-9][0-9]\.[0-9][0-9]*[%] \

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -248,6 +248,7 @@ jobs:
       run: |
         git config --global "url.https://${GH_ACCESS_TOKEN}@github.com/.insteadOf" https://github.com/
         go get -v -t -d ./...
+        go install golang.org/x/perf/cmd/benchstat@latest
       env:
         GH_ACCESS_TOKEN: ${{env.GH_ACCESS_TOKEN}}
         GOPRIVATE: ${{env.GOPRIVATE}}
@@ -295,7 +296,47 @@ jobs:
     
     - name: Benchmark
       if: success()
-      run: go test -run='^$' -bench . -count=3 ./...
+      run: |
+        outFile="cicd/log/current-bench-nocache.txt"
+        baselineRefFile="cicd/ref/bench/baseline-go-bench.log"
+        thresholdRefFile="cicd/ref/bench/max-threshold-go-bench.log"
+        go test -run='^$' -bench . -benchtime=100x -count=6 \
+          --tags "json1 sqleanall" --ldflags "-X stackql/internal/stackql/planbuilder.PlanCacheEnabled=false"  \
+          ./... > ${outFile}
+        if [ "$?" = "0" ]; then
+          echo "Benchmarking run completed successfully"
+        else
+          echo "Benchmarking run failed"
+          exit 1
+        fi
+        cat ${outFile}
+        echo ""
+        echo "##### Raw benchstat on current run #####"
+        echo ""
+        benchstat ${outFile} | tee cicd/log/raw-benchstat.txt
+        echo ""
+        echo "##### Comparing to baseline #####"
+        echo ""
+        benchstat -row .name -table .config -ignore goos,goarch,cpu ${baselineRefFile} ${outFile} | tee cicd/log/comparison-benchstat.txt
+        echo ""
+        echo "##### Comparing to max threshold #####"
+        echo ""
+        benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
+        nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
+          | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \
+          | grep [+-][0-9][0-9]\.[0-9][0-9]*[%] \
+          | grep -v [-].* \
+        )
+        if [ -z "${nonNegativeComparisons}" ]; then
+          echo "All max threshold comparisons are negative: this is acceptable"
+        else
+          echo "Some max threshold comparisons are positive or zero: this is unacceptable"
+          echo ""
+          echo "##### Non-negative comparisons #####"
+          echo "${nonNegativeComparisons}"
+          echo ""
+          exit 1
+        fi
 
     - name: Mock Server Download
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -333,6 +333,7 @@ jobs:
         echo "${comparisons}"
         nonNegativeComparisons=$( echo "${comparisons}" \
           | grep -v [-].* \
+          || true
         )
         echo "completed comparison logic"
         if [ -z "${nonNegativeComparisons}" ]; then

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -322,9 +322,16 @@ jobs:
         echo "##### Comparing to max threshold #####"
         echo ""
         benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
-        nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
+        # shellcheck disable=SC2002,SC2062
+        comparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
           | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \
-          | grep [+-][0-9][0-9]\.[0-9][0-9]*[%] \
+          | grep [+-][0-9][0-9]*\.[0-9][0-9]*[%] \
+        )
+        echo ""
+        echo "##### Comparisons #####"
+        echo ""
+        echo "${comparisons}"
+        nonNegativeComparisons=$( echo "${comparisons}" \
           | grep -v [-].* \
         )
         echo "completed comparison logic"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -331,6 +331,7 @@ jobs:
         echo "##### Comparisons #####"
         echo ""
         echo "${comparisons}"
+        # shellcheck disable=SC2062
         nonNegativeComparisons=$( echo "${comparisons}" \
           | grep -v [-].* \
           || true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -322,11 +322,11 @@ jobs:
         echo "##### Comparing to max threshold #####"
         echo ""
         benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
-        # shellcheck disable=SC2002
+        # shellcheck disable=SC2002,SC2062
         nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
           | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \
-          | grep '[+-][0-9][0-9]\.[0-9][0-9]*[%]' \
-          | grep -v '[-].*' \
+          | grep [+-][0-9][0-9]\.[0-9][0-9]*[%] \
+          | grep -v [-].* \
         )
         if [ -z "${nonNegativeComparisons}" ]; then
           echo "All max threshold comparisons are negative: this is acceptable"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -321,9 +321,7 @@ jobs:
         echo ""
         echo "##### Comparing to max threshold #####"
         echo ""
-        benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} > cicd/log/threshold-comparison-benchstat.txt
-        # shellcheck disable=SC2002
-        cat cicd/log/threshold-comparison-benchstat.txt
+        benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
         # shellcheck disable=SC2002,SC2062
         nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
           | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -327,6 +327,7 @@ jobs:
           | grep [+-][0-9][0-9]\.[0-9][0-9]*[%] \
           | grep -v [-].* \
         )
+        echo "completed comparison logic"
         if [ -z "${nonNegativeComparisons}" ]; then
           echo "All max threshold comparisons are negative: this is acceptable"
         else

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -302,14 +302,14 @@ jobs:
         thresholdRefFile="cicd/ref/bench/max-threshold-go-bench.log"
         go test -run='^$' -bench . -benchtime=100x -count=6 \
           --tags "json1 sqleanall" --ldflags "-X stackql/internal/stackql/planbuilder.PlanCacheEnabled=false"  \
-          ./... > ${outFile}
+          ./... | tee ${outFile}
+        # shellcheck disable=SC2181
         if [ "$?" = "0" ]; then
           echo "Benchmarking run completed successfully"
         else
           echo "Benchmarking run failed"
           exit 1
         fi
-        cat ${outFile}
         echo ""
         echo "##### Raw benchstat on current run #####"
         echo ""
@@ -324,8 +324,8 @@ jobs:
         benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
         nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
           | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \
-          | grep [+-][0-9][0-9]\.[0-9][0-9]*[%] \
-          | grep -v [-].* \
+          | grep '[+-][0-9][0-9]\.[0-9][0-9]*[%]' \
+          | grep -v '[-].*' \
         )
         if [ -z "${nonNegativeComparisons}" ]; then
           echo "All max threshold comparisons are negative: this is acceptable"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -321,7 +321,9 @@ jobs:
         echo ""
         echo "##### Comparing to max threshold #####"
         echo ""
-        benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} | tee cicd/log/threshold-comparison-benchstat.txt
+        benchstat -row .name -table .config -ignore goos,goarch,cpu ${thresholdRefFile} ${outFile} > cicd/log/threshold-comparison-benchstat.txt
+        # shellcheck disable=SC2002
+        cat cicd/log/threshold-comparison-benchstat.txt
         # shellcheck disable=SC2002,SC2062
         nonNegativeComparisons=$( cat cicd/log/threshold-comparison-benchstat.txt \
           | sed 's/.*\([+-][0-9][0-9]\.[0-9][0-9]*[%]\).*/\1/' \

--- a/cicd/ref/bench/baseline-go-bench.log
+++ b/cicd/ref/bench/baseline-go-bench.log
@@ -1,0 +1,34 @@
+goos: linux
+goarch: amd64
+pkg: github.com/stackql/stackql/internal/stackql/driver
+cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   6400764 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   6418996 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   6451862 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   6598328 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   7677712 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   6482811 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   6785489 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   6846661 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   6786778 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   6815967 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   6885115 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   6786656 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  11455720 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  11635215 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  12137071 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  11957348 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  12013644 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  11845601 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  10491956 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  10402432 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  10280864 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  10541940 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  10451181 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  10596109 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  10224503 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  10453230 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  10115479 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  10275647 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  10389938 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  10171688 ns/op

--- a/cicd/ref/bench/max-threshold-go-bench.log
+++ b/cicd/ref/bench/max-threshold-go-bench.log
@@ -1,0 +1,34 @@
+goos: linux
+goarch: amd64
+pkg: github.com/stackql/stackql/internal/stackql/driver
+cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   9000000 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   9000000 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   9000000 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   9000000 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   9000000 ns/op
+BenchmarkSelectGoogleComputeInstanceDriver-2                                 	     100	   9000000 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   9000000 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   9000000 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   9000000 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   9000000 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   9000000 ns/op
+BenchmarkParallelProjectSelectGoogleComputeInstanceDriver-2                  	     100	   9000000 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  14000000 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  14000000 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  14000000 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  14000000 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  14000000 ns/op
+BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver-2            	     100	  14000000 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  14000000 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  14000000 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  14000000 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  14000000 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  14000000 ns/op
+BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2    	     100	  14000000 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  14000000 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  14000000 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  14000000 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  14000000 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  14000000 ns/op
+BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver-2   	     100	  14000000 ns/op

--- a/internal/stackql/driver/driver_bench_test.go
+++ b/internal/stackql/driver/driver_bench_test.go
@@ -2,8 +2,8 @@ package driver_test
 
 import (
 	"fmt"
+	"io"
 	"net/url"
-	"os"
 	"testing"
 
 	. "github.com/stackql/stackql/internal/stackql/driver"
@@ -44,12 +44,12 @@ func BenchmarkSelectGoogleComputeInstanceDriver(b *testing.B) {
 		b.Fatalf("Test failed: %v", err)
 	}
 
-	stringQuery := `select name, zone from google.compute.instances where zone = 'australia-southeast1-b' AND /* */ project = 'testing-project';`
+	stringQuery := `select count(1) as inst_count from google.compute.instances where zone = 'australia-southeast1-b' AND /* */ project = 'testing-project';`
 
 	runtimeCtx.LogLevelStr = "fatal"
 	handlerCtx, err := handler.GetHandlerCtx(stringQuery, *runtimeCtx, lrucache.NewLRUCache(int64(runtimeCtx.QueryCacheSize)), inputBundle)
-	handlerCtx.SetOutfile(os.Stdout)
-	handlerCtx.SetOutErrFile(os.Stderr)
+	handlerCtx.SetOutfile(io.Discard)
+	handlerCtx.SetOutErrFile(io.Discard)
 
 	dr, _ := NewStackQLDriver(handlerCtx)
 
@@ -98,8 +98,8 @@ func BenchmarkParallelProjectSelectGoogleComputeInstanceDriver(b *testing.B) {
 	stringQuery := `select count(1) as inst_count from google.compute.instances where zone = 'australia-southeast1-b' AND /* */ project in ('testing-project', 'testing-project-two');`
 
 	handlerCtx, err := handler.GetHandlerCtx(stringQuery, *runtimeCtx, lrucache.NewLRUCache(int64(runtimeCtx.QueryCacheSize)), inputBundle)
-	handlerCtx.SetOutfile(os.Stdout)
-	handlerCtx.SetOutErrFile(os.Stderr)
+	handlerCtx.SetOutfile(io.Discard)
+	handlerCtx.SetOutErrFile(io.Discard)
 
 	dr, _ := NewStackQLDriver(handlerCtx)
 
@@ -308,8 +308,8 @@ func BenchmarkHighlyParallelProjectSelectGoogleComputeInstanceDriver(b *testing.
 	  ;`
 
 	handlerCtx, err := handler.GetHandlerCtx(stringQuery, *runtimeCtx, lrucache.NewLRUCache(int64(runtimeCtx.QueryCacheSize)), inputBundle)
-	handlerCtx.SetOutfile(os.Stdout)
-	handlerCtx.SetOutErrFile(os.Stderr)
+	handlerCtx.SetOutfile(io.Discard)
+	handlerCtx.SetOutErrFile(io.Discard)
 
 	dr, _ := NewStackQLDriver(handlerCtx)
 
@@ -518,8 +518,8 @@ func BenchmarkLoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver(b *
 	  ;`
 
 	handlerCtx, err := handler.GetHandlerCtx(stringQuery, *runtimeCtx, lrucache.NewLRUCache(int64(runtimeCtx.QueryCacheSize)), inputBundle)
-	handlerCtx.SetOutfile(os.Stdout)
-	handlerCtx.SetOutErrFile(os.Stderr)
+	handlerCtx.SetOutfile(io.Discard)
+	handlerCtx.SetOutErrFile(io.Discard)
 
 	dr, _ := NewStackQLDriver(handlerCtx)
 
@@ -728,8 +728,8 @@ func BenchmarkUnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver(b 
 	  ;`
 
 	handlerCtx, err := handler.GetHandlerCtx(stringQuery, *runtimeCtx, lrucache.NewLRUCache(int64(runtimeCtx.QueryCacheSize)), inputBundle)
-	handlerCtx.SetOutfile(os.Stdout)
-	handlerCtx.SetOutErrFile(os.Stderr)
+	handlerCtx.SetOutfile(io.Discard)
+	handlerCtx.SetOutErrFile(io.Discard)
 
 	dr, _ := NewStackQLDriver(handlerCtx)
 

--- a/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
+++ b/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
@@ -27,41 +27,39 @@ components:
         views:
           'select':
               predicate: sqlDialect == "sqlite3"
-              ddl: '
+              ddl: |
                 SELECT 
-                JSON_EXTRACT(Properties, ''$.Arn'') as Arn,
-                JSON_EXTRACT(Properties, ''$.BucketName'') as BucketName,
-                JSON_EXTRACT(Properties, ''$.DomainName'') as DomainName,
-                JSON_EXTRACT(Properties, ''$.RegionalDomainName'') as RegionalDomainName,
-                JSON_EXTRACT(Properties, ''$.DualStackDomainName'') as DualStackDomainName,
-                JSON_EXTRACT(Properties, ''$.WebsiteURL'') as WebsiteURL,
-                JSON_EXTRACT(Properties, ''$.OwnershipControls.Rules[0].ObjectOwnership'') as ObjectOwnership,
-                IIF(JSON_EXTRACT(Properties, ''$.PublicAccessBlockConfiguration.RestrictPublicBuckets'') = 0, ''false'', ''true'') as RestrictPublicBuckets,
-                IIF(JSON_EXTRACT(Properties, ''$.PublicAccessBlockConfiguration.BlockPublicPolicy'') = 0, ''false'', ''true'') as BlockPublicPolicy,
-                IIF(JSON_EXTRACT(Properties, ''$.PublicAccessBlockConfiguration.BlockPublicAcls'') = 0, ''false'', ''true'') as BlockPublicAcls,
-                IIF(JSON_EXTRACT(Properties, ''$.PublicAccessBlockConfiguration.IgnorePublicAcls'') = 0, ''false'', ''true'') as IgnorePublicAcls,
-                JSON_EXTRACT(Properties, ''$.Tags'') as Tags
-                FROM aws.cloud_control.resources WHERE region = ''ap-southeast-1'' and data__TypeName = ''AWS::S3::Bucket''
+                JSON_EXTRACT(Properties, '$.Arn') as Arn,
+                JSON_EXTRACT(Properties, '$.BucketName') as BucketName,
+                JSON_EXTRACT(Properties, '$.DomainName') as DomainName,
+                JSON_EXTRACT(Properties, '$.RegionalDomainName') as RegionalDomainName,
+                JSON_EXTRACT(Properties, '$.DualStackDomainName') as DualStackDomainName,
+                JSON_EXTRACT(Properties, '$.WebsiteURL') as WebsiteURL,
+                JSON_EXTRACT(Properties, '$.OwnershipControls.Rules[0].ObjectOwnership') as ObjectOwnership,
+                IIF(JSON_EXTRACT(Properties, '$.PublicAccessBlockConfiguration.RestrictPublicBuckets') = 0, 'false', 'true') as RestrictPublicBuckets,
+                IIF(JSON_EXTRACT(Properties, '$.PublicAccessBlockConfiguration.BlockPublicPolicy') = 0, 'false', 'true') as BlockPublicPolicy,
+                IIF(JSON_EXTRACT(Properties, '$.PublicAccessBlockConfiguration.BlockPublicAcls') = 0, 'false', 'true') as BlockPublicAcls,
+                IIF(JSON_EXTRACT(Properties, '$.PublicAccessBlockConfiguration.IgnorePublicAcls') = 0, 'false', 'true') as IgnorePublicAcls,
+                JSON_EXTRACT(Properties, '$.Tags') as Tags
+                FROM aws.cloud_control.resources WHERE region = 'ap-southeast-1' and data__TypeName = 'AWS::S3::Bucket'
                 ;
-                '
               fallback:
                 predicate: sqlDialect == "postgres"
-                ddl: '
+                ddl: |
                   SELECT 
-                  json_extract_path_text(Properties, ''Arn'') as Arn,
-                  json_extract_path_text(Properties, ''BucketName'') as BucketName,
-                  json_extract_path_text(Properties, ''DomainName'') as DomainName,
-                  json_extract_path_text(Properties, ''RegionalDomainName'') as RegionalDomainName,
-                  json_extract_path_text(Properties, ''DualStackDomainName'') as DualStackDomainName,
-                  json_extract_path_text(Properties, ''WebsiteURL'') as WebsiteURL,
-                  json_extract_path_text(Properties, ''OwnershipControls'', ''Rules'', ''0'', ''ObjectOwnership'') as ObjectOwnership,
-                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''RestrictPublicBuckets'') = ''0'' THEN ''false'' ELSE ''true'' END as RestrictPublicBuckets,
-                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''BlockPublicPolicy'') = ''0'' THEN ''false'' ELSE ''true'' END as BlockPublicPolicy,
-                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''BlockPublicAcls'') = ''0'' THEN ''false'' ELSE ''true'' END as BlockPublicAcls,
-                  CASE WHEN json_extract_path_text(Properties, ''PublicAccessBlockConfiguration'', ''IgnorePublicAcls'') = ''0'' THEN ''false'' ELSE ''true'' END as IgnorePublicAcls,
-                  json_extract_path_text(Properties, ''Tags'') as Tags
-                  FROM aws.cloud_control.resources WHERE region = ''ap-southeast-1'' and data__TypeName = ''AWS::S3::Bucket''
+                  json_extract_path_text(Properties, 'Arn') as Arn,
+                  json_extract_path_text(Properties, 'BucketName') as BucketName,
+                  json_extract_path_text(Properties, 'DomainName') as DomainName,
+                  json_extract_path_text(Properties, 'RegionalDomainName') as RegionalDomainName,
+                  json_extract_path_text(Properties, 'DualStackDomainName') as DualStackDomainName,
+                  json_extract_path_text(Properties, 'WebsiteURL') as WebsiteURL,
+                  json_extract_path_text(Properties, 'OwnershipControls', 'Rules', '0', 'ObjectOwnership') as ObjectOwnership,
+                  CASE WHEN json_extract_path_text(Properties, 'PublicAccessBlockConfiguration', 'RestrictPublicBuckets') = '0' THEN 'false' ELSE 'true' END as RestrictPublicBuckets,
+                  CASE WHEN json_extract_path_text(Properties, 'PublicAccessBlockConfiguration', 'BlockPublicPolicy') = '0' THEN 'false' ELSE 'true' END as BlockPublicPolicy,
+                  CASE WHEN json_extract_path_text(Properties, 'PublicAccessBlockConfiguration', 'BlockPublicAcls') = '0' THEN 'false' ELSE 'true' END as BlockPublicAcls,
+                  CASE WHEN json_extract_path_text(Properties, 'PublicAccessBlockConfiguration', 'IgnorePublicAcls') = '0' THEN 'false' ELSE 'true' END as IgnorePublicAcls,
+                  json_extract_path_text(Properties, 'Tags') as Tags
+                  FROM aws.cloud_control.resources WHERE region = 'ap-southeast-1' and data__TypeName = 'AWS::S3::Bucket'
                   ;
-                  '
 security:
   - hmac: []


### PR DESCRIPTION
## Description

- Benchmark tests without plan cache.
- Benchmark tests statistics collection.
- Idiomatic `yaml` strings in doc-based views example.
- Diagnostics and thresholds.
- Comparison against historical benchmark baseline.
- Comparison against arbitrary benchmark maximum threshold.
- Becnhmark CI step enforces max threshold compliance.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

#314 

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

From a previous run in a private repository, wherein the benchmarks were **accidentally** compared against historical baseline rather than hard limits, the below output proves that threshold overrun generates the desired CI failure:

```
##### Comparing to max threshold #####

pkg: github.com/stackql/stackql/internal/stackql/driver
                                                                │ cicd/ref/bench/baseline-go-bench.log │ cicd/log/current-bench-nocache.txt  │
                                                                │                sec/op                │    sec/op     vs base               │
SelectGoogleComputeInstanceDriver                                                         6.467m ± 19%   7.807m ± 17%  +20.71% (p=0.002 n=6)
ParallelProjectSelectGoogleComputeInstanceDriver                                          6.801m ±  1%   8.262m ±  2%  +21.47% (p=0.002 n=6)
HighlyParallelProjectSelectGoogleComputeInstanceDriver                                    11.90m ±  4%   14.15m ±  2%  +18.90% (p=0.002 n=6)
LoosenedHighlyParallelProjectSelectGoogleComputeInstanceDriver                            10.47m ±  2%   12.11m ±  2%  +15.68% (p=0.002 n=6)
UnlimitedHighlyParallelProjectSelectGoogleComputeInstanceDriver                           10.25m ±  2%   11.86m ±  2%  +15.69% (p=0.002 n=6)
geomean                                                                                   8.911m         10.56m        +18.47%
Some max threshold comparisons are positive or zero: this is unacceptable

##### Non-negative comparisons #####
+20.71%
+21.47%
+18.90%
+15.68%
+15.69%
+18.47%
```

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
