### PR TITLE
feat(unit-test): add unit test for package selectmetadata

### DIFF
--- a/internal/stackql/astanalysis/selectmetadata/select_metadata_test.go
+++ b/internal/stackql/astanalysis/selectmetadata/select_metadata_test.go
@@ -1,0 +1,48 @@
+package selectmetadata //nolint:testpackage // to test unexported methods
+
+import (
+	"testing"
+
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/dataflow"
+	"github.com/stackql/stackql/internal/stackql/taxonomy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectMetadata(t *testing.T) {
+	var onConditionDataFlows dataflow.Collection
+	onConditionsToRewrite := make(map[*sqlparser.ComparisonExpr]struct{})
+	tableMap := taxonomy.TblMap{}
+	annotations := taxonomy.AnnotationCtxMap{}
+	t.Run("NewSelectMetadata", func(t *testing.T) {
+		sm := NewSelectMetadata(onConditionDataFlows, onConditionsToRewrite, tableMap, annotations)
+		assert.NotNil(t, sm)
+	})
+
+	t.Run("GetTableMap", func(t *testing.T) {
+		sm := NewSelectMetadata(onConditionDataFlows, onConditionsToRewrite, tableMap, annotations)
+		val, exp := sm.GetTableMap()
+		assert.Equal(t, val, tableMap)
+		assert.Equal(t, exp, true)
+	})
+
+	t.Run("GetAnnotations", func(t *testing.T) {
+		sm := NewSelectMetadata(onConditionDataFlows, onConditionsToRewrite, tableMap, annotations)
+		val, exp := sm.GetAnnotations()
+		assert.Equal(t, val, annotations)
+		assert.Equal(t, exp, true)
+	})
+
+	t.Run("GetOnConditionsToRewrite", func(t *testing.T) {
+		sm := NewSelectMetadata(onConditionDataFlows, onConditionsToRewrite, tableMap, annotations)
+		val := sm.GetOnConditionsToRewrite()
+		assert.Equal(t, val, onConditionsToRewrite)
+	})
+
+	t.Run("GetOnConditionDataFlows", func(t *testing.T) {
+		sm := NewSelectMetadata(onConditionDataFlows, onConditionsToRewrite, tableMap, annotations)
+		val, exp := sm.GetOnConditionDataFlows()
+		assert.Equal(t, val, onConditionDataFlows)
+		assert.Equal(t, exp, false)
+	})
+}


### PR DESCRIPTION
## Description

- add unit testing for package `internal/stackql/astanalysis/selectmetadata`
## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

Fix issue #289

## Evidence

![image](https://github.com/stackql/stackql/assets/75016595/4a94cd6a-d43d-4263-a7c4-74e983e15957)

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
