### PR TITLE
real-world-s3-hybrid-insert

### DIFF
--- a/test/mockserver/expectations/static-aws-expectations.json
+++ b/test/mockserver/expectations/static-aws-expectations.json
@@ -697,7 +697,7 @@
         "type": "JSON",
         "json": {
           "TypeName": "AWS::S3::Bucket",
-          "DesiredState": "{ \"Properties\": { \"BucketName\": \"my-bucket\" } }"
+          "DesiredState": "{ \"BucketName\": \"my-bucket\" }"
         },
         "matchType": "STRICT"
       }

--- a/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
+++ b/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache 2.0 License
     url: 'http://www.apache.org/licenses/'
   x-providerName: amazonaws.com
-  x-serviceName: pseudo_s3
+  x-serviceName: cloudcontrolapi
 externalDocs:
   description: Amazon Web Services documentation
   url: 'https://docs.aws.amazon.com/cloudcontrolapi/'
@@ -382,7 +382,7 @@ components:
             default: |
               {
                 "TypeName": "AWS::S3::Bucket",
-                "DesiredState": "{ \"Properties\": { \"BucketName\": \"my-bucket\" } }"
+                "DesiredState": "{ \"BucketName\": \"my-bucket\" }"
               }
           response:
             mediaType: application/json

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -336,7 +336,7 @@ AWS Hybrid Service Cloud Control S3 Bucket Insert Dynamic
     ...              ) 
     ...              select 
     ...              'ap-southeast-1',
-    ...              string('{ "Properties": { "BucketName": "my-bucket" } }')
+    ...              string('{ "BucketName": "my-bucket" }')
     ...              ;
     Should StackQL Exec Inline Equal Both Streams
     ...    ${STACKQL_EXE}


### PR DESCRIPTION
## Description

- Adjusted `s3` hybrid resource insert API to match reality.
- Amended request payload and expectation for robot test `AWS Hybrid Service Cloud Control S3 Bucket Insert Defaulted`.
- Amended request payload and expectation for robot test `AWS Hybrid Service Cloud Control S3 Bucket Insert Dynamic`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Amended request payload and expectation for robot test `AWS Hybrid Service Cloud Control S3 Bucket Insert Defaulted`.
- Amended request payload and expectation for robot test `AWS Hybrid Service Cloud Control S3 Bucket Insert Dynamic`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
