### PR TITLE
export-materializations-v01

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,13 +81,6 @@ jobs:
       timeout-minutes: 20
       with:
         version: '8.1.0'
-
-    - name: Choco install postgres
-      # uses: crazy-max/ghaction-chocolatey@v2
-      uses: crazy-max/ghaction-chocolatey@v3.0.0
-      timeout-minutes: 20
-      with:
-        args: "install --force postgresql13 openssl"
     
     - name: Git Ref Parse
       id: git_ref_parse
@@ -97,6 +90,13 @@ jobs:
           echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}"
           echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}"
         } >> "${GITHUB_STATE}"
+
+    - name: Choco install packages
+      uses: crazy-max/ghaction-chocolatey@v3.0.0
+      if: startsWith(steps.git_ref_parse.outputs.SOURCE_TAG, 'build-release')
+      timeout-minutes: 40
+      with:
+        args: "install --force postgresql13 openssl sqlite"
 
     - name: Install Python dependencies
       run: |
@@ -147,21 +147,37 @@ jobs:
       run: python cicd/python/build.py --verbose --test
 
     - name: Mock Server Download
+      if: startsWith(steps.git_ref_parse.outputs.SOURCE_TAG, 'build-release')
       run: |
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.0.2:copy `
         '-Dartifact=org.mock-server:mockserver-netty:5.12.0:jar:shaded' `
         '-DoutputDirectory=test/downloads'
 
     - name: Create certificates for robot tests
+      if: startsWith(steps.git_ref_parse.outputs.SOURCE_TAG, 'build-release')
       run: |
         openssl req -x509 -keyout test/server/mtls/credentials/pg_server_key.pem -out test/server/mtls/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
         openssl req -x509 -keyout test/server/mtls/credentials/pg_client_key.pem -out test/server/mtls/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
         openssl req -x509 -keyout test/server/mtls/credentials/pg_rubbish_key.pem -out test/server/mtls/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365
     
+    - name: Run robot mocked functional tests
+      if: startsWith(steps.git_ref_parse.outputs.SOURCE_TAG, 'build-release')
+      env:
+        PSQL_EXE: C:\Program Files\PostgreSQL\13\bin\psql
+        SQLITE_EXE: C:\ProgramData\chocolatey\lib\SQLite\tools\sqlite3.exe
+      run: |
+        python cicd/python/build.py --robot-test
+
+    - name: Output from mocked functional tests
+      if: startsWith(steps.git_ref_parse.outputs.SOURCE_TAG, 'build-release')
+      run: |
+        cat ./test/robot/functional/output.xml
+    
     - name: Run robot integration tests
       if: env.AZURE_CLIENT_SECRET != '' && startsWith(steps.git_ref_parse.outputs.SOURCE_TAG, 'build-release')
       env:
         PSQL_EXE: C:\Program Files\PostgreSQL\13\bin\psql
+        SQLITE_EXE: C:\ProgramData\chocolatey\lib\SQLite\tools\sqlite3.exe
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         AZURE_INTEGRATION_TESTING_SUB_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
@@ -431,6 +447,7 @@ jobs:
           postgresql
           python3
           python3-pip
+          sqlite3
         wsl-conf: |
           [automount]
           options = "metadata"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -254,6 +254,16 @@
     },
     {
       "type": "pickString",
+      "id": "exportAliasString",
+      "description": "export namespace",
+      "default": "{}",
+      "options": [
+        "",
+        "stackql_export"
+      ]
+    },
+    {
+      "type": "pickString",
       "id": "pgsrvTlsString",
       "description": "pgsrv.tls config",
       // you will need to fill in the gaps here
@@ -323,6 +333,7 @@
         "--namespaces=${input:namespaceString}",
         "--dbInternal=${input:dbInternalString}",
         "--execution.concurrency.limit=${input:concurrencyLimit}",
+        "--export.alias=${input:exportAliasString}",
         "${input:queryString}"
       ],
     },

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update \
       maven \
       openssl \
       postgresql-client \
+      sqlite3 \
     && pip3 install PyYaml robotframework psycopg2-binary "psycopg[binary]" sqlalchemy \
     && mvn \
         org.apache.maven.plugins:maven-dependency-plugin:3.0.2:copy \

--- a/cicd/vol/postgres/.gitignore
+++ b/cicd/vol/postgres/.gitignore
@@ -1,0 +1,1 @@
+persist/

