### PR TITLE
indirect-placeholders

### DIFF
--- a/internal/stackql/astvisit/param_extract.go
+++ b/internal/stackql/astvisit/param_extract.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	_ ParserParamAstVisitor = &standardParserParamAstVisitor{}
+	_       ParserParamAstVisitor = &standardParserParamAstVisitor{}
+	ordinal int                   //nolint:gochecknoglobals  // TODO: remove this global
 )
 
 type ParserParamAstVisitor interface {
@@ -37,6 +38,11 @@ func NewParamAstVisitor(
 		annotatedAST: annotatedAST,
 		params:       parserutil.NewParameterMap(),
 	}
+}
+
+func (v *standardParserParamAstVisitor) getNextOrdinal() int {
+	ordinal++
+	return ordinal
 }
 
 func (v *standardParserParamAstVisitor) GetParameters() parserutil.ParameterMap {
@@ -711,6 +717,7 @@ func (v *standardParserParamAstVisitor) Visit(node sqlparser.SQLNode) error {
 				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
 					node,
 					rt,
+					v.getNextOrdinal(),
 				))
 			case *sqlparser.ColName:
 				k, err := parserutil.NewUnknownTypeColumnarReference(lt)
@@ -720,6 +727,7 @@ func (v *standardParserParamAstVisitor) Visit(node sqlparser.SQLNode) error {
 				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
 					node,
 					rt,
+					v.getNextOrdinal(),
 				))
 				kr, err := parserutil.NewUnknownTypeColumnarReference(rt)
 				if err != nil {
@@ -728,6 +736,7 @@ func (v *standardParserParamAstVisitor) Visit(node sqlparser.SQLNode) error {
 				v.params.Set(kr, parserutil.NewComparisonParameterMetadata(
 					node,
 					lt,
+					v.getNextOrdinal(),
 				))
 			case sqlparser.ValTuple:
 				k, err := parserutil.NewUnknownTypeColumnarReference(lt)
@@ -737,6 +746,7 @@ func (v *standardParserParamAstVisitor) Visit(node sqlparser.SQLNode) error {
 				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
 					node,
 					rt,
+					v.getNextOrdinal(),
 				))
 			default:
 				logging.GetLogger().Debugf("unhandled type: %T", rt)
@@ -752,6 +762,7 @@ func (v *standardParserParamAstVisitor) Visit(node sqlparser.SQLNode) error {
 				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
 					node,
 					lt,
+					v.getNextOrdinal(),
 				))
 			default:
 			}

--- a/internal/stackql/astvisit/placeholder_param_extract.go
+++ b/internal/stackql/astvisit/placeholder_param_extract.go
@@ -733,6 +733,7 @@ func (v *standardParserPlaceholderParamAstVisitor) Visit(node sqlparser.SQLNode)
 				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
 					node,
 					rt,
+					0,
 				))
 			default:
 			}
@@ -747,6 +748,7 @@ func (v *standardParserPlaceholderParamAstVisitor) Visit(node sqlparser.SQLNode)
 				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
 					node,
 					lt,
+					0,
 				))
 			default:
 			}
@@ -971,7 +973,7 @@ func (v *standardParserPlaceholderParamAstVisitor) Visit(node sqlparser.SQLNode)
 			if err != nil {
 				return err
 			}
-			v.params.Set(k, parserutil.NewPlaceholderParameterMetadata())
+			v.params.Set(k, parserutil.NewPlaceholderParameterMetadata(0))
 		}
 		buf.AstPrintf(node, "%v = %v", node.Name, node.Expr)
 
@@ -1004,7 +1006,7 @@ func (v *standardParserPlaceholderParamAstVisitor) Visit(node sqlparser.SQLNode)
 		if err != nil {
 			return err
 		}
-		err = v.params.Set(k, parserutil.NewPlaceholderParameterMetadata())
+		err = v.params.Set(k, parserutil.NewPlaceholderParameterMetadata(0))
 		if err != nil {
 			return err
 		}

--- a/internal/stackql/dataflow/collection.go
+++ b/internal/stackql/dataflow/collection.go
@@ -60,14 +60,6 @@ func (dc *standardDataFlowCollection) GetNextID() int64 {
 	return dc.maxID
 }
 
