### PR TITLE
union-select-inline

### DIFF
--- a/internal/stackql/sql_system/postgres.go
+++ b/internal/stackql/sql_system/postgres.go
@@ -962,8 +962,10 @@ func (eng *postgresSystem) composeSelectQuery(
 	}
 	whereExprsStr := wq.String()
 
-	q.WriteString(fmt.Sprintf(`SELECT %s FROM `, strings.Join(quotedColNames, ", ")))
-	q.WriteString(fromString)
+	q.WriteString(fmt.Sprintf(`SELECT %s `, strings.Join(quotedColNames, ", ")))
+	if fromString != "" {
+		q.WriteString(fmt.Sprintf(`FROM %s `, fromString))
+	}
 	if whereExprsStr != "" {
 		q.WriteString(" WHERE ")
 		q.WriteString(whereExprsStr)

--- a/internal/stackql/sql_system/sqlite.go
+++ b/internal/stackql/sql_system/sqlite.go
@@ -1117,8 +1117,10 @@ func (eng *sqLiteSystem) composeSelectQuery(
 	}
 	whereExprsStr := wq.String()
 
-	q.WriteString(fmt.Sprintf(`SELECT %s FROM `, strings.Join(quotedColNames, ", ")))
-	q.WriteString(fromString)
+	q.WriteString(fmt.Sprintf(`SELECT %s `, strings.Join(quotedColNames, ", ")))
+	if fromString != "" {
+		q.WriteString(fmt.Sprintf(`FROM %s `, fromString))
+	}
 	if whereExprsStr != "" {
 		q.WriteString(" WHERE ")
 		q.WriteString(whereExprsStr)

--- a/internal/stackql/sqlengine/postgres_tcp.go
+++ b/internal/stackql/sqlengine/postgres_tcp.go
@@ -294,7 +294,11 @@ func (se postgresTCPEngine) Query(query string, varArgs ...interface{}) (*sql.Ro
 }
 
 func (se postgresTCPEngine) query(query string, varArgs ...interface{}) (*sql.Rows, error) {
-	bodgedQuery, _ := se.bodgePrepStmt(query)
+	bodgedQuery, containsParameters := se.bodgePrepStmt(query)
+	if !containsParameters {
+		res, err := se.db.Query(bodgedQuery, []interface{}{}...)
+		return res, err
+	}
 	res, err := se.db.Query(bodgedQuery, varArgs...)
 	return res, err
 }

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -3180,6 +3180,27 @@ Function On Projection Resource Level View of Cloud Control Resource Returns Exp
     ...    ${outputStr}
     ...    ${CURDIR}/tmp/Funtion-On-Projection-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
+Inline Union Select Returns Expected Result
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------------------|----------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}bucket_name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}region${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------|----------------|
+    ...    |${SPACE}some-other-placeholder${SPACE}|${SPACE}ap-southeast-2${SPACE}|
+    ...    |------------------------|----------------|
+    ...    |${SPACE}some-placeholder${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}ap-southeast-2${SPACE}|
+    ...    |------------------------|----------------|
+    Should Horrid Query StackQL Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}    
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    SELECT 'some\-placeholder' as bucket_name, 'ap\-southeast\-2' as region UNION SELECT 'some\-other\-placeholder' as bucket_name, 'ap\-southeast\-2' as region;
+    ...    ${outputStr}
+    ...    ${CURDIR}/tmp/Inline-Union-Select-Returns-Expected-Result.tmp
+
 Filtered Projection Detail Resource Level View of Cloud Control Resource Returns Expected Result
     ${outputStr} =    Catenate    SEPARATOR=\n
     ...    |--------------------------------------------|----------------------------------------|


### PR DESCRIPTION
## Description

- Inline `SELECT... UNION SELECT...` supported.
- Added robot test `Inline Union Select Returns Expected Result`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Inline Union Select Returns Expected Result`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [\x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

This change in itself does not introduce technical debt.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