--- a/cicd/vol/stackql/test/.gitignore
+++ b/cicd/vol/stackql/test/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose-persist-postgres.yml
+++ b/docker-compose-persist-postgres.yml
@@ -1,0 +1,81 @@
+version: "3.9"
+   
+services:
+  stackqlsrv:
+    image: stackql/stackql
+    build:
+      context: .
+      cache_from: 
+        - stackql/stackql
+        - stackql/integration
+        - stackql/stackqlsrvcertificates
+      args:
+        - BUILDMAJORVERSION=${BUILDMAJORVERSION:-1}
+        - BUILDMINORVERSION=${BUILDMINORVERSION:-1}
+        - BUILDPATCHVERSION=${BUILDPATCHVERSION:-1}
+    command: 
+      - bash
+      - -c
+      - 'stackql 
+         --auth=''{ 
+           "google": { "credentialsfilepath": "/opt/stackql/credentials/dummy/google/functional-test-dummy-sa-key.json", "type": "service_account" }, 
+           "okta": { "credentialsenvvar": "OKTA_SECRET_KEY", "type": "api_key" }, 
+           "github": { "type": "basic", "credentialsenvvar": "GITHUB_CREDS" }, 
+           "aws": { "type": "aws_signing_v4", "credentialsfilepath": "/opt/stackql/credentials/dummy/aws/functional-test-dummy-aws-key.txt", "keyID": "some-key-not-a-secret" }, 
+           "k8s": { "credentialsenvvar": "K8S_TOKEN", "type": "api_key", "valuePrefix": "Bearer " } 
+         }'' 
+         --registry=''{
+           "url": "https://cdn.statically.io/gh/stackql/stackql-provider-registry/dev/providers",
+           "verifyConfig": { "nopVerify": true }
+         }'' 
+         --pgsrv.tls=''{ 
+           "keyFilePath": "/opt/stackql/srv/credentials/pg_server_key.pem", 
+           "certFilePath": "/opt/stackql/srv/credentials/pg_server_cert.pem", 
+           "clientCAs": [ 
+             "''$$(base64 -w 0 /opt/stackql/srv/credentials/pg_client_cert.pem)''" 
+           ] 
+         }'' 
+         --pgsrv.address=0.0.0.0 
+         --pgsrv.port=${PG_SRV_PORT_MTLS:-5476} 
+         srv'
+    volumes:
+      - ./cicd/keys:/opt/stackql/keys:ro
+      - ./cicd/vol/srv/credentials:/opt/stackql/srv/credentials:ro
+      - ./test/assets/credentials/dummy:/opt/stackql/credentials/dummy:ro
+      - ./test/assets/input:/opt/stackql/input:ro
+      - ${DB_SETUP_SRC:-./test/db/sqlite}:/opt/stackql/db:ro
+      - ${REGISTRY_SRC:-./test/registry-mocked}:/opt/stackql/registry:ro
+      - ./cicd/vol/stackql/config:/opt/stackql/.stackql:rw 
+      - ./cicd/vol/stackql/test:/opt/stackql/test:rw 
+      - ./cicd/vol/logs:/opt/stackql/logs:rw 
+    ports:
+      - "${PG_SRV_PORT_DOCKER_MTLS:-5576}:${PG_SRV_PORT_MTLS:-5476}/tcp"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - OKTA_SECRET_KEY=${OKTA_SECRET_STR:-some-junk}
+      - GITHUB_SECRET_KEY=${GITHUB_SECRET_STR:-some-junk}
+      - K8S_SECRET_KEY=${K8S_SECRET_STR:-some-junk}
+      - AZ_ACCESS_TOKEN=${AZ_ACCESS_TOKEN:-some_junk}
+      - SUMO_CREDS=${SUMO_CREDS:-some_junk}
+      - DIGITALOCEAN_TOKEN=${DIGITALOCEAN_TOKEN:-some_junk}
+      - DUMMY_DIGITALOCEAN_USERNAME=${DUMMY_DIGITALOCEAN_USERNAME:-myusername}
+      - DUMMY_DIGITALOCEAN_PASSWORD=${DUMMY_DIGITALOCEAN_PASSWORD:-mypassword}
+      - DD_API_KEY=${DD_API_KEY:-myusername}
+      - DD_APPLICATION_KEY=${DD_APPLICATION_KEY:-mypassword}
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-/opt/stackql/credentials/dummy/google/docker-functional-test-dummy-sa-key.json}
+      - BUILDMAJORVERSION=${BUILDMAJORVERSION:-1}
+      - BUILDMINORVERSION=${BUILDMINORVERSION:-1}
+      - BUILDPATCHVERSION=${BUILDPATCHVERSION:-1}
+    depends_on:
+      - postgres_stackql
+  postgres_stackql:
+    image: postgres:14.5-bullseye
+    hostname: postgres_stackql
+    volumes:
+      - ./cicd/vol/postgres/setup:/docker-entrypoint-initdb.d:ro
+      - ./cicd/vol/postgres/persist:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=stackql
+    ports:
+      - "5532:5432/tcp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - ${DB_SETUP_SRC:-./test/db/sqlite}:/opt/stackql/db:ro
       - ${REGISTRY_SRC:-./test/registry-mocked}:/opt/stackql/registry:ro
       - ./cicd/vol/stackql/config:/opt/stackql/.stackql:rw 