-func (dc *standardDataFlowCollection) AddOrUpdateEdgeOld(e Edge) error {
-	dc.AddVertex(e.GetSource())
-	dc.AddVertex(e.GetDest())
-	dc.edges = append(dc.edges, e)
-	dc.g.SetWeightedEdge(e)
-	return nil
-}
-
 func (dc *standardDataFlowCollection) AddOrUpdateEdge(
 	source Vertex,
 	dest Vertex,
@@ -79,7 +71,7 @@ func (dc *standardDataFlowCollection) AddOrUpdateEdge(
 	dc.AddVertex(dest)
 	existingEdge := dc.g.WeightedEdge(source.ID(), dest.ID())
 	if existingEdge == nil {
-		edge := NewStandardDataFlowEdge(source, dest, comparisonExpr, sourceExpr, destColumn)
+		edge := newStandardDataFlowEdge(source, dest, comparisonExpr, sourceExpr, destColumn)
 		dc.edges = append(dc.edges, edge)
 		dc.g.SetWeightedEdge(edge)
 		return nil

--- a/internal/stackql/dataflow/edge.go
+++ b/internal/stackql/dataflow/edge.go
@@ -22,7 +22,7 @@ type standardDataFlowEdge struct {
 	relations    []Relation
 }
 
-func NewStandardDataFlowEdge(
+func newStandardDataFlowEdge(
 	source Vertex,
 	dest Vertex,
 	comparisonExpr *sqlparser.ComparisonExpr,

--- a/internal/stackql/parserutil/parameter_metadata.go
+++ b/internal/stackql/parserutil/parameter_metadata.go
@@ -16,28 +16,38 @@ type ParameterMetadata interface {
 	GetParent() *sqlparser.ComparisonExpr
 	GetVal() interface{}
 	GetTable() sqlparser.SQLNode
+	GetOrdinal() int
 	SetTable(sqlparser.SQLNode) error
 }
 
 type StandardComparisonParameterMetadata struct {
-	Parent *sqlparser.ComparisonExpr
-	Val    interface{}
-	table  sqlparser.SQLNode
+	Parent  *sqlparser.ComparisonExpr
+	Val     interface{}
+	table   sqlparser.SQLNode
+	ordinal int
 }
 
 type PlaceholderParameterMetadata struct {
+	ordinal        int
 	placeholderVal struct{}
 }
 
-func NewComparisonParameterMetadata(parent *sqlparser.ComparisonExpr, val interface{}) ParameterMetadata {
+func NewComparisonParameterMetadata(parent *sqlparser.ComparisonExpr, val interface{}, ordinal int) ParameterMetadata {
 	return &StandardComparisonParameterMetadata{
-		Parent: parent,
-		Val:    val,
+		Parent:  parent,
+		Val:     val,
+		ordinal: ordinal,
 	}
 }
 
-func NewPlaceholderParameterMetadata() ParameterMetadata {
-	return PlaceholderParameterMetadata{}
+func NewPlaceholderParameterMetadata(ordinal int) ParameterMetadata {
+	return &PlaceholderParameterMetadata{
+		ordinal: ordinal,
+	}
+}
+
+func (pm *PlaceholderParameterMetadata) GetOrdinal() int {
+	return pm.ordinal
 }
 
 func (pm *StandardComparisonParameterMetadata) iParameterMetadata() {}
@@ -48,6 +58,10 @@ func (pm *StandardComparisonParameterMetadata) GetParent() *sqlparser.Comparison
 
 func (pm *StandardComparisonParameterMetadata) GetVal() interface{} {
 	return pm.Val
+}
+
+func (pm *StandardComparisonParameterMetadata) GetOrdinal() int {
+	return pm.ordinal
 }
 
 func (pm *StandardComparisonParameterMetadata) GetTable() sqlparser.SQLNode {

--- a/internal/stackql/parserutil/table_parameter_coupling.go
+++ b/internal/stackql/parserutil/table_parameter_coupling.go
@@ -19,6 +19,7 @@ type TableParameterCoupling interface {
 	getParameterMap() ParameterMap
 	AbbreviateMap() (map[string]interface{}, error)
 	Add(ColumnarReference, ParameterMetadata, ParamSourceType) error
+	DeleteByOrdinal(int) bool
 	Clone() TableParameterCoupling
 	GetOnCoupling() TableParameterCoupling
 	GetNotOnCoupling() TableParameterCoupling
@@ -42,6 +43,16 @@ func NewTableParameterCoupling() TableParameterCoupling {
 func (tpc *standardTableParameterCoupling) AndStringMap(rhs map[string]interface{}) ColumnKeyedDatastore {
 	tpc.paramMap.AndStringMap(rhs)
 	return tpc
+}
+
+func (tpc *standardTableParameterCoupling) DeleteByOrdinal(ord int) bool {
+	var rv bool
+	for k, v := range tpc.paramMap.GetMap() {
+		if v.GetOrdinal() == ord {
+			rv = tpc.paramMap.Delete(k)
+		}
+	}
+	return rv
 }
 
 func (tpc *standardTableParameterCoupling) DeleteStringMap(rhs map[string]interface{}) ColumnKeyedDatastore {

--- a/internal/stackql/primitivebuilder/dependent_recursive.go
+++ b/internal/stackql/primitivebuilder/dependent_recursive.go
@@ -38,18 +38,14 @@ func (ss *DependencySubDAGBuilder) Build() error {
 	if err != nil {
 		return err
 	}
-	for i, acbBld := range ss.dependencyBuilders {
+	for _, db := range ss.dependencyBuilders {
+		acbBld := db
 		err = acbBld.Build()
 		if err != nil {
 			return err
 		}
 		graph := ss.graph
-		if i > 0 {
-			graph.NewDependency(ss.dependencyBuilders[i-1].GetTail(), acbBld.GetRoot(), 1.0)
-		}
-		if i == len(ss.dependencyBuilders)-1 {
-			graph.NewDependency(acbBld.GetTail(), ss.dependentBuilder.GetRoot(), 1.0)
-		}
+		graph.NewDependency(acbBld.GetTail(), ss.dependentBuilder.GetRoot(), 1.0)
 	}
 	return nil
 }

--- a/internal/stackql/sql_system/sql/postgres/sqlengine-setup.ddl
+++ b/internal/stackql/sql_system/sql/postgres/sqlengine-setup.ddl
@@ -102,7 +102,7 @@ INSERT INTO "__iql__.views" (
 ) 
 VALUES (
   'stackql_repositories',
-  'select id, name, url from github.repos.repos where org = ''stackql'';'
+  'select id, name, url, org from github.repos.repos where org = ''stackql'';'
 )
 ON CONFLICT (view_name) DO NOTHING
 ;

--- a/internal/stackql/sql_system/sql/sqlite/sqlengine-setup.ddl
+++ b/internal/stackql/sql_system/sql/sqlite/sqlengine-setup.ddl
@@ -95,7 +95,7 @@ INSERT OR IGNORE INTO "__iql__.views" (
 ) 
 VALUES (
   'stackql_repositories',
-  'select id, name, url from github.repos.repos where org = ''stackql'';'
+  'select id, name, url, org from github.repos.repos where org = ''stackql'';'
 )
 ;
 

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -2684,6 +2684,63 @@ Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expect
     ...    ${outputStr}
     ...    stdout=${CURDIR}/tmp/Select-With-Path-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
 
+Mutable View Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result
+    # this is to mitigate against seldom occuring bug as previously observed, hence repeat_count
+    ${inputStr} =     Catenate
+    ...               create or replace view mutable_view_one as
+    ...               select 
+    ...               kind, 
+    ...               name, 
+    ...               maximumCardsPerInstance, 
+    ...               project 
+    ...               from google.compute.acceleratorTypes 
+    ...               where 
+    ...               project = 'rubbish-project' 
+    ...               and 
+    ...               zone = 'australia-southeast1-a'
+    ...               ;
+    ...               select
+    ...               kind, name, maximumCardsPerInstance, project 
+    ...               from mutable_view_one 
+    ...               where project in ('testing-project', 'another-project')
+    ...               order by name desc, project desc
+    ...               ;
+    ...               drop view mutable_view_one 
+    ...               ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}kind${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}maximumCardsPerInstance${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}project${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}testing-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-t4-vws${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}another-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}testing-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-t4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}another-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}testing-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-p4-vws${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}another-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}testing-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    ...               |${SPACE}compute#acceleratorType${SPACE}|${SPACE}nvidia-tesla-p4${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}4${SPACE}|${SPACE}another-project${SPACE}|
+    ...               |-------------------------|---------------------|-------------------------|-----------------|
+    Should StackQL Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Mutable-View-Select-With-Path-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result.tmp
+    ...    stderr=${CURDIR}/tmp/Mutable-View-Select-With-Path-Parameters-inside-IN-Scalars-inside-WHERE-Clause-Returns-Expected-Result-stderr.tmp
+    ...    repeat_count=20 
+
 Select With Path Parameters inside IN Scalars Mixed With an Equals Parameter all inside WHERE Clause Returns Expected Result
     ${inputStr} =     Catenate
     ...    select 

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -661,19 +661,21 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
     *args,
     **cfg
   ):
-    result = self._run_stackql_exec_command(
-      stackql_exe, 
-      okta_secret_str,
-      github_secret_str,
-      k8s_secret_str,
-      registry_cfg, 
-      auth_cfg_str, 
-      sql_backend_cfg_str,
-      query,
-      *args,
-      **cfg
-    )
-    return self.should_be_equal(result.stdout, expected_output)
+    repeat_count = int(cfg.pop('repeat_count', 1))
+    for _ in range(repeat_count):
+      result = self._run_stackql_exec_command(
+        stackql_exe, 
+        okta_secret_str,
+        github_secret_str,
+        k8s_secret_str,
+        registry_cfg, 
+        auth_cfg_str, 
+        sql_backend_cfg_str,
+        query,
+        *args,
+        **cfg
+      )
+      self.should_be_equal(result.stdout, expected_output)
   
 
   @keyword


### PR DESCRIPTION
## Description

- Added logic to enable dynamic view `where` parameter overwrite, deterministically.
- Added robot test `Mutable View Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.
- Streamlined dependency graph edge assembly.

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Mutable View Select With Path Parameters inside IN Scalars inside WHERE Clause Returns Expected Result`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

This change does not alter technical debt significantly.  From a certain point of view, the late binding clobber of view `where` clause parameters, which is **NOT** `sql`-native, is an unnecessary liability and therefore technical debt.  And this change supports same.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
