### PR TITLE
regression-coverage-expansion

### DIFF
--- a/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
+++ b/internal/stackql/internal_data_transfer/internaldto/heirarchy_identifiers.go
@@ -36,19 +36,22 @@ type HeirarchyIdentifiers interface {
 	IsPgInternalObject() bool
 	IsPhysicalTable() bool
 	SetIsPhysicalTable(isPhysical bool)
+	SetIsMaterializedView(isMaterialized bool)
+	IsMaterializedView() bool
 }
 
 type standardHeirarchyIdentifiers struct {
-	providerStr       string
-	serviceStr        string
-	resourceStr       string
-	responseSchemaStr string
-	methodStr         string
-	viewDTO           RelationDTO
-	subqueryDTO       SubqueryDTO
-	viewAST           sqlparser.Statement
-	containsDBMSTable bool
-	isPhysicalTable   bool
+	providerStr        string
+	serviceStr         string
+	resourceStr        string
+	responseSchemaStr  string
+	methodStr          string
+	viewDTO            RelationDTO
+	subqueryDTO        SubqueryDTO
+	viewAST            sqlparser.Statement
+	containsDBMSTable  bool
+	isPhysicalTable    bool
+	isMaterializedView bool
 }
 
 func (hi *standardHeirarchyIdentifiers) IsPhysicalTable() bool {
@@ -57,6 +60,14 @@ func (hi *standardHeirarchyIdentifiers) IsPhysicalTable() bool {
 
 func (hi *standardHeirarchyIdentifiers) SetIsPhysicalTable(isPhysical bool) {
 	hi.isPhysicalTable = isPhysical
+}
+
+func (hi *standardHeirarchyIdentifiers) IsMaterializedView() bool {
+	return hi.isMaterializedView
+}
+
+func (hi *standardHeirarchyIdentifiers) SetIsMaterializedView(isMaterialized bool) {
+	hi.isMaterializedView = isMaterialized
 }
 
 func (hi *standardHeirarchyIdentifiers) IsPgInternalObject() bool {

--- a/internal/stackql/sqlrewrite/sqlrewrite.go
+++ b/internal/stackql/sqlrewrite/sqlrewrite.go
@@ -247,6 +247,14 @@ func GenerateRewrittenSelectDML(input SQLRewriteInput) (drm.PreparedStatementCtx
 	if err != nil {
 		return nil, err
 	}
+	countedTables := 0
+	for _, tbl := range input.GetTables() {
+		isMaterializedView := tbl.IsMaterializedView()
+		isPhysicalTable := tbl.IsPhysicalTable()
+		if tbl != nil && !isMaterializedView && !isPhysicalTable {
+			countedTables++
+		}
+	}
 	rv := drm.NewPreparedStatementCtx(
 		query,
 		"",
@@ -257,7 +265,7 @@ func GenerateRewrittenSelectDML(input SQLRewriteInput) (drm.PreparedStatementCtx
 		insIDColName,
 		insEncodedColName,
 		columns,
-		len(input.GetTables()),
+		countedTables,
 		txnCtrlCtrs,
 		secondaryCtrlCounters,
 		input.GetDRMConfig().GetNamespaceCollection(),

--- a/internal/stackql/tablemetadata/extended_table_metadata.go
+++ b/internal/stackql/tablemetadata/extended_table_metadata.go
@@ -60,6 +60,7 @@ type ExtendedTableMetadata interface {
 	SetIsOnClauseHoistable(bool)
 	IsOnClauseHoistable() bool
 	IsPhysicalTable() bool
+	IsMaterializedView() bool
 	GetServerVariables() (map[string]*openapi3.ServerVariable, bool)
 	Clone() ExtendedTableMetadata
 }
@@ -127,6 +128,13 @@ func (ex *standardExtendedTableMetadata) IsPhysicalTable() bool {
 		return false
 	}
 	return ex.heirarchyObjects.GetHeirarchyIds().IsPhysicalTable()
+}
+
+func (ex *standardExtendedTableMetadata) IsMaterializedView() bool {
+	if ex.heirarchyObjects == nil || ex.heirarchyObjects.GetHeirarchyIds() == nil {
+		return false
+	}
+	return ex.heirarchyObjects.GetHeirarchyIds().IsMaterializedView()
 }
 
 func (ex *standardExtendedTableMetadata) SetIsOnClauseHoistable(isOnClauseHoistable bool) {

--- a/internal/stackql/taxonomy/hierarchy.go
+++ b/internal/stackql/taxonomy/hierarchy.go
@@ -84,6 +84,7 @@ func getHids(handlerCtx handler.HandlerContext, node sqlparser.SQLNode) (interna
 	materializedViewDTO, isMaterializedView := handlerCtx.GetSQLSystem().GetMaterializedViewByName(hIds.GetTableName())
 	if isMaterializedView {
 		hIds = hIds.WithView(materializedViewDTO)
+		hIds.SetIsMaterializedView(true)
 	}
 	// TODO: pass in current counters
 	physicalTableDTO, isPhysicalTable := handlerCtx.GetSQLSystem().GetPhysicalTableByName(hIds.GetTableName())

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -883,6 +883,56 @@ Create Then Replace and Interrogate Materialized View With Union
     ...    stdout=${CURDIR}/tmp/Create-Then-Replace-and-Interrogate-Materialized-View-With-Union.tmp
     ...    stderr=${CURDIR}/tmp/Create-Then-Replace-and-Interrogate-Materialized-View-With-Union-stderr.tmp
 
+Create Then Replace and Interrogate Materialized View With Union of MAterialized Views
+    ${inputStr} =    Catenate
+    ...    create or replace materialized view vw_aws_usr as select Arn, UserName, UserId, region from aws.iam.users where region = 'us-east-1' union all select 'prefixed' || Arn, UserName, 'prefixed' || UserId, region from aws.iam.users where region = 'us-east-1'; 
+    ...    create or replace materialized view vw_aws_usr_two as select Arn, UserName, UserId, region from aws.iam.users where region = 'us-east-1' union all select 'prefixed' || Arn, UserName, 'prefixed' || UserId, region from aws.iam.users where region = 'us-east-1'; 
+    ...    create materialized view composite_mv as select Arn, UserName, UserId, region from vw_aws_usr union all select Arn, UserName, UserId, region from vw_aws_usr_two; 
+    ...    select Arn, UserName, UserId, region from composite_mv order by Arn, region;
+    ...    drop materialized view vw_aws_usr;
+    ...    drop materialized view vw_aws_usr_two;
+    ...    drop materialized view composite_mv;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}Arn${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}UserName${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}UserId${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}region${SPACE}${SPACE}${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}Andrew${SPACE}${SPACE}${SPACE}|${SPACE}AID2MAB8DPLSRHEXAMPLE${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}Andrew${SPACE}${SPACE}${SPACE}|${SPACE}AID2MAB8DPLSRHEXAMPLE${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}Jackie${SPACE}${SPACE}${SPACE}|${SPACE}AIDIODR4TAW7CSEXAMPLE${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}Jackie${SPACE}${SPACE}${SPACE}|${SPACE}AIDIODR4TAW7CSEXAMPLE${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}prefixedarn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew${SPACE}|${SPACE}Andrew${SPACE}${SPACE}${SPACE}|${SPACE}prefixedAID2MAB8DPLSRHEXAMPLE${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}prefixedarn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew${SPACE}|${SPACE}Andrew${SPACE}${SPACE}${SPACE}|${SPACE}prefixedAID2MAB8DPLSRHEXAMPLE${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}prefixedarn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie${SPACE}|${SPACE}Jackie${SPACE}${SPACE}${SPACE}|${SPACE}prefixedAIDIODR4TAW7CSEXAMPLE${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ...    |${SPACE}prefixedarn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie${SPACE}|${SPACE}Jackie${SPACE}${SPACE}${SPACE}|${SPACE}prefixedAIDIODR4TAW7CSEXAMPLE${SPACE}|${SPACE}us-east-1${SPACE}|
+    ...    |----------------------------------------------------------------------------------------|----------|-------------------------------|-----------|
+    ${stdErrStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${stdErrStr}
+    ...    stdout=${CURDIR}/tmp/Create-Then-Replace-and-Interrogate-Materialized-View-With-Union-of-Materioalized-Views.tmp
+    ...    stderr=${CURDIR}/tmp/Create-Then-Replace-and-Interrogate-Materialized-View-With-Union-of-Materioalized-Views-stderr.tmp
+
 Create and Interrogate Materialized View With Parenthesized Select and Union
     ${inputStr} =    Catenate
     ...    create materialized view vw_aws_usr as (select Arn, UserName, UserId, region from aws.iam.users where region = 'us-east-1' union all select 'prefixed' || Arn, UserName, 'prefixed' || UserId, region from aws.iam.users where region = 'us-east-1');


### PR DESCRIPTION
Summary:

- Support for unions of materialized views in materialized views.
- Added robot test `Create Then Replace and Interrogate Materialized View With Union of Materialized Views`.


## Description

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [ ] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [ ] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
