### PR TITLE
export-expanded

### DIFF
--- a/internal/stackql/sql_system/sqlite.go
+++ b/internal/stackql/sql_system/sqlite.go
@@ -666,7 +666,7 @@ func (eng *sqLiteSystem) InsertIntoPhysicalTable(naiveTableName string,
 	}
 	fullyQualifiedRelationName := eng.getFullyQualifiedRelationName(naiveTableName)
 	// TODO: check colz against supplied columns
-	relationDTO, relationDTOok := eng.getTableByName(fullyQualifiedRelationName, txn)
+	relationDTO, relationDTOok := eng.getTableByName(naiveTableName, txn)
 	if !relationDTOok {
 		if len(relationDTO.GetColumns()) == 0 {
 		}
@@ -946,7 +946,8 @@ func (eng *sqLiteSystem) getFullyQualifiedRelationName(tableName string) string 
 	if eng.exportNamespace == "" {
 		return tableName
 	}
-	return fmt.Sprintf(`"%s.%s"`, eng.exportNamespace, tableName)
+	strippedTableName := strings.ReplaceAll(tableName, `"`, "")
+	return fmt.Sprintf(`"%s.%s"`, eng.exportNamespace, strippedTableName)
 }
 
 // TODO: implement temp table creation

--- a/test/robot/functional/stackql_export.robot
+++ b/test/robot/functional/stackql_export.robot
@@ -77,3 +77,107 @@ Export Materialized View and then Access From RDBMSs Over Stackql Postgres Serve
     ...    ${EMPTY}
     ...    stdout=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2.tmp
     ...    stderr=${CURDIR}/tmp/Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2-stderr.tmp 
+
+Export User Space Table and then Access From RDBMSs
+    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create table my_silly_export_table(id int, name text, magnitude numeric);
+    ...    insert into my_silly_export_table(id, name, magnitude) values (1, 'one', 1.0);
+    ...    insert into my_silly_export_table(id, name, magnitude) values (2, 'two', 2.0);
+    ${ddlOutputStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ...    insert into table completed
+    ...    insert into table completed
+    ${queryStringSQLite} =    Catenate
+    ...    select id, name, magnitude from "stackql_export.my_silly_export_table" order by id;
+    ${queryStringPostgres} =    Catenate
+    ...    select id, name, magnitude from stackql_export.my_silly_export_table order by id;
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    1,one,1
+    ...    2,two,2
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_CLIENT_EXPORT_BACKEND}
+    ...    ${ddlInputStr}
+    ...    ${EMPTY}
+    ...    ${ddlOutputStr}
+    ...    \-\-export.alias\=stackql_export
+    ...    stdout=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs.tmp
+    ...    stderr=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-stderr.tmp
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-stage-2-stderr.tmp
+
+Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create table my_silly_export_table_two(id int, name text, magnitude numeric);
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (1, 'one', 1.0);
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (2, 'two', 2.0);
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server.tmp
+    ...    stderr=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${ddlInputStr} =    Catenate
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (1, 'one', 1.0);
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-one.tmp
+    ...    stderr=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-one-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${ddlInputStr} =    Catenate
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (2, 'two', 2.0);
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-two.tmp
+    ...    stderr=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-two-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${queryStringSQLite} =    Catenate
+    ...    select id, name, magnitude from "stackql_export.my_silly_export_table_two" order by id;
+    ${queryStringPostgres} =    Catenate
+    ...    select id, name, magnitude from stackql_export.my_silly_export_table_two order by id;
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    id,name,magnitude
+    ...    1,one,1.0
+    ...    2,two,2.0
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2-stderr.tmp 


### PR DESCRIPTION
## Description

- Support for export of user space tables.
- Added robot test `Export User Space Table and then Access From RDBMSs`.
- Added robot test `Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server`.
- Postgres logic adjusted.
- Identified bug: One statement per psql string only at this stage.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Export User Space Table and then Access From RDBMSs`.
- Added robot test `Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