+      - ./cicd/vol/stackql/test:/opt/stackql/test:rw 
       - ./cicd/vol/logs:/opt/stackql/logs:rw 
     ports:
       - "${PG_SRV_PORT_DOCKER_MTLS:-5576}:${PG_SRV_PORT_MTLS:-5476}/tcp"

--- a/internal/stackql/cmd/root.go
+++ b/internal/stackql/cmd/root.go
@@ -128,6 +128,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.HTTPProxyPassword, dto.HTTPProxyPasswordKey, "", "http proxy password")
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.HTTPProxyUser, dto.HTTPProxyUserKey, "", "http proxy user")
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.ProviderStr, dto.ProviderStrKey, "", "stackql provider")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.ExportAlias, dto.ExportAliasKey, "", "export alias prefix (namespace or schema)")
 	rootCmd.PersistentFlags().BoolVar(&runtimeCtx.WorkOffline, dto.WorkOfflineKey, false, "Work offline, using cached data")
 	rootCmd.PersistentFlags().BoolVarP(&runtimeCtx.VerboseFlag, dto.VerboseFlagKey, "v", false, "Verbose flag")
 	rootCmd.PersistentFlags().BoolVar(&runtimeCtx.DryRunFlag, dto.DryRunFlagKey, false, "dryrun flag; preprocessor only will run and output returned")

--- a/internal/stackql/drm/drm_cfg.go
+++ b/internal/stackql/drm/drm_cfg.go
@@ -81,8 +81,9 @@ type Config interface {
 		relationName string,
 		ctxParameterized PreparedStatementParameterized,
 	) error
