### PR TITLE
feat(unit-test): add unit testing for package sql_datasource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
 	github.com/Azure/azure-storage-blob-go v0.15.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.1 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/PaesslerAG/jsonpath v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 h1:VgSJlZH5u0k
 github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.1 h1:FK6RCIUSfmbnI/imIICmboyQBkOckutaa6R5YYlLZyo=
+github.com/DATA-DOG/go-sqlmock v1.5.1/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/internal/stackql/datasource/sql_datasource/generic.go
+++ b/internal/stackql/datasource/sql_datasource/generic.go
@@ -14,15 +14,16 @@ import (
 )
 
 var (
-	_ SQLDataSource = &genericSQLDataSource{}
+	_         SQLDataSource = &genericSQLDataSource{}
+	getDBFunc               = db_util.GetDB //nolint:gochecknoglobals // patching variable
 )
 
-func newGenericSQLDataSource(authCtx *dto.AuthCtx, driverName string, dbName string) (SQLDataSource, error) {
+func NewGenericSQLDataSource(authCtx *dto.AuthCtx, driverName string, dbName string) (SQLDataSource, error) {
 	sqlCfg, hasSQLCfg := authCtx.GetSQLCfg()
 	if !hasSQLCfg {
 		return nil, fmt.Errorf("cannot init %s data source with empty SQL config", dbName)
 	}
-	db, err := db_util.GetDB(driverName, dbName, sqlCfg)
+	db, err := getDBFunc(driverName, dbName, sqlCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stackql/datasource/sql_datasource/generic_test.go
+++ b/internal/stackql/datasource/sql_datasource/generic_test.go
@@ -1,0 +1,104 @@
+package sql_datasource //nolint:testpackage,stylecheck // test package
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stackql/stackql/internal/stackql/constants"
+	"github.com/stackql/stackql/internal/stackql/dto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDBUtil struct {
+	mock.Mock
+}
+
+func (m *MockDBUtil) GetDB(driverName, dbName string, sqlCfg *dto.SQLBackendCfg) (*sql.DB, error) {
+	args := m.Called(driverName, dbName, sqlCfg)
+	return args.Get(0).(*sql.DB), args.Error(1)
+}
+
+func TestNewGenericSQLDataSource(t *testing.T) {
+	dbName := "test"
+	driverName := "test"
+	authCtx := &dto.AuthCtx{}
+	authCtx.SQLCfg = &dto.SQLBackendCfg{
+		DBEngine: "test",
+	}
+
+	db, mock, stubErr := sqlmock.New()
+	if stubErr != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", stubErr)
+	}
+	defer db.Close()
+
+	//nolint:unparam // patch function
+	getDBFuncPatch := func(string, string, dto.SQLBackendCfg) (*sql.DB, error) {
+		return db, nil
+	}
+
+	t.Run("check if sqlcfg is nil", func(t *testing.T) {
+		testAuthCtx := &dto.AuthCtx{}
+		_, err := NewGenericSQLDataSource(testAuthCtx, driverName, dbName)
+		assert.Equal(t, fmt.Sprintf("cannot init %s data source with empty SQL config", dbName), err.Error())
+	})
+
+	t.Run("get db name", func(t *testing.T) {
+		getDBFunc = getDBFuncPatch
+		res, _ := NewGenericSQLDataSource(authCtx, driverName, dbName)
+		assert.Equal(t, dbName, res.GetDBName())
+	})
+
+	t.Run("check if schematype value is default", func(t *testing.T) {
+		getDBFunc = getDBFuncPatch
+		res, _ := NewGenericSQLDataSource(authCtx, driverName, dbName)
+		assert.Equal(t, constants.SQLDataSourceSchemaDefault, res.GetSchemaType())
+	})
+
+	t.Run("test exec", func(t *testing.T) {
+		getDBFunc = getDBFuncPatch
+		res, _ := NewGenericSQLDataSource(authCtx, driverName, dbName)
+		mock.ExpectExec("^INSERT INTO test VALUES \\(\\)$").WillReturnResult(sqlmock.NewResult(1, 1))
+		_, err := res.Exec("INSERT INTO test VALUES ()")
+		assert.NoError(t, err)
+	})
+
+	t.Run("test query", func(t *testing.T) {
+		getDBFunc = getDBFuncPatch
+		res, _ := NewGenericSQLDataSource(authCtx, driverName, dbName)
+		mock.ExpectQuery("^SELECT \\* FROM test$").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+		//nolint:rowserrcheck // row will be closed
+		row, err := res.Query("SELECT * FROM test")
+		assert.NoError(t, err)
+		defer row.Close()
+	})
+
+	t.Run("test query row", func(t *testing.T) {
+		getDBFunc = getDBFuncPatch
+		res, _ := NewGenericSQLDataSource(authCtx, driverName, dbName)
+		mock.ExpectQuery("^SELECT \\* FROM test$").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		row := res.QueryRow("SELECT * FROM test")
+		assert.NotNil(t, row)
+	})
+
+	t.Run("test begin", func(t *testing.T) {
+		getDBFunc = getDBFuncPatch
+		res, _ := NewGenericSQLDataSource(authCtx, driverName, dbName)
+		mock.ExpectBegin()
+		tx, err := res.Begin()
+		assert.NoError(t, err)
+		assert.NotNil(t, tx)
+	})
+
+	t.Run("test get table metadata", func(t *testing.T) {
+		getDBFunc = getDBFuncPatch
+		res, _ := NewGenericSQLDataSource(authCtx, driverName, dbName)
+		args := []string{"arg1", "arg2"}
+		_, err := res.GetTableMetadata(args...)
+		assert.Equal(t, fmt.Sprintf("could not obtain sql data source table metadata for args = '%v'", args), err.Error())
+	})
+}

--- a/internal/stackql/datasource/sql_datasource/sql_datasource.go
+++ b/internal/stackql/datasource/sql_datasource/sql_datasource.go
@@ -19,7 +19,9 @@ type SQLDataSource interface {
 	GetDBName() string
 }
 
-func NewDataSource(authCtx *dto.AuthCtx) (SQLDataSource, error) {
+type genericSQLDataSourceFunc func(*dto.AuthCtx, string, string) (SQLDataSource, error)
+
+func NewDataSource(authCtx *dto.AuthCtx, genericSQL genericSQLDataSourceFunc) (SQLDataSource, error) {
 	if authCtx == nil {
 		return nil, fmt.Errorf("cannot create sql data source from nil auth context")
 	}
@@ -29,7 +31,7 @@ func NewDataSource(authCtx *dto.AuthCtx) (SQLDataSource, error) {
 		constants.AuthTypeDelimiter,
 		"snowflake",
 	) {
-		return newGenericSQLDataSource(authCtx, "snowflake", "snowflake")
+		return genericSQL(authCtx, "snowflake", "snowflake")
 	}
 	if authCtx.Type == fmt.Sprintf(
 		"%s%s%s",
@@ -37,7 +39,7 @@ func NewDataSource(authCtx *dto.AuthCtx) (SQLDataSource, error) {
 		constants.AuthTypeDelimiter,
 		"postgres",
 	) {
-		return newGenericSQLDataSource(authCtx, "pgx", "postgres")
+		return genericSQL(authCtx, "pgx", "postgres")
 	}
 	return nil, fmt.Errorf("sql data source of type '%s' not supported", authCtx.Type)
 }

--- a/internal/stackql/datasource/sql_datasource/sql_datasource_test.go
+++ b/internal/stackql/datasource/sql_datasource/sql_datasource_test.go
@@ -1,0 +1,98 @@
+package sql_datasource //nolint:testpackage,stylecheck // test package
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stackql/stackql/internal/stackql/constants"
+	"github.com/stackql/stackql/internal/stackql/datasource/sqltable"
+	"github.com/stackql/stackql/internal/stackql/dto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type SQLDataSourceMock struct {
+	mock.Mock
+}
+
+func (m *SQLDataSourceMock) Begin() (*sql.Tx, error) {
+	args := m.Called()
+	return args.Get(0).(*sql.Tx), args.Error(1)
+}
+
+func (m *SQLDataSourceMock) Exec(query string, args ...interface{}) (sql.Result, error) {
+	args1 := m.Called(query, args)
+	return args1.Get(0).(sql.Result), args1.Error(1)
+}
+
+func (m *SQLDataSourceMock) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	args1 := m.Called(query, args)
+	return args1.Get(0).(*sql.Rows), args1.Error(1)
+}
+
+func (m *SQLDataSourceMock) QueryRow(query string, args ...interface{}) *sql.Row {
+	args1 := m.Called(query, args)
+	return args1.Get(0).(*sql.Row)
+}
+
+func (m *SQLDataSourceMock) GetTableMetadata(args ...string) (sqltable.SQLTable, error) {
+	args1 := m.Called(args)
+	return args1.Get(0).(sqltable.SQLTable), args1.Error(1)
+}
+
+func (m *SQLDataSourceMock) GetSchemaType() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *SQLDataSourceMock) GetDBName() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func genericSQLDataSourceFuncMock(authCtx *dto.AuthCtx, driverName, dbName string) (SQLDataSource, error) {
+	// Mock implementation
+	return &SQLDataSourceMock{}, nil
+}
+
+func TestNewDataSource(t *testing.T) {
+	t.Run("authCtx is nil", func(t *testing.T) {
+		ds, err := NewDataSource(nil, nil)
+		assert.Error(t, err)
+		assert.Nil(t, ds)
+		assert.Equal(t, "cannot create sql data source from nil auth context", err.Error())
+	})
+
+	t.Run("authCtx is not supported", func(t *testing.T) {
+		authCtx := &dto.AuthCtx{Type: "not_supported"}
+		ds, err := NewDataSource(authCtx, nil)
+		assert.Error(t, err)
+		assert.Nil(t, ds)
+		assert.Equal(t, fmt.Sprintf("sql data source of type '%s' not supported", authCtx.Type), err.Error())
+	})
+
+	t.Run("authCtx.Type is snowflake", func(t *testing.T) {
+		authCtx := &dto.AuthCtx{Type: fmt.Sprintf(
+			"%s%s%s",
+			constants.AuthTypeSQLDataSourcePrefix,
+			constants.AuthTypeDelimiter,
+			"snowflake",
+		)}
+		ds, err := NewDataSource(authCtx, genericSQLDataSourceFuncMock)
+		assert.NotNil(t, ds)
+		assert.Nil(t, err)
+	})
+
+	t.Run("authCtx.Type is postgres", func(t *testing.T) {
+		authCtx := &dto.AuthCtx{Type: fmt.Sprintf(
+			"%s%s%s",
+			constants.AuthTypeSQLDataSourcePrefix,
+			constants.AuthTypeDelimiter,
+			"postgres",
+		)}
+		ds, err := NewDataSource(authCtx, genericSQLDataSourceFuncMock)
+		assert.NotNil(t, ds)
+		assert.Nil(t, err)
+	})
+}

--- a/internal/stackql/entryutil/entryutil.go
+++ b/internal/stackql/entryutil/entryutil.go
@@ -131,7 +131,7 @@ func initSQLDataSources(authContextMap map[string]*dto.AuthCtx) (map[string]sql_
 	for k, ac := range authContextMap {
 		_, isSQLCfg := ac.GetSQLCfg()
 		if isSQLCfg {
-			sqlDataSource, err := sql_datasource.NewDataSource(ac)
+			sqlDataSource, err := sql_datasource.NewDataSource(ac, sql_datasource.NewGenericSQLDataSource)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description

- add implementation for testing sql_datasource.go
- modify sql_datasource.go by adding function for dependency injection
- add implementation for testing generic.go
- modify generic.go by adding variable for patching GetDB function
- modify entryutil.go to adjust sql_datasource.go
- include new package DATA-DOG/go-sqlmock

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

Fix issue #299 

## Evidence

![image](https://github.com/stackql/stackql/assets/75016595/a5fe505b-4bbf-4c36-9ec0-5cbd1ab9c07b)

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
