### PR TITLE
external-benchmark

### DIFF
--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -207,3 +207,63 @@ PG Session Postgres Client V2 Typed Queries
     ...    ${SELECT_AWS_CLOUD_CONTROL_EVENTS_MINIMAL_EXPECTED}
     ...    stdout=${CURDIR}/tmp/PG-Session-Postgres-Client-V2-Typed-Queries.tmp
     [Teardown]    NONE
+
+
+
+High Volume IN Query Is Correct and Performs OK
+    Pass Execution If    "${CONCURRENCY_LIMIT}" == "1"    We only expect performance when concurrency settings are aggressive.
+    ${inputStr} =    Catenate
+    ...              select 
+    ...              instanceId, 
+    ...              ipAddress 
+    ...              from aws.ec2.instances 
+    ...              where 
+    ...              instanceId not in ('some-silly-id')  
+    ...              and region in (
+    ...              'us-east-1',
+    ...              'us-east-2',
+    ...              'us-west-1',
+    ...              'us-west-2',
+    ...              'ap-south-1',
+    ...              'ap-northeast-3',
+    ...              'ap-northeast-2',
+    ...              'ap-southeast-1',
+    ...              'ap-southeast-2',
+    ...              'ap-northeast-1',
+    ...              'ca-central-1',
+    ...              'eu-central-1',
+    ...              'eu-west-1',
+    ...              'eu-west-2',
+    ...              'eu-west-3',
+    ...              'eu-north-1',
+    ...              'sa-east-1'
+    ...              )
+    ...              ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...               ${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}instanceId${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}ipAddress${SPACE}${SPACE}${SPACE}${SPACE}
+    ...               ---------------------+----------------
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               ${SPACE}i-1234567890abcdef0${SPACE}|${SPACE}54.194.252.215
+    ...               (17${SPACE}rows)
+    ...               ${EMPTY}
+    Should PG Client Inline Equal Bench
+    ...    ${CURDIR}
+    ...    ${PSQL_EXE}
+    ...    ${PSQL_MTLS_CONN_STR}
+    ...    ${inputStr}
+    ...    ${outputStr}

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -267,3 +267,4 @@ High Volume IN Query Is Correct and Performs OK
     ...    ${PSQL_MTLS_CONN_STR}
     ...    ${inputStr}
     ...    ${outputStr}
+    ...    max_mean_time=1.7

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -3,6 +3,7 @@
 from asyncio import subprocess
 import json
 import os
+import time
 import typing
 
 from robot.api.deco import keyword, library
@@ -479,6 +480,28 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       query
     )
     return self.should_be_equal(result.stdout, expected_output)
+  
+
+  @keyword
+  def should_PG_client_inline_equal_bench(self, curdir :str, psql_exe :str, psql_conn_str :str, query :str, expected_output :str, max_mean_time :float = 4.0, max_time :float = 10.0, repeat_count = 10, **cfg):
+    times = []
+    for i in range(repeat_count):
+      start_time = time.time()
+      result =    self._run_PG_client_command(
+        curdir,
+        psql_exe,
+        psql_conn_str,
+        query
+      )
+      end_time = time.time()
+      duration = end_time - start_time
+      times.append(duration)
+      self.should_be_equal(result.stdout, expected_output)
+    mean_time = sum(times) / len(times)
+    self.log(f"mean_time = {mean_time}")
+    self.log(f"max_time = {max(times)}")
+    self.should_be_true(mean_time < max_mean_time)
+    return self.should_be_true(all([ t < max_time for t in times ]))
 
 
   @keyword

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -483,7 +483,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
   
 
   @keyword
-  def should_PG_client_inline_equal_bench(self, curdir :str, psql_exe :str, psql_conn_str :str, query :str, expected_output :str, max_mean_time :float = 4.0, max_time :float = 10.0, repeat_count = 10, **cfg):
+  def should_PG_client_inline_equal_bench(self, curdir :str, psql_exe :str, psql_conn_str :str, query :str, expected_output :str, max_mean_time :float = 1.7, max_time :float = 10.0, repeat_count = 10, **cfg):
     times = []
     for i in range(repeat_count):
       start_time = time.time()


### PR DESCRIPTION
## Description

- Added robot test `High Volume IN Query Is Correct and Performs OK`.
- This test serves as a benchmark for a realistic multi cloud query scenario.
- At this stage, test only applies where comncurrency settings are aggressive.
- Limits are pretty conservative, can revisit once more real world data has been gathered.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Explanation**: Including a robot framework based benchmark to mitigate against performance regressions.

## Issues referenced.

Closes #314 

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `High Volume IN Query Is Correct and Performs OK`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