+	// This one the DDL is ahead of time so table name already aware; it is the exception
 	CreatePhysicalTable(
-		relationName string,
+		fullyQualifiedRelationName string,
 		rawDDL string,
 		tableSpec *sqlparser.TableSpec,
 		ifNotExists bool,
@@ -92,6 +93,7 @@ type Config interface {
 		insertColumnsString string,
 		ctxParameterized PreparedStatementParameterized,
 	) error
+	GetFullyQualifiedRelationName(string) string
 }
 
 type staticDRMConfig struct {
@@ -111,6 +113,10 @@ func (dc *staticDRMConfig) GetTable(
 	discoveryID int,
 ) (internaldto.DBTable, error) {
 	return dc.sqlSystem.GetTable(hids, discoveryID)
+}
+
+func (dc *staticDRMConfig) GetFullyQualifiedRelationName(relationName string) string {
+	return dc.sqlSystem.GetFullyQualifiedRelationName(relationName)
 }
 
 func (dc *staticDRMConfig) OpenapiColumnsToRelationalColumns(

--- a/internal/stackql/dto/dto.go
+++ b/internal/stackql/dto/dto.go
@@ -46,6 +46,7 @@ const (
 	ApplicationFilesRootPathKey     string = "approot"
 	ApplicationFilesRootPathModeKey string = "approotfilemode"
 	PgSrvAddressKey                 string = "pgsrv.address"
+	ExportAliasKey                  string = "export.alias"
 	PgSrvLogLevelKey                string = "pgsrv.loglevel"
 	PgSrvPortKey                    string = "pgsrv.port"
 	PgSrvRawTLSCfgKey               string = "pgsrv.tls"

--- a/internal/stackql/dto/runtime_ctx.go
+++ b/internal/stackql/dto/runtime_ctx.go
@@ -37,6 +37,7 @@ type RuntimeCtx struct {
 	PGSrvLogLevel                string
 	PGSrvPort                    int
 	PGSrvRawTLSCfg               string
+	ExportAlias                  string
 	ProviderStr                  string
 	RegistryRaw                  string
 	SessionCtxRaw                string
@@ -158,6 +159,8 @@ func (rc *RuntimeCtx) Set(key string, val string) error {
 		rc.PGSrvAddress = val
 	case PgSrvLogLevelKey:
 		rc.PGSrvLogLevel = val
+	case ExportAliasKey:
+		rc.ExportAlias = val
 	case PgSrvPortKey:
 		retVal = setInt(&rc.PGSrvPort, val)
 	case PgSrvRawTLSCfgKey:

--- a/internal/stackql/entryutil/entryutil.go
+++ b/internal/stackql/entryutil/entryutil.go
@@ -67,7 +67,7 @@ func BuildInputBundle(runtimeCtx dto.RuntimeCtx) (bundle.Bundle, error) {
 		namespaces.GetAnalyticsCacheTableNamespaceConfigurator().GetLikeString(),
 		controlAttributes,
 		sqlCfg,
-		ac, typCfg)
+		ac, typCfg, runtimeCtx.ExportAlias)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stackql/handler/handler.go
+++ b/internal/stackql/handler/handler.go
@@ -89,6 +89,9 @@ type HandlerContext interface { //nolint:revive // don't mind stuttering this on
 
 	GetTSM() (tsm.TSM, bool)
 	SetTSM(tsm.TSM)
+
+	SetExportNamespace(string)
+	GetExportNamespace() string
 }
 
 type standardHandlerContext struct {
@@ -123,6 +126,15 @@ type standardHandlerContext struct {
 	typCfg              typing.Config
 	sessionContext      dto.SessionContext
 	walInstance         tsm.TSM
+	exportNamespace     string
+}
+
+func (hc *standardHandlerContext) SetExportNamespace(exportNamespace string) {
+	hc.exportNamespace = exportNamespace
+}
+
+func (hc *standardHandlerContext) GetExportNamespace() string {
+	return hc.exportNamespace
 }
 
 func (hc *standardHandlerContext) GetTSM() (tsm.TSM, bool) {
@@ -442,6 +454,7 @@ func (hc *standardHandlerContext) Clone() HandlerContext {
 		txnCoordinatorCtx:   hc.txnCoordinatorCtx,
 		typCfg:              hc.typCfg,
 		sessionContext:      hc.sessionContext,
+		exportNamespace:     hc.exportNamespace,
 	}
 	return &rv
 }
@@ -484,6 +497,7 @@ func GetHandlerCtx(
 		txnCoordinatorCtx:   inputBundle.GetTxnCoordinatorContext(),
 		typCfg:              inputBundle.GetTypingConfig(),
 		sessionContext:      inputBundle.GetSessionContext(),
+		exportNamespace:     runtimeCtx.ExportAlias,
 	}
 	drmCfg, err := drm.GetDRMConfig(inputBundle.GetSQLSystem(),
 		inputBundle.GetTypingConfig(),

--- a/internal/stackql/internal_data_transfer/internaldto/materialized_view_dto.go
+++ b/internal/stackql/internal_data_transfer/internaldto/materialized_view_dto.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO: refactor
+//nolint:dupl,nolintlint // TODO: refactor
 package internaldto
 
 import (
@@ -9,16 +9,18 @@ var (
 	_ RelationDTO = &standardMaterializedViewDTO{}
 )
 
-func NewMaterializedViewDTO(viewName, rawViewQuery string) RelationDTO {
+func NewMaterializedViewDTO(viewName, rawViewQuery, namespace string) RelationDTO {
 	return &standardMaterializedViewDTO{
 		viewName:     viewName,
 		rawViewQuery: rawViewQuery,
+		namespace:    namespace,
 	}
 }
 
 type standardMaterializedViewDTO struct {
 	rawViewQuery string
 	viewName     string
+	namespace    string
 	columns      []typing.RelationalColumn
 }
 
@@ -32,6 +34,10 @@ func (v *standardMaterializedViewDTO) GetName() string {
 
 func (v *standardMaterializedViewDTO) IsMaterialized() bool {
 	return true
+}
+
+func (v *standardMaterializedViewDTO) GetNamespace() string {
+	return v.namespace
 }
 
 func (v *standardMaterializedViewDTO) IsTable() bool {

--- a/internal/stackql/internal_data_transfer/internaldto/physical_table_dto.go
+++ b/internal/stackql/internal_data_transfer/internaldto/physical_table_dto.go
@@ -1,4 +1,4 @@
-//nolint:dupl // TODO: refactor
+//nolint:dupl,nolintlint // TODO: refactor
 package internaldto
 
 import (
@@ -9,16 +9,18 @@ var (
 	_ RelationDTO = &standardPhysicalTableDTO{}
 )
 
-func NewPhysicalTableDTO(viewName, rawViewQuery string) RelationDTO {
+func NewPhysicalTableDTO(viewName, rawViewQuery, namespace string) RelationDTO {
 	return &standardPhysicalTableDTO{
 		viewName:     viewName,
 		rawViewQuery: rawViewQuery,
+		namespace:    namespace,
 	}
 }
 
 type standardPhysicalTableDTO struct {
 	rawViewQuery string
 	viewName     string
+	namespace    string
 	columns      []typing.RelationalColumn
 }
 
@@ -28,6 +30,10 @@ func (v *standardPhysicalTableDTO) GetRawQuery() string {
 
 func (v *standardPhysicalTableDTO) GetName() string {
 	return v.viewName
+}
+
+func (v *standardPhysicalTableDTO) GetNamespace() string {
+	return v.namespace
 }
 
 func (v *standardPhysicalTableDTO) IsMaterialized() bool {

--- a/internal/stackql/internal_data_transfer/internaldto/view_dto.go
+++ b/internal/stackql/internal_data_transfer/internaldto/view_dto.go
@@ -18,6 +18,7 @@ type RelationDTO interface {
 	GetName() string
 	IsMaterialized() bool
 	IsTable() bool
+	GetNamespace() string
 	GetColumns() []typing.RelationalColumn
 	SetColumns(columns []typing.RelationalColumn)
 }
@@ -34,6 +35,10 @@ func (v *standardViewDTO) GetRawQuery() string {
 
 func (v *standardViewDTO) GetName() string {
 	return v.viewName
+}
+
+func (v *standardViewDTO) GetNamespace() string {
+	return ""
 }
 
 func (v *standardViewDTO) IsMaterialized() bool {

--- a/internal/stackql/parserutil/parser_util.go
+++ b/internal/stackql/parserutil/parser_util.go
@@ -819,13 +819,17 @@ func isCreatePhysicalTable(ddl *sqlparser.DDL) bool {
 	}
 }
 
-func RenderDDLStmt(ddl *sqlparser.DDL) string {
-	return renderDDLStmt(ddl)
+func RenderDDLTableSpecStmt(ddl *sqlparser.DDL) (string, error) {
+	return renderDDLTableSpecStmt(ddl)
 }
 
-func renderDDLStmt(ddl *sqlparser.DDL) string {
+func renderDDLTableSpecStmt(ddl *sqlparser.DDL) (string, error) {
+	if ddl == nil || ddl.TableSpec == nil {
+		return "", fmt.Errorf("cannot render DDL table spec for ddl = '%v'", ddl)
+	}
 	return strings.ReplaceAll(
-		astformat.String(ddl, astformat.DefaultSelectExprsFormatter), `"`, "")
+			astformat.String(ddl.TableSpec, astformat.DefaultSelectExprsFormatter), `"`, ""),
+		nil
 }
 
 func RenderDDLSelectStmt(ddl *sqlparser.DDL) string {

--- a/internal/stackql/sql_system/sql_system.go
+++ b/internal/stackql/sql_system/sql_system.go
@@ -116,6 +116,9 @@ type SQLSystem interface {
 	ObtainRelationalColumnsFromExternalSQLtable(
 		hierarchyIDs internaldto.HeirarchyIdentifiers,
 	) ([]typing.RelationalColumn, error)
+
+	GetFullyQualifiedRelationName(tableName string) string
+	IsRelationExported(relationName string) bool
 }
 
 func getNodeFormatter(name string) sqlparser.NodeFormatter {
@@ -135,6 +138,7 @@ func NewSQLSystem(
 	sqlCfg dto.SQLBackendCfg,
 	authCfg map[string]*dto.AuthCtx,
 	typCfg typing.Config,
+	exportNamepsace string,
 ) (SQLSystem, error) {
 	name := sqlCfg.SQLSystem
 	nameLowered := strings.ToLower(name)
@@ -149,6 +153,7 @@ func NewSQLSystem(
 			sqlCfg,
 			authCfg,
 			typCfg,
+			exportNamepsace,
 		)
 	case constants.SQLDialectPostgres:
 		return newPostgresSystem(
@@ -159,6 +164,7 @@ func NewSQLSystem(
 			sqlCfg,
 			authCfg,
 			typCfg,
+			exportNamepsace,
 		)
 	default:
 		return nil, fmt.Errorf("cannot initialise sql system: cannot accomodate sql dialect '%s'", name)

--- a/test/robot/functional/stackql.resource
+++ b/test/robot/functional/stackql.resource
@@ -62,6 +62,7 @@ Prepare StackQL Environment
     Start StackQL PG Server mTLS    ${PG_SRV_PORT_MTLS_WITH_NAMESPACES}    ${PG_SRV_MTLS_CFG_STR}    ${NAMESPACES_TTL_SPECIALCASE_TRANSPARENT}    {}    ${SQL_BACKEND_CFG_STR_CANONICAL}    ${PG_SRV_PORT_DOCKER_MTLS_WITH_NAMESPACES}
     Start StackQL PG Server mTLS    ${PG_SRV_PORT_MTLS_WITH_EAGER_GC}    ${PG_SRV_MTLS_CFG_STR}    {}    ${GC_CFG_EAGER}    ${SQL_BACKEND_CFG_STR_CANONICAL}    ${PG_SRV_PORT_DOCKER_MTLS_WITH_EAGER_GC}
     Start StackQL PG Server unencrypted    ${PG_SRV_PORT_UNENCRYPTED}    {}    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    Start StackQL PG Server mTLS Expose Backing DB    ${PG_SRV_PORT_MTLS_EXPORT}    ${PG_SRV_MTLS_CFG_STR}    {}    {}    ${SQL_BACKEND_CFG_STR_CANONICAL}    ${PG_SRV_PORT_DOCKER_MTLS_EXPORT}
     Start Postgres External Source If Viable
     Sleep    50s
 
@@ -99,6 +100,39 @@ Start StackQL PG Server mTLS
                         ...  bash
                         ...  \-c
                         ...  sleep 2 && stackql srv \-\-execution\.concurrency\.limit\=${CONCURRENCY_LIMIT} \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-gc\='${_GC_CFG}' \-\-sqlBackend\='${_SQL_BACKEND_CFG}' \-\-dbInternal\='${DB_INTERNAL_CFG_LAX}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\='0.0.0.0' \-\-pgsrv\.port\=${_DOCKER_PORT} \-\-pgsrv\.tls\='{\"keyFilePath\": \"/opt/stackql/srv/credentials/pg_server_key.pem\", \"certFilePath\": \"/opt/stackql/srv/credentials/pg_server_cert.pem\", \"clientCAs\": [\"'$(base64 -w 0 /opt/stackql/srv/credentials/pg_client_cert.pem)'\"]}'
+                        ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
+                        ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
+    END
+    [Return]    ${process}
+
+Start StackQL PG Server mTLS Expose Backing DB
+    [Arguments]    ${_SRV_PORT_MTLS}    ${_MTLS_CFG_STR}    ${_NAMESPACES_CFG}    ${_GC_CFG}    ${_SQL_BACKEND_CFG}    ${_DOCKER_PORT}
+    IF    "${EXECUTION_PLATFORM}" == "native"
+        ${process} =    Start Process    ${STACKQL_EXE}
+                        ...  srv    \-\-registry\=${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('native')}
+                        ...  \-\-auth\=${AUTH_CFG_STR}
+                        ...  \-\-tls\.allowInsecure\=true
+                        ...  \-\-pgsrv\.address\=0.0.0.0 
+                        ...  \-\-pgsrv\.port\=${_SRV_PORT_MTLS} 
+                        ...  \-\-pgsrv\.tls    ${_MTLS_CFG_STR}
+                        ...  \-\-namespaces\=${_NAMESPACES_CFG}
+                        ...  \-\-gc\=${_GC_CFG}
+                        ...  \-\-execution\.concurrency\.limit\=${CONCURRENCY_LIMIT}
+                        ...  \-\-sqlBackend\=${_SQL_BACKEND_CFG}
+                        ...  \-\-dbInternal\=${DB_INTERNAL_CFG_LAX}
+                        ...  \-\-export.alias\=stackql_export
+                        ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
+                        ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
+    ELSE IF    "${EXECUTION_PLATFORM}" == "docker"
+        ${process} =    Start Process    docker    compose
+                        ...  \-p     stackqlpgsrv\-mtls\-${_DOCKER_PORT}
+                        ...  \-f    ./docker\-compose\-persist\-postgres.yml
+                        ...  run
+                        ...  \-\-rm    \-p${_SRV_PORT_MTLS}:${_DOCKER_PORT}/tcp
+                        ...  stackqlsrv
+                        ...  bash
+                        ...  \-c
+                        ...  sleep 2 && stackql srv \-\-execution\.concurrency\.limit\=${CONCURRENCY_LIMIT} \-\-registry\='${REGISTRY_NO_VERIFY_CFG_STR.get_config_str('docker')}' \-\-auth\='${AUTH_CFG_STR}' \-\-namespaces\='${_NAMESPACES_CFG}' \-\-gc\='${_GC_CFG}' \-\-sqlBackend\='${_SQL_BACKEND_CFG}' \-\-export.alias\='stackql_export' \-\-dbInternal\='${DB_INTERNAL_CFG_LAX}' \-\-tls\.allowInsecure\=true \-\-pgsrv\.address\='0.0.0.0' \-\-pgsrv\.port\=${_DOCKER_PORT} \-\-pgsrv\.tls\='{\"keyFilePath\": \"/opt/stackql/srv/credentials/pg_server_key.pem\", \"certFilePath\": \"/opt/stackql/srv/credentials/pg_server_cert.pem\", \"clientCAs\": [\"'$(base64 -w 0 /opt/stackql/srv/credentials/pg_client_cert.pem)'\"]}'
                         ...  stderr=${CURDIR}/tmp/stdout-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
                         ...  stdout=${CURDIR}/tmp/stderr-stackql-srv-mtls-${_SRV_PORT_MTLS}.txt
     END

--- a/test/robot/functional/stackql_export.robot
+++ b/test/robot/functional/stackql_export.robot
@@ -1,0 +1,79 @@
+*** Settings ***
+Resource          ${CURDIR}/stackql.resource
+Test Setup        Remove File    ${EXPORT_SQLITE_FILE_PATH}
+Test Teardown     Stackql Per Test Teardown
+
+*** Test Cases *** 
+Export Materialized View and then Access From RDBMSs
+    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create materialized view nv as select BackupId, BackupState 
+    ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
+    ${ddlOutputStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ${queryStringSQLite} =    Catenate
+    ...    select BackupId, BackupState from "stackql_export.nv" order by BackupId;
+    ${queryStringPostgres} =    Catenate
+    ...    select "BackupId", "BackupState" from stackql_export.nv order by "BackupId";
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    bkp-000001,READY
+    ...    bkp-000002,READY
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_CLIENT_EXPORT_BACKEND}
+    ...    ${ddlInputStr}
+    ...    ${EMPTY}
+    ...    ${ddlOutputStr}
+    ...    \-\-export.alias\=stackql_export
+    ...    stdout=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs.tmp
+    ...    stderr=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-stderr.tmp
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-stage-2-stderr.tmp
+
+Export Materialized View and then Access From RDBMSs Over Stackql Postgres Server
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create materialized view nv as select BackupId, BackupState 
+    ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server.tmp
+    ...    stderr=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${queryStringSQLite} =    Catenate
+    ...    select BackupId, BackupState from "stackql_export.nv" order by BackupId;
+    ${queryStringPostgres} =    Catenate
+    ...    select "BackupId", "BackupState" from stackql_export.nv order by "BackupId";
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    BackupId,BackupState
+    ...    bkp-000001,READY
+    ...    bkp-000002,READY
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2-stderr.tmp 

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -12,7 +12,7 @@ from robot.libraries.Collections import Collections
 from robot.libraries.Process import Process
 from robot.libraries.OperatingSystem import OperatingSystem 
 
-from stackql_context import RegistryCfg, _TEST_APP_CACHE_ROOT
+from stackql_context import RegistryCfg, _TEST_APP_CACHE_ROOT, PSQL_EXE, SQLITE_EXE
 from ShellSession import ShellSession
 from psycopg_client import PsycoPGClient
 from psycopg2_client import PsycoPG2Client
@@ -55,8 +55,71 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       psql_exe, 
       '-d', _mod_conn, 
       '-c', query,
+      *args,
       **cfg,
     )
+    self.log(result.stdout)
+    self.log(result.stderr)
+    return result
+  
+  @keyword
+  def should_rdbms_query_return_csv_result(
+    self,
+    db_name :str,
+    sql_client_export_connection_arg :str,
+    query :str,
+    expected_output :str,
+    expected_stderr_output :str,
+    *args,
+    **kwargs):
+    result = None
+    if db_name == "sqlite":
+      result = self._run_sqlite_command(
+        SQLITE_EXE,
+        sql_client_export_connection_arg,
+        query,
+        *("--csv",),
+        **kwargs,
+      )
+    elif db_name == "postgres":
+      result = self._run_PG_client_command(
+        os.getcwd(),
+        PSQL_EXE,
+        sql_client_export_connection_arg,
+        query,
+        *("--csv",),
+        **kwargs,
+      )
+    return self._verify_both_streams(result, expected_output, expected_stderr_output)
+  
+
+  def _verify_both_streams(self, result, expected_output, expected_stderr_output):
+    stdout_ok = self.should_be_equal(result.stdout, expected_output)
+    if self._execution_platform == "docker":
+      # cannot silence stupid compose status logs
+      stderr_ok = self.should_contain(result.stderr, expected_stderr_output)
+      return stdout_ok and stderr_ok
+    stderr_ok = self.should_be_equal(result.stderr, expected_stderr_output)
+    return stdout_ok and stderr_ok
+
+  def _run_sqlite_command(self, sqlite_exe :str, sqlite_db_file :str, query :str, *args, **cfg):
+    self.log_to_console(f"sqlite_exe = '{sqlite_exe}'")
+    result = None
+    if len(args) == 0:
+      result = super().run_process(
+        sqlite_exe,
+        sqlite_db_file, 
+        query,
+        **cfg,
+      )
+    else:
+      result = super().run_process(
+        sqlite_exe,
+        *args,
+        sqlite_db_file, 
+        query,
+        **cfg,
+      )
     self.log(result.stdout)
     self.log(result.stderr)
     return result
@@ -155,6 +218,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
   def _docker_transform_args(self, *args) -> typing.Iterable:
     rv = [ f"--namespaces='{b[13:]}'" if type(b) == str and b.startswith('--namespaces=') else b for b in list(args) ]
     rv = [ f"--sqlBackend='{b[13:]}'" if type(b) == str and b.startswith('--sqlBackend=') else b for b in list(rv) ]
+    rv = [ f"--export.alias='{b[15:]}'" if type(b) == str and b.startswith('--export.alias=') else b for b in list(rv) ]
     return rv
 
   def _run_stackql_exec_command_docker(
@@ -173,6 +237,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       query = query.decode("utf-8") 
     reg_location = registry_cfg.get_source_path_for_docker()
     supplied_args = []
+    stackql_persist_postgres_as_needed = cfg.pop('stackql_persist_postgres_as_needed', False)
     if cfg.pop('stackql_rollback_eager', False):
       supplied_args.append("--session='{\"rollback_type\":\"eager\"}'")
     if cfg.pop('stackql_H', False):
@@ -347,6 +412,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
     self.set_environment_variable("DUMMY_DIGITALOCEAN_USERNAME", f"{self._get_default_env().get('DUMMY_DIGITALOCEAN_USERNAME')}")
     self.set_environment_variable("DUMMY_DIGITALOCEAN_PASSWORD", f"{self._get_default_env().get('DUMMY_DIGITALOCEAN_PASSWORD')}")
     supplied_args = [ stackql_exe, "exec" ]
+    stackql_persist_postgres_as_needed = cfg.pop('stackql_persist_postgres_as_needed', False)
     if cfg.pop('stackql_rollback_eager', False):
       supplied_args.append("--session={\"rollback_type\":\"eager\"}")
     if cfg.pop('stackql_H', False):
@@ -479,6 +545,27 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       psql_conn_str,
       query
     )
+    return self.should_be_equal(result.stdout, expected_output)
+  
+
+  @keyword
+  def should_sqlite_inline_equal(self, curdir :str, sqlite_exe :str, sqlite_db_file :str, query :str, expected_output :str, *args, **kwargs):
+    result = None
+    if len(args) == 0:
+      result =    self._run_sqlite_command(
+        curdir,
+        sqlite_exe,
+        sqlite_db_file,
+        query
+      )
+    else:
+      result =    self._run_sqlite_command(
+        curdir,
+        sqlite_exe,
+        *args,
+        sqlite_db_file,
+        query
+      ) 
     return self.should_be_equal(result.stdout, expected_output)
   
 
@@ -706,13 +793,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       *args,
       **cfg
     )
-    stdout_ok = self.should_be_equal(result.stdout, expected_output)
-    if self._execution_platform == "docker":
-      # cannot silence stupid compose status logs
-      stderr_ok = self.should_contain(result.stderr, expected_stderr_output)
-      return stdout_ok and stderr_ok
-    stderr_ok = self.should_be_equal(result.stderr, expected_stderr_output)
-    return stdout_ok and stderr_ok
+    return self._verify_both_streams(result, expected_output, expected_stderr_output)
 
 
   @keyword


### PR DESCRIPTION
## Description

- Export materializations to their own schema / namespace, configurably.
- Publish `materialized view` relations to dedicated namespace.
- Added robot test `Export Materialized View and then Access From RDBMSs`.
- Added robot test `Export Materialized View and then Access From RDBMSs Over Stackql Postgres Server`.
- Added `sqlite3` to docker testing image.
- Added `sqlite` to windows testing image.
- Works for both `postgres` and `sqlite` backends, using schema and dot-delimited table names, respectively.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Export Materialized View and then Access From RDBMSs`.
- Added robot test `Export Materialized View and then Access From RDBMSs Over Stackql Postgres Server`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
