### PR TITLE
updated `aws` auth to support `sts assume role` creds

### DIFF
--- a/internal/stackql/dto/auth_ctx.go
+++ b/internal/stackql/dto/auth_ctx.go
@@ -18,6 +18,7 @@ type AuthCtx struct {
 	KeyFilePath             string         `json:"credentialsfilepath" yaml:"credentialsfilepath"`
 	KeyFilePathEnvVar       string         `json:"credentialsfilepathenvvar" yaml:"credentialsfilepathenvvar"`
 	KeyEnvVar               string         `json:"credentialsenvvar" yaml:"credentialsenvvar"`
+	SessionTokenEnvVar      string         `json:"sessiontokenenvvar" yaml:"sessiontokenenvvar"`
 	APIKeyStr               string         `json:"api_key" yaml:"api_key"`
 	APISecretStr            string         `json:"api_secret" yaml:"api_secret"`
 	Username                string         `json:"username" yaml:"username"`
@@ -54,6 +55,7 @@ func (ac *AuthCtx) Clone() *AuthCtx {
 		KeyFilePath:             ac.KeyFilePath,
 		KeyFilePathEnvVar:       ac.KeyFilePathEnvVar,
 		KeyEnvVar:               ac.KeyEnvVar,
+		SessionTokenEnvVar: 	 ac.SessionTokenEnvVar,
 		Active:                  ac.Active,
 		Username:                ac.Username,
 		Password:                ac.Password,
@@ -126,6 +128,18 @@ func (ac *AuthCtx) GetKeyIDString() (string, error) {
 		return rv, nil
 	}
 	return ac.KeyID, nil
+}
+
+func (ac *AuthCtx) GetSessionTokenString() (string, error) {
+    if ac.SessionTokenEnvVar != "" {
+        token := os.Getenv(ac.SessionTokenEnvVar)
+        if token == "" {
+            // Session token is optional, so an empty token isn't considered an error.
+            return "", nil
+        }
+        return token, nil
+    }
+    return "", nil // No session token environment variable specified.
 }
 
 func (ac *AuthCtx) InferAuthType(authTypeRequested string) string {

--- a/internal/stackql/provider/auth_util.go
+++ b/internal/stackql/provider/auth_util.go
@@ -212,23 +212,40 @@ func apiTokenAuth(authCtx *dto.AuthCtx, runtimeCtx dto.RuntimeCtx, enforceBearer
 }
 
 func awsSigningAuth(authCtx *dto.AuthCtx, runtimeCtx dto.RuntimeCtx) (*http.Client, error) {
-	b, err := authCtx.GetCredentialsBytes()
-	if err != nil {
-		return nil, fmt.Errorf("credentials error: %w", err)
-	}
-	keyStr := string(b)
-	keyID, err := authCtx.GetKeyIDString()
-	if err != nil {
-		return nil, err
-	}
-	if keyStr == "" || keyID == "" {
-		return nil, fmt.Errorf("cannot compose AWS signing credentials")
-	}
-	activateAuth(authCtx, "", dto.AuthAWSSigningv4Str)
-	httpClient := netutils.GetHTTPClient(runtimeCtx, http.DefaultClient)
-	tr := awssign.NewAwsSignTransport(httpClient.Transport, keyID, keyStr, "")
-	httpClient.Transport = tr
-	return httpClient, nil
+    // Retrieve the AWS access key and secret key.
+    credentialsBytes, err := authCtx.GetCredentialsBytes()
+    if err != nil {
+        return nil, fmt.Errorf("credentials error: %w", err)
+    }
+    keyStr := string(credentialsBytes)
+
+    // Retrieve the AWS access key ID.
+    keyID, err := authCtx.GetKeyIDString()
+    if err != nil {
+        return nil, err
+    }
+
+    // Validate that both keyID and keyStr are not empty.
+    if keyStr == "" || keyID == "" {
+        return nil, fmt.Errorf("cannot compose AWS signing credentials")
+    }
+
+    // Retrieve the optional session token. Note: No error handling for missing session token.
+    sessionToken, _ := authCtx.GetSessionTokenString()
+
+    // Mark the authentication context as active for AWS signing.
+    activateAuth(authCtx, "", dto.AuthAWSSigningv4Str)
+
+    // Get the HTTP client from the runtime context.
+    httpClient := netutils.GetHTTPClient(runtimeCtx, http.DefaultClient)
+
+    // Initialize the AWS signing transport with credentials and optional session token.
+    tr := awssign.NewAwsSignTransport(httpClient.Transport, keyID, keyStr, sessionToken)
+
+    // Set the custom AWS signing transport as the client's transport.
+    httpClient.Transport = tr
+
+    return httpClient, nil
 }
 
 func basicAuth(authCtx *dto.AuthCtx, runtimeCtx dto.RuntimeCtx) (*http.Client, error) {


### PR DESCRIPTION
## Description

Updates to enable optional `AWS_SESSION_TOKEN` variable, when present this is used with the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as part of the cred signing request

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

None

## Evidence

Will test both scenarios

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [ ] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [ ] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

None

## Tech Debt

None