### PR TITLE
shell-orchestration-in-robot

### DIFF
--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -300,11 +300,9 @@ Unacceptable Insecure Connection to mTLS Server Returns Error Message
     Should Contain    ${result.stdout}    Verify return code: 18
 
 Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns Connection Info
-    Pass Execution If    "${IS_WINDOWS}" == "1"    Unknown stream handling issue in powershell and sh hence using bash
     ${input} =     Catenate
-    ...    echo     '\\conninfo'     |
-    ...    ${PSQL_EXE}    -d     "${PSQL_MTLS_CONN_STR_UNIX}"
-    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    bash
+    ...    ${PSQL_EXE}    -d     "${PSQL_MTLS_CONN_STR_UNIX}" -c "\\conninfo"
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
     ${result} =    Run Process
     ...    ${shellExe}     \-c    ${input}
     ...    stdout=${CURDIR}/tmp/Acceptable-Secure-PSQL-Connection-to-mTLS-Server-With-Diagnostic-Query-Returns-Connection-Info.tmp
@@ -312,13 +310,11 @@ Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns C
     Should Contain    ${result.stdout}    SSL connection (protocol: TLSv1.3
 
 Unacceptable Insecure PSQL Connection to mTLS Server Returns Error Message
-    Pass Execution If    "${IS_WINDOWS}" == "1"    Unknown stream handling issue in powershell and sh hence using bash
     ${input} =     Catenate
-    ...    echo     '\\conninfo'     |
-    ...    ${PSQL_EXE}    -d    "${PSQL_MTLS_DISABLE_CONN_STR_UNIX}"
-    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    bash
+    ...    ${PSQL_EXE}    -d    "${PSQL_MTLS_DISABLE_CONN_STR_UNIX}" -c "\\conninfo"
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
     ${result} =    Run Process
-    ...    ${shellExe}     \-c    ${input}
+    ...    ${shellExe}     \-c    ${input} 
     ...    stdout=${CURDIR}/tmp/Unacceptable-Insecure-PSQL-Connection-to-mTLS-Server-Returns-Error-Message.tmp
     ...    stderr=${CURDIR}/tmp/Unacceptable-Insecure-PSQL-Connection-to-mTLS-Server-Returns-Error-Message-stderr.tmp
     Should Contain    ${result.stderr}    server closed the connection unexpectedly

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -300,8 +300,11 @@ Unacceptable Insecure Connection to mTLS Server Returns Error Message
     Should Contain    ${result.stdout}    Verify return code: 18
 
 Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns Connection Info
-    ${input} =     Catenate
+    ${posixInput} =     Catenate
     ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_UNIX}" -c "\\conninfo"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
     ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
     ${result} =    Run Process
     ...    ${shellExe}     \-c    ${input}
@@ -310,11 +313,14 @@ Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns C
     Should Contain    ${result.stdout}    SSL connection (protocol: TLSv1.3
 
 Unacceptable Insecure PSQL Connection to mTLS Server Returns Error Message
-    ${input} =     Catenate
+    ${posixInput} =     Catenate
     ...    "${PSQL_EXE}"    -d    "${PSQL_MTLS_DISABLE_CONN_STR_UNIX}" -c "\\conninfo"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
     ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
     ${result} =    Run Process
-    ...    ${shellExe}     \-c    ${input} 
+    ...    ${shellExe}     \-c    ${input}
     ...    stdout=${CURDIR}/tmp/Unacceptable-Insecure-PSQL-Connection-to-mTLS-Server-Returns-Error-Message.tmp
     ...    stderr=${CURDIR}/tmp/Unacceptable-Insecure-PSQL-Connection-to-mTLS-Server-Returns-Error-Message-stderr.tmp
     Should Contain    ${result.stderr}    server closed the connection unexpectedly

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -301,7 +301,7 @@ Unacceptable Insecure Connection to mTLS Server Returns Error Message
 
 Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns Connection Info
     ${input} =     Catenate
-    ...    ${PSQL_EXE}    -d     "${PSQL_MTLS_CONN_STR_UNIX}" -c "\\conninfo"
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_UNIX}" -c "\\conninfo"
     ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
     ${result} =    Run Process
     ...    ${shellExe}     \-c    ${input}
@@ -311,7 +311,7 @@ Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns C
 
 Unacceptable Insecure PSQL Connection to mTLS Server Returns Error Message
     ${input} =     Catenate
-    ...    ${PSQL_EXE}    -d    "${PSQL_MTLS_DISABLE_CONN_STR_UNIX}" -c "\\conninfo"
+    ...    "${PSQL_EXE}"    -d    "${PSQL_MTLS_DISABLE_CONN_STR_UNIX}" -c "\\conninfo"
     ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
     ${result} =    Run Process
     ...    ${shellExe}     \-c    ${input} 


### PR DESCRIPTION
Summary:

- Avoid piping in `robot`invocations with standard shells.
- Broadened effected tests to cover windows.
- Uplift for robot test `Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns Connection Info`.
- Uplift for robot test `Unacceptable Insecure PSQL Connection to mTLS Server Returns Error Message`.


## Description

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

Closes #365 

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Uplift for robot test `Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns Connection Info`.
- Uplift for robot test `Unacceptable Insecure PSQL Connection to mTLS Server Returns Error Message`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

This change does not introduce technical debt.  Quite the opposite; it reduces technical debt.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
