### PR TITLE
export-relation-life-cycle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -352,7 +352,8 @@
         "--registry=${input:registryString}",
         "--namespaces=${input:namespaceString}",
         "--sqlBackend=${input:sqlBackendString}",
-        "--dbInternal=${input:dbInternalString}"
+        "--dbInternal=${input:dbInternalString}",
+        "--export.alias=${input:exportAliasString}"
       ],
     },
     {
@@ -371,7 +372,8 @@
         "--namespaces=${input:namespaceString}",
         "--sqlBackend=${input:sqlBackendString}",
         "--dbInternal=${input:dbInternalString}",
-        "--pgsrv.tls=${input:pgsrvTlsString}"
+        "--pgsrv.tls=${input:pgsrvTlsString}",
+        "--export.alias=${input:exportAliasString}"
       ],
     },
     {
@@ -389,7 +391,8 @@
         "--registry=${input:registryString}",
         "--namespaces=${input:namespaceString}",
         "--sqlBackend={ \"dbEngine\": \"postgres_tcp\", \"sqlDialect\": \"postgres\", \"dsn\": \"postgres://stackql:stackql@127.0.0.1:7432/stackql\" }",
-        "--dbInternal=${input:dbInternalString}"
+        "--dbInternal=${input:dbInternalString}",
+        "--export.alias=${input:exportAliasString}"
       ],
     },
     {

--- a/internal/stackql/drm/drm_cfg.go
+++ b/internal/stackql/drm/drm_cfg.go
@@ -94,6 +94,7 @@ type Config interface {
 		ctxParameterized PreparedStatementParameterized,
 	) error
 	GetFullyQualifiedRelationName(string) string
+	DelimitFullyQualifiedRelationName(string) string
 }
 
 type staticDRMConfig struct {
@@ -117,6 +118,10 @@ func (dc *staticDRMConfig) GetTable(
 
 func (dc *staticDRMConfig) GetFullyQualifiedRelationName(relationName string) string {
 	return dc.sqlSystem.GetFullyQualifiedRelationName(relationName)
+}
+
+func (dc *staticDRMConfig) DelimitFullyQualifiedRelationName(fqtn string) string {
+	return dc.sqlSystem.DelimitFullyQualifiedRelationName(fqtn)
 }
 
 func (dc *staticDRMConfig) OpenapiColumnsToRelationalColumns(

--- a/internal/stackql/sql_system/sql_system.go
+++ b/internal/stackql/sql_system/sql_system.go
@@ -118,6 +118,7 @@ type SQLSystem interface {
 	) ([]typing.RelationalColumn, error)
 
 	GetFullyQualifiedRelationName(tableName string) string
+	DelimitFullyQualifiedRelationName(string) string
 	IsRelationExported(relationName string) bool
 }
 

--- a/test/robot/functional/stackql_export.robot
+++ b/test/robot/functional/stackql_export.robot
@@ -185,7 +185,7 @@ Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server
 Lifecycle Export Materialized View and then Access From RDBMSs
     Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
     ${ddlInputStr} =    Catenate
-    ...    create materialized view nv as select 'junk' as id, BackupId, BackupState 
+    ...    create or replace materialized view nv as select 'junk' as id, BackupId, BackupState 
     ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
     ...    create or replace materialized view nv as select BackupId, BackupState 
     ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
@@ -276,11 +276,11 @@ Lifecycle Export Materialized View and then Access From RDBMSs Over Stackql Post
 Lifecycle Export User Space Table and then Access From RDBMSs
     Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
     ${ddlInputStr} =    Catenate
-    ...    create table my_silly_export_table(id int, name text, magnitude numeric);
-    ...    drop table my_silly_export_table;
-    ...    create table my_silly_export_table(id int, name text, magnitude numeric);
-    ...    insert into my_silly_export_table(id, name, magnitude) values (1, 'one', 1.0);
-    ...    insert into my_silly_export_table(id, name, magnitude) values (2, 'two', 2.0);
+    ...    create table my_silly_export_table_two(id int, name text, magnitude numeric);
+    ...    drop table my_silly_export_table_two;
+    ...    create table my_silly_export_table_two(id int, name text, magnitude numeric);
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (1, 'one', 1.0);
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (2, 'two', 2.0);
     ${ddlOutputStr} =    Catenate    SEPARATOR=\n
     ...    DDL Execution Completed
     ...    DDL Execution Completed
@@ -288,9 +288,9 @@ Lifecycle Export User Space Table and then Access From RDBMSs
     ...    insert into table completed
     ...    insert into table completed
     ${queryStringSQLite} =    Catenate
-    ...    select id, name, magnitude from "stackql_export.my_silly_export_table" order by id;
+    ...    select id, name, magnitude from "stackql_export.my_silly_export_table_two" order by id;
     ${queryStringPostgres} =    Catenate
-    ...    select id, name, magnitude from stackql_export.my_silly_export_table order by id;
+    ...    select id, name, magnitude from stackql_export.my_silly_export_table_two order by id;
     ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
     ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
     ${queryOutputStr} =    Catenate    SEPARATOR=\n
@@ -321,6 +321,18 @@ Lifecycle Export User Space Table and then Access From RDBMSs
 
 Lifecycle Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server
     Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    drop table if exists my_silly_export_table_two;
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-Drop-Guard.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-Drop-Guard-stderr.tmp
     ${ddlInputStr} =    Catenate
     ...    create table my_silly_export_table_two(id int, name text, magnitude numeric);
     ${posixInput} =     Catenate

--- a/test/robot/functional/stackql_export.robot
+++ b/test/robot/functional/stackql_export.robot
@@ -227,7 +227,7 @@ Lifecycle Export Materialized View and then Access From RDBMSs
 Lifecycle Export Materialized View and then Access From RDBMSs Over Stackql Postgres Server
     Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
     ${ddlInputStr} =    Catenate
-    ...    create materialized view nv as select 'junk' as c1, BackupId, BackupState 
+    ...    create or replace materialized view nv as select 'junk' as c1, BackupId, BackupState 
     ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
     ${posixInput} =     Catenate
     ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"

--- a/test/robot/functional/stackql_export.robot
+++ b/test/robot/functional/stackql_export.robot
@@ -181,3 +181,226 @@ Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server
     ...    ${EMPTY}
     ...    stdout=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2.tmp
     ...    stderr=${CURDIR}/tmp/Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2-stderr.tmp 
+
+Lifecycle Export Materialized View and then Access From RDBMSs
+    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create materialized view nv as select 'junk' as id, BackupId, BackupState 
+    ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
+    ...    create or replace materialized view nv as select BackupId, BackupState 
+    ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
+    ${ddlOutputStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    ${queryStringSQLite} =    Catenate
+    ...    select BackupId, BackupState from "stackql_export.nv" order by BackupId;
+    ${queryStringPostgres} =    Catenate
+    ...    select "BackupId", "BackupState" from stackql_export.nv order by "BackupId";
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    bkp-000001,READY
+    ...    bkp-000002,READY
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_CLIENT_EXPORT_BACKEND}
+    ...    ${ddlInputStr}
+    ...    ${EMPTY}
+    ...    ${ddlOutputStr}
+    ...    \-\-export.alias\=stackql_export
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-stderr.tmp
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-stage-2-stderr.tmp
+
+Lifecycle Export Materialized View and then Access From RDBMSs Over Stackql Postgres Server
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create materialized view nv as select 'junk' as c1, BackupId, BackupState 
+    ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${ddlInputStr} =    Catenate
+    ...    create or replace materialized view nv as select BackupId, BackupState 
+    ...    from aws.cloudhsm.backups where region = 'ap-southeast-2' order by BackupId;
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${queryStringSQLite} =    Catenate
+    ...    select BackupId, BackupState from "stackql_export.nv" order by BackupId;
+    ${queryStringPostgres} =    Catenate
+    ...    select "BackupId", "BackupState" from stackql_export.nv order by "BackupId";
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    BackupId,BackupState
+    ...    bkp-000001,READY
+    ...    bkp-000002,READY
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-Materialized-View-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2-stderr.tmp 
+
+Lifecycle Export User Space Table and then Access From RDBMSs
+    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create table my_silly_export_table(id int, name text, magnitude numeric);
+    ...    drop table my_silly_export_table;
+    ...    create table my_silly_export_table(id int, name text, magnitude numeric);
+    ...    insert into my_silly_export_table(id, name, magnitude) values (1, 'one', 1.0);
+    ...    insert into my_silly_export_table(id, name, magnitude) values (2, 'two', 2.0);
+    ${ddlOutputStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    ...    insert into table completed
+    ...    insert into table completed
+    ${queryStringSQLite} =    Catenate
+    ...    select id, name, magnitude from "stackql_export.my_silly_export_table" order by id;
+    ${queryStringPostgres} =    Catenate
+    ...    select id, name, magnitude from stackql_export.my_silly_export_table order by id;
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    1,one,1
+    ...    2,two,2
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_CLIENT_EXPORT_BACKEND}
+    ...    ${ddlInputStr}
+    ...    ${EMPTY}
+    ...    ${ddlOutputStr}
+    ...    \-\-export.alias\=stackql_export
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-stderr.tmp
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-stage-2-stderr.tmp
+
+Lifecycle Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    TODO: FIX THIS... Engineer a way to do postgres and sqlite export testing in same test case
+    ${ddlInputStr} =    Catenate
+    ...    create table my_silly_export_table_two(id int, name text, magnitude numeric);
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${ddlInputStr} =    Catenate
+    ...    drop table my_silly_export_table_two;
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-Drop.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-Drop-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${ddlInputStr} =    Catenate
+    ...    create table my_silly_export_table_two(id int, name text, magnitude numeric);
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-Recreate.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-Recreate-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${ddlInputStr} =    Catenate
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (1, 'one', 1.0);
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-one.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-one-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${ddlInputStr} =    Catenate
+    ...    insert into my_silly_export_table_two(id, name, magnitude) values (2, 'two', 2.0);
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     "${PSQL_MTLS_CONN_STR_EXPORT_UNIX}"   -c   "${ddlInputStr}"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-two.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-insert-two-stderr.tmp
+    Should Be Equal    ${result.stdout}    OK
+    ${queryStringSQLite} =    Catenate
+    ...    select id, name, magnitude from "stackql_export.my_silly_export_table_two" order by id;
+    ${queryStringPostgres} =    Catenate
+    ...    select id, name, magnitude from stackql_export.my_silly_export_table_two order by id;
+    ${dbName} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     postgres    sqlite
+    ${queryString} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${queryStringPostgres}    ${queryStringSQLite}
+    ${queryOutputStr} =    Catenate    SEPARATOR=\n
+    ...    id,name,magnitude
+    ...    1,one,1.0
+    ...    2,two,2.0
+    Should RDBMS Query Return CSV Result
+    ...    ${dbName}
+    ...    ${SQL_CLIENT_EXPORT_CONNECTION_ARG}
+    ...    ${queryString}
+    ...    ${queryOutputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2.tmp
+    ...    stderr=${CURDIR}/tmp/Lifecycle-Export-User-Space-Table-and-then-Access-From-RDBMSs-Over-Stackql-Postgres-Server-stage-2-stderr.tmp 


### PR DESCRIPTION
## Description

- Support for basic lifecycle of exported relations.
- Added robot test `Lifecycle Export Materialized View and then Access From RDBMSs`.
- Added robot test `Lifecycle Export Materialized View and then Access From RDBMSs Over Stackql Postgres Server`.
- Added robot test `Lifecycle Export User Space Table and then Access From RDBMSs`.
- Added robot test `Lifecycle Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Lifecycle Export Materialized View and then Access From RDBMSs`.
- Added robot test `Lifecycle Export Materialized View and then Access From RDBMSs Over Stackql Postgres Server`.
- Added robot test `Lifecycle Export User Space Table and then Access From RDBMSs`.
- Added robot test `Lifecycle Export User Space Table and then Access From RDBMSs Over Stackql Postgres Server`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
