### PR TITLE
successor-token-repeat-patch

### DIFF
--- a/internal/stackql/provider/auth_util.go
+++ b/internal/stackql/provider/auth_util.go
@@ -109,7 +109,8 @@ const (
 )
 
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	for _, tokenConfig := range t.tokenConfigs {
+	for _, tc := range t.tokenConfigs {
+		tokenConfig := tc
 		switch tokenConfig.tokenLocation {
 		case locationHeader:
 			switch tokenConfig.authType {
@@ -259,7 +260,7 @@ func customAuth(authCtx *dto.AuthCtx, runtimeCtx dto.RuntimeCtx) (*http.Client, 
 	successor, successorExists := authCtx.GetSuccessor()
 	for {
 		if successorExists {
-			successorCredentialsBytes, sbErr := authCtx.GetCredentialsBytes()
+			successorCredentialsBytes, sbErr := successor.GetCredentialsBytes()
 			if sbErr != nil {
 				return nil, fmt.Errorf("successor credentials error: %w", sbErr)
 			}

--- a/test/mockserver/expectations/static-auth-testing-expectations.json
+++ b/test/mockserver/expectations/static-auth-testing-expectations.json
@@ -4,8 +4,8 @@
       "method": "GET",
       "path": "/v1/collectors",
       "headers": {
-        "DD-API-KEY": ["^.+$" ],
-        "DD-APPLICATION-KEY": ["^.+$" ]
+        "DD-API-KEY": ["^myusername$" ],
+        "DD-APPLICATION-KEY": ["^mypassword$" ]
       }
     },
     "httpResponse": {

--- a/test/robot/functional/stackql.resource
+++ b/test/robot/functional/stackql.resource
@@ -54,8 +54,8 @@ Prepare StackQL Environment
     Set Environment Variable    DUMMY_DIGITALOCEAN_PASSWORD    ${DUMMY_DIGITALOCEAN_PASSWORD_STR}
     Set Environment Variable    DB_SETUP_SRC    ${DB_SETUP_SRC}
     Set Environment Variable    GOOGLE_APPLICATION_CREDENTIALS    ${GOOGLE_APPLICATION_CREDENTIALS}
-    Set Environment Variable    DD_API_KEY    %{DD_API_KEY=dummy_dd_api_key}
-    Set Environment Variable    DD_APPLICATION_KEY    %{DD_APPLICATION_KEY=dummy_dd_application_key}
+    Set Environment Variable    DD_API_KEY    %{DD_API_KEY=myusername}
+    Set Environment Variable    DD_APPLICATION_KEY    %{DD_APPLICATION_KEY=mypassword}
     Start All Mock Servers
     Generate Container Credentials for StackQL PG Server mTLS
     Start StackQL PG Server mTLS    ${PG_SRV_PORT_MTLS}    ${PG_SRV_MTLS_CFG_STR}    {}    {}    ${SQL_BACKEND_CFG_STR_CANONICAL}    ${PG_SRV_PORT_DOCKER_MTLS}


### PR DESCRIPTION
## Description

- Fix bug where parent token was attached to all children in `custom` auth.
- Uplift header verification for robot test `Custom Auth Linear Should Send Appropriate Credentials`, in order to ensure correct functionality.



<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Uplift header verification for robot test `Custom Auth Linear Should Send Appropriate Credentials`, in order to ensure correct functionality.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
