### PR TITLE
empty-response-empty-table

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -144,6 +144,7 @@
         "select * from aws.pseudo_s3.s3_bucket_polymorphic;",
         "show methods in aws.pseudo_s3.s3_bucket_detail;",
         "select * from aws_cc_bucket_unfiltered where data__Identifier = 'stackql-trial-bucket-01' ;",
+        "select * from  google.cloudkms.key_rings where projectsId = 'testing-project' and locationsId = 'australia-southeast1';",
       ],
       "default": "show providers;"
     },

--- a/test/mockserver/expectations/static-gcp-expectations.json
+++ b/test/mockserver/expectations/static-gcp-expectations.json
@@ -5,6 +5,40 @@
         "accept": [ "application/json" ]
       },
       "method": "GET",
+      "path": "/v1/projects/testing-project/locations/australia-southeast1/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {}
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project/locations/global/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "keyRings": [
+          {
+            "name": "projects/testing-project/locations/global/keyRings/testing",
+            "createTime": "2022-02-02T02:02:02.02000000Z"
+          }
+        ],
+        "totalSize": 1
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
       "path": "/projects/testing-project/zones/australia-southeast1-a/instances/000000001/getIamPolicy"
     },
     "httpResponse": {

--- a/test/registry/src/googleapis.com/v0.1.2/services/cloudkms-v1.yaml
+++ b/test/registry/src/googleapis.com/v0.1.2/services/cloudkms-v1.yaml
@@ -1,0 +1,6486 @@
+openapi: 3.1.0
+info:
+  contact:
+    name: StackQL Studios
+    url: https://github.com/stackql/google-discovery-to-openapi
+    email: info@stackql.io
+  title: Cloud Key Management Service (KMS) API
+  description: >-
+    Manages keys and performs cryptographic operations in a central cloud
+    service, for direct use by other cloud resources and applications. 
+  version: v1
+  x-discovery-doc-revision: '20240523'
+  x-generated-date: '2024-06-02'
+externalDocs:
+  url: https://cloud.google.com/kms/
+servers:
+  - url: https://cloudkms.googleapis.com
+components:
+  securitySchemes:
+    Oauth2:
+      type: oauth2
+      description: Oauth 2.0 implicit authentication
+      flows:
+        implicit:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          scopes: &ref_0
+            https://www.googleapis.com/auth/cloud-platform: >-
+              See, edit, configure, and delete your Google Cloud data and see
+              the email address for your Google Account.
+            https://www.googleapis.com/auth/cloudkms: >-
+              View and manage your keys and secrets stored in Cloud Key
+              Management Service
+    Oauth2c:
+      type: oauth2
+      description: Oauth 2.0 authorization code authentication
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          tokenUrl: https://accounts.google.com/o/oauth2/token
+          scopes: *ref_0
+  schemas:
+    AutokeyConfig:
+      id: AutokeyConfig
+      description: Cloud KMS Autokey configuration for a folder.
+      type: object
+      properties:
+        name:
+          description: >-
+            Identifier. Name of the AutokeyConfig resource, e.g.
+            `folders/{FOLDER_NUMBER}/autokeyConfig`.
+          type: string
+        keyProject:
+          description: >-
+            Optional. Name of the key project, e.g. `projects/{PROJECT_ID}` or
+            `projects/{PROJECT_NUMBER}`, where Cloud KMS Autokey will provision
+            a new CryptoKey when a KeyHandle is created. On UpdateAutokeyConfig,
+            the caller will require `cloudkms.cryptoKeys.setIamPolicy`
+            permission on this key project. Once configured, for Cloud KMS
+            Autokey to function properly, this key project must have the Cloud
+            KMS API activated and the Cloud KMS Service Agent for this key
+            project must be granted the `cloudkms.admin` role (or pertinent
+            permissions). A request with an empty key project field will clear
+            the configuration.
+          type: string
+    ShowEffectiveAutokeyConfigResponse:
+      id: ShowEffectiveAutokeyConfigResponse
+      description: Response message for ShowEffectiveAutokeyConfig.
+      type: object
+      properties:
+        keyProject:
+          description: >-
+            Name of the key project configured in the resource project's folder
+            ancestry.
+          type: string
+    Operation:
+      id: Operation
+      description: >-
+        This resource represents a long-running operation that is the result of
+        a network API call.
+      type: object
+      properties:
+        name:
+          description: >-
+            The server-assigned name, which is only unique within the same
+            service that originally returns it. If you use the default HTTP
+            mapping, the `name` should be a resource name ending with
+            `operations/{unique_id}`.
+          type: string
+        metadata:
+          description: >-
+            Service-specific metadata associated with the operation. It
+            typically contains progress information and common metadata such as
+            create time. Some services might not provide such metadata. Any
+            method that returns a long-running operation should document the
+            metadata type, if any.
+          type: object
+          additionalProperties:
+            type: any
+            description: Properties of the object. Contains field @type with type URL.
+        done:
+          description: >-
+            If the value is `false`, it means the operation is still in
+            progress. If `true`, the operation is completed, and either `error`
+            or `response` is available.
+          type: boolean
+        error:
+          description: >-
+            The error result of the operation in case of failure or
+            cancellation.
+          $ref: '#/components/schemas/Status'
+        response:
+          description: >-
+            The normal, successful response of the operation. If the original
+            method returns no data on success, such as `Delete`, the response is
+            `google.protobuf.Empty`. If the original method is standard
+            `Get`/`Create`/`Update`, the response should be the resource. For
+            other methods, the response should have the type `XxxResponse`,
+            where `Xxx` is the original method name. For example, if the
+            original method name is `TakeSnapshot()`, the inferred response type
+            is `TakeSnapshotResponse`.
+          type: object
+          additionalProperties:
+            type: any
+            description: Properties of the object. Contains field @type with type URL.
+    Status:
+      id: Status
+      description: >-
+        The `Status` type defines a logical error model that is suitable for
+        different programming environments, including REST APIs and RPC APIs. It
+        is used by [gRPC](https://github.com/grpc). Each `Status` message
+        contains three pieces of data: error code, error message, and error
+        details. You can find out more about this error model and how to work
+        with it in the [API Design
+        Guide](https://cloud.google.com/apis/design/errors).
+      type: object
+      properties:
+        code:
+          description: The status code, which should be an enum value of google.rpc.Code.
+          type: integer
+          format: int32
+        message:
+          description: >-
+            A developer-facing error message, which should be in English. Any
+            user-facing error message should be localized and sent in the
+            google.rpc.Status.details field, or localized by the client.
+          type: string
+        details:
+          description: >-
+            A list of messages that carry the error details. There is a common
+            set of message types for APIs to use.
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: any
+              description: Properties of the object. Contains field @type with type URL.
+    KeyHandle:
+      id: KeyHandle
+      description: >-
+        Resource-oriented representation of a request to Cloud KMS Autokey and
+        the resulting provisioning of a CryptoKey.
+      type: object
+      properties:
+        name:
+          description: >-
+            Identifier. Name of the KeyHandle resource, e.g.
+            `projects/{PROJECT_ID}/locations/{LOCATION}/keyHandles/{KEY_HANDLE_ID}`.
+          type: string
+        kmsKey:
+          description: >-
+            Output only. Name of a CryptoKey that has been provisioned for
+            Customer Managed Encryption Key (CMEK) use in the KeyHandle project
+            and location for the requested resource type. The CryptoKey project
+            will reflect the value configured in the AutokeyConfig on the
+            resource project's ancestor folder at the time of the KeyHandle
+            creation. If more than one ancestor folder has a configured
+            AutokeyConfig, the nearest of these configurations is used.
+          readOnly: true
+          type: string
+        resourceTypeSelector:
+          description: >-
+            Required. Indicates the resource type that the resulting CryptoKey
+            is meant to protect, e.g. `{SERVICE}.googleapis.com/{TYPE}`. See
+            documentation for supported resource types.
+          type: string
+    ListKeyHandlesResponse:
+      id: ListKeyHandlesResponse
+      description: Response message for Autokey.ListKeyHandles.
+      type: object
+      properties:
+        keyHandles:
+          description: Resulting KeyHandles.
+          type: array
+          items:
+            $ref: '#/components/schemas/KeyHandle'
+    ListEkmConnectionsResponse:
+      id: ListEkmConnectionsResponse
+      description: Response message for EkmService.ListEkmConnections.
+      type: object
+      properties:
+        ekmConnections:
+          description: The list of EkmConnections.
+          type: array
+          items:
+            $ref: '#/components/schemas/EkmConnection'
+        nextPageToken:
+          description: >-
+            A token to retrieve next page of results. Pass this value in
+            ListEkmConnectionsRequest.page_token to retrieve the next page of
+            results.
+          type: string
+        totalSize:
+          description: The total number of EkmConnections that matched the query.
+          type: integer
+          format: int32
+    EkmConnection:
+      id: EkmConnection
+      description: >-
+        An EkmConnection represents an individual EKM connection. It can be used
+        for creating CryptoKeys and CryptoKeyVersions with a ProtectionLevel of
+        EXTERNAL_VPC, as well as performing cryptographic operations using keys
+        created within the EkmConnection.
+      type: object
+      properties:
+        name:
+          description: >-
+            Output only. The resource name for the EkmConnection in the format
+            `projects/*/locations/*/ekmConnections/*`.
+          readOnly: true
+          type: string
+        createTime:
+          description: Output only. The time at which the EkmConnection was created.
+          readOnly: true
+          type: string
+          format: google-datetime
+        serviceResolvers:
+          description: >-
+            A list of ServiceResolvers where the EKM can be reached. There
+            should be one ServiceResolver per EKM replica. Currently, only a
+            single ServiceResolver is supported.
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceResolver'
+        etag:
+          description: Optional. Etag of the currently stored EkmConnection.
+          type: string
+        keyManagementMode:
+          description: >-
+            Optional. Describes who can perform control plane operations on the
+            EKM. If unset, this defaults to MANUAL.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - >-
+              EKM-side key management operations on CryptoKeys created with this
+              EkmConnection must be initiated from the EKM directly and cannot
+              be performed from Cloud KMS. This means that: * When creating a
+              CryptoKeyVersion associated with this EkmConnection, the caller
+              must supply the key path of pre-existing external key material
+              that will be linked to the CryptoKeyVersion. * Destruction of
+              external key material cannot be requested via the Cloud KMS API
+              and must be performed directly in the EKM. * Automatic rotation of
+              key material is not supported.
+            - >-
+              All CryptoKeys created with this EkmConnection use EKM-side key
+              management operations initiated from Cloud KMS. This means that: *
+              When a CryptoKeyVersion associated with this EkmConnection is
+              created, the EKM automatically generates new key material and a
+              new key path. The caller cannot supply the key path of
+              pre-existing external key material. * Destruction of external key
+              material associated with this EkmConnection can be requested by
+              calling DestroyCryptoKeyVersion. * Automatic rotation of key
+              material is supported.
+          enum:
+            - KEY_MANAGEMENT_MODE_UNSPECIFIED
+            - MANUAL
+            - CLOUD_KMS
+        cryptoSpacePath:
+          description: >-
+            Optional. Identifies the EKM Crypto Space that this EkmConnection
+            maps to. Note: This field is required if KeyManagementMode is
+            CLOUD_KMS.
+          type: string
+    ServiceResolver:
+      id: ServiceResolver
+      description: >-
+        A ServiceResolver represents an EKM replica that can be reached within
+        an EkmConnection.
+      type: object
+      properties:
+        serviceDirectoryService:
+          description: >-
+            Required. The resource name of the Service Directory service
+            pointing to an EKM replica, in the format
+            `projects/*/locations/*/namespaces/*/services/*`.
+          type: string
+        endpointFilter:
+          description: >-
+            Optional. The filter applied to the endpoints of the resolved
+            service. If no filter is specified, all endpoints will be
+            considered. An endpoint will be chosen arbitrarily from the filtered
+            list for each request. For endpoint filter syntax and examples, see
+            https://cloud.google.com/service-directory/docs/reference/rpc/google.cloud.servicedirectory.v1#resolveservicerequest.
+          type: string
+        hostname:
+          description: >-
+            Required. The hostname of the EKM replica used at TLS and HTTP
+            layers.
+          type: string
+        serverCertificates:
+          description: >-
+            Required. A list of leaf server certificates used to authenticate
+            HTTPS connections to the EKM replica. Currently, a maximum of 10
+            Certificate is supported.
+          type: array
+          items:
+            $ref: '#/components/schemas/Certificate'
+    Certificate:
+      id: Certificate
+      description: >-
+        A Certificate represents an X.509 certificate used to authenticate HTTPS
+        connections to EKM replicas.
+      type: object
+      properties:
+        rawDer:
+          description: Required. The raw certificate bytes in DER format.
+          type: string
+          format: byte
+        parsed:
+          description: Output only. True if the certificate was parsed successfully.
+          readOnly: true
+          type: boolean
+        issuer:
+          description: >-
+            Output only. The issuer distinguished name in RFC 2253 format. Only
+            present if parsed is true.
+          readOnly: true
+          type: string
+        subject:
+          description: >-
+            Output only. The subject distinguished name in RFC 2253 format. Only
+            present if parsed is true.
+          readOnly: true
+          type: string
+        subjectAlternativeDnsNames:
+          description: >-
+            Output only. The subject Alternative DNS names. Only present if
+            parsed is true.
+          readOnly: true
+          type: array
+          items:
+            type: string
+        notBeforeTime:
+          description: >-
+            Output only. The certificate is not valid before this time. Only
+            present if parsed is true.
+          readOnly: true
+          type: string
+          format: google-datetime
+        notAfterTime:
+          description: >-
+            Output only. The certificate is not valid after this time. Only
+            present if parsed is true.
+          readOnly: true
+          type: string
+          format: google-datetime
+        serialNumber:
+          description: >-
+            Output only. The certificate serial number as a hex string. Only
+            present if parsed is true.
+          readOnly: true
+          type: string
+        sha256Fingerprint:
+          description: >-
+            Output only. The SHA-256 certificate fingerprint as a hex string.
+            Only present if parsed is true.
+          readOnly: true
+          type: string
+    EkmConfig:
+      id: EkmConfig
+      description: >-
+        An EkmConfig is a singleton resource that represents configuration
+        parameters that apply to all CryptoKeys and CryptoKeyVersions with a
+        ProtectionLevel of EXTERNAL_VPC in a given project and location.
+      type: object
+      properties:
+        name:
+          description: >-
+            Output only. The resource name for the EkmConfig in the format
+            `projects/*/locations/*/ekmConfig`.
+          readOnly: true
+          type: string
+        defaultEkmConnection:
+          description: >-
+            Optional. Resource name of the default EkmConnection. Setting this
+            field to the empty string removes the default.
+          type: string
+    VerifyConnectivityResponse:
+      id: VerifyConnectivityResponse
+      description: Response message for EkmService.VerifyConnectivity.
+      type: object
+      properties: {}
+    ListKeyRingsResponse:
+      id: ListKeyRingsResponse
+      description: Response message for KeyManagementService.ListKeyRings.
+      type: object
+      properties:
+        keyRings:
+          description: The list of KeyRings.
+          type: array
+          items:
+            $ref: '#/components/schemas/KeyRing'
+        nextPageToken:
+          description: >-
+            A token to retrieve next page of results. Pass this value in
+            ListKeyRingsRequest.page_token to retrieve the next page of results.
+          type: string
+        totalSize:
+          description: The total number of KeyRings that matched the query.
+          type: integer
+          format: int32
+    KeyRing:
+      id: KeyRing
+      description: A KeyRing is a toplevel logical grouping of CryptoKeys.
+      type: object
+      properties:
+        name:
+          description: >-
+            Output only. The resource name for the KeyRing in the format
+            `projects/*/locations/*/keyRings/*`.
+          readOnly: true
+          type: string
+        createTime:
+          description: Output only. The time at which this KeyRing was created.
+          readOnly: true
+          type: string
+          format: google-datetime
+    ListCryptoKeysResponse:
+      id: ListCryptoKeysResponse
+      description: Response message for KeyManagementService.ListCryptoKeys.
+      type: object
+      properties:
+        cryptoKeys:
+          description: The list of CryptoKeys.
+          type: array
+          items:
+            $ref: '#/components/schemas/CryptoKey'
+        nextPageToken:
+          description: >-
+            A token to retrieve next page of results. Pass this value in
+            ListCryptoKeysRequest.page_token to retrieve the next page of
+            results.
+          type: string
+        totalSize:
+          description: The total number of CryptoKeys that matched the query.
+          type: integer
+          format: int32
+    CryptoKey:
+      id: CryptoKey
+      description: >-
+        A CryptoKey represents a logical key that can be used for cryptographic
+        operations. A CryptoKey is made up of zero or more versions, which
+        represent the actual key material used in cryptographic operations.
+      type: object
+      properties:
+        name:
+          description: >-
+            Output only. The resource name for this CryptoKey in the format
+            `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
+          readOnly: true
+          type: string
+        primary:
+          description: >-
+            Output only. A copy of the "primary" CryptoKeyVersion that will be
+            used by Encrypt when this CryptoKey is given in EncryptRequest.name.
+            The CryptoKey's primary version can be updated via
+            UpdateCryptoKeyPrimaryVersion. Keys with purpose ENCRYPT_DECRYPT may
+            have a primary. For other keys, this field will be omitted.
+          readOnly: true
+          $ref: '#/components/schemas/CryptoKeyVersion'
+        purpose:
+          description: Immutable. The immutable purpose of this CryptoKey.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - CryptoKeys with this purpose may be used with Encrypt and Decrypt.
+            - >-
+              CryptoKeys with this purpose may be used with AsymmetricSign and
+              GetPublicKey.
+            - >-
+              CryptoKeys with this purpose may be used with AsymmetricDecrypt
+              and GetPublicKey.
+            - >-
+              CryptoKeys with this purpose may be used with RawEncrypt and
+              RawDecrypt. This purpose is meant to be used for interoperable
+              symmetric encryption and does not support automatic CryptoKey
+              rotation.
+            - CryptoKeys with this purpose may be used with MacSign.
+          enum:
+            - CRYPTO_KEY_PURPOSE_UNSPECIFIED
+            - ENCRYPT_DECRYPT
+            - ASYMMETRIC_SIGN
+            - ASYMMETRIC_DECRYPT
+            - RAW_ENCRYPT_DECRYPT
+            - MAC
+        createTime:
+          description: Output only. The time at which this CryptoKey was created.
+          readOnly: true
+          type: string
+          format: google-datetime
+        nextRotationTime:
+          description: >-
+            At next_rotation_time, the Key Management Service will
+            automatically: 1. Create a new version of this CryptoKey. 2. Mark
+            the new version as primary. Key rotations performed manually via
+            CreateCryptoKeyVersion and UpdateCryptoKeyPrimaryVersion do not
+            affect next_rotation_time. Keys with purpose ENCRYPT_DECRYPT support
+            automatic rotation. For other keys, this field must be omitted.
+          type: string
+          format: google-datetime
+        rotationPeriod:
+          description: >-
+            next_rotation_time will be advanced by this period when the service
+            automatically rotates a key. Must be at least 24 hours and at most
+            876,000 hours. If rotation_period is set, next_rotation_time must
+            also be set. Keys with purpose ENCRYPT_DECRYPT support automatic
+            rotation. For other keys, this field must be omitted.
+          type: string
+          format: google-duration
+        versionTemplate:
+          description: >-
+            A template describing settings for new CryptoKeyVersion instances.
+            The properties of new CryptoKeyVersion instances created by either
+            CreateCryptoKeyVersion or auto-rotation are controlled by this
+            template.
+          $ref: '#/components/schemas/CryptoKeyVersionTemplate'
+        labels:
+          description: >-
+            Labels with user-defined metadata. For more information, see
+            [Labeling Keys](https://cloud.google.com/kms/docs/labeling-keys).
+          type: object
+          additionalProperties:
+            type: string
+        importOnly:
+          description: Immutable. Whether this key may contain imported versions only.
+          type: boolean
+        destroyScheduledDuration:
+          description: >-
+            Immutable. The period of time that versions of this key spend in the
+            DESTROY_SCHEDULED state before transitioning to DESTROYED. If not
+            specified at creation time, the default duration is 24 hours.
+          type: string
+          format: google-duration
+        cryptoKeyBackend:
+          description: >-
+            Immutable. The resource name of the backend environment where the
+            key material for all CryptoKeyVersions associated with this
+            CryptoKey reside and where all related cryptographic operations are
+            performed. Only applicable if CryptoKeyVersions have a
+            ProtectionLevel of EXTERNAL_VPC, with the resource name in the
+            format `projects/*/locations/*/ekmConnections/*`. Note, this list is
+            non-exhaustive and may apply to additional ProtectionLevels in the
+            future.
+          type: string
+    CryptoKeyVersion:
+      id: CryptoKeyVersion
+      description: >-
+        A CryptoKeyVersion represents an individual cryptographic key, and the
+        associated key material. An ENABLED version can be used for
+        cryptographic operations. For security reasons, the raw cryptographic
+        key material represented by a CryptoKeyVersion can never be viewed or
+        exported. It can only be used to encrypt, decrypt, or sign data when an
+        authorized user or application invokes Cloud KMS.
+      type: object
+      properties:
+        name:
+          description: >-
+            Output only. The resource name for this CryptoKeyVersion in the
+            format
+            `projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*`.
+          readOnly: true
+          type: string
+        state:
+          description: The current state of the CryptoKeyVersion.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - >-
+              This version is still being generated. It may not be used,
+              enabled, disabled, or destroyed yet. Cloud KMS will automatically
+              mark this version ENABLED as soon as the version is ready.
+            - This version may be used for cryptographic operations.
+            - >-
+              This version may not be used, but the key material is still
+              available, and the version can be placed back into the ENABLED
+              state.
+            - >-
+              This version is destroyed, and the key material is no longer
+              stored. This version may only become ENABLED again if this version
+              is reimport_eligible and the original key material is reimported
+              with a call to KeyManagementService.ImportCryptoKeyVersion.
+            - >-
+              This version is scheduled for destruction, and will be destroyed
+              soon. Call RestoreCryptoKeyVersion to put it back into the
+              DISABLED state.
+            - >-
+              This version is still being imported. It may not be used, enabled,
+              disabled, or destroyed yet. Cloud KMS will automatically mark this
+              version ENABLED as soon as the version is ready.
+            - >-
+              This version was not imported successfully. It may not be used,
+              enabled, disabled, or destroyed. The submitted key material has
+              been discarded. Additional details can be found in
+              CryptoKeyVersion.import_failure_reason.
+            - >-
+              This version was not generated successfully. It may not be used,
+              enabled, disabled, or destroyed. Additional details can be found
+              in CryptoKeyVersion.generation_failure_reason.
+            - >-
+              This version was destroyed, and it may not be used or enabled
+              again. Cloud KMS is waiting for the corresponding key material
+              residing in an external key manager to be destroyed.
+            - >-
+              This version was destroyed, and it may not be used or enabled
+              again. However, Cloud KMS could not confirm that the corresponding
+              key material residing in an external key manager was destroyed.
+              Additional details can be found in
+              CryptoKeyVersion.external_destruction_failure_reason.
+          enum:
+            - CRYPTO_KEY_VERSION_STATE_UNSPECIFIED
+            - PENDING_GENERATION
+            - ENABLED
+            - DISABLED
+            - DESTROYED
+            - DESTROY_SCHEDULED
+            - PENDING_IMPORT
+            - IMPORT_FAILED
+            - GENERATION_FAILED
+            - PENDING_EXTERNAL_DESTRUCTION
+            - EXTERNAL_DESTRUCTION_FAILED
+        protectionLevel:
+          description: >-
+            Output only. The ProtectionLevel describing how crypto operations
+            are performed with this CryptoKeyVersion.
+          readOnly: true
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+        algorithm:
+          description: >-
+            Output only. The CryptoKeyVersionAlgorithm that this
+            CryptoKeyVersion supports.
+          readOnly: true
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Creates symmetric encryption keys.
+            - AES-GCM (Galois Counter Mode) using 128-bit keys.
+            - AES-GCM (Galois Counter Mode) using 256-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 128-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 256-bit keys.
+            - AES-CTR (Counter Mode) using 128-bit keys.
+            - AES-CTR (Counter Mode) using 256-bit keys.
+            - RSASSA-PSS 2048 bit key with a SHA256 digest.
+            - RSASSA-PSS 3072 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 2048 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 3072 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 4096 bit key.
+            - RSAES-OAEP 2048 bit key with a SHA256 digest.
+            - RSAES-OAEP 3072 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA512 digest.
+            - RSAES-OAEP 2048 bit key with a SHA1 digest.
+            - RSAES-OAEP 3072 bit key with a SHA1 digest.
+            - RSAES-OAEP 4096 bit key with a SHA1 digest.
+            - >-
+              ECDSA on the NIST P-256 curve with a SHA256 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the NIST P-384 curve with a SHA384 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the non-NIST secp256k1 curve. This curve is only
+              supported for HSM protection level. Other hash functions can also
+              be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - EdDSA on the Curve25519 in pure mode (taking data as input).
+            - HMAC-SHA256 signing with a 256 bit key.
+            - HMAC-SHA1 signing with a 160 bit key.
+            - HMAC-SHA384 signing with a 384 bit key.
+            - HMAC-SHA512 signing with a 512 bit key.
+            - HMAC-SHA224 signing with a 224 bit key.
+            - >-
+              Algorithm representing symmetric encryption by an external key
+              manager.
+          enum:
+            - CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+            - GOOGLE_SYMMETRIC_ENCRYPTION
+            - AES_128_GCM
+            - AES_256_GCM
+            - AES_128_CBC
+            - AES_256_CBC
+            - AES_128_CTR
+            - AES_256_CTR
+            - RSA_SIGN_PSS_2048_SHA256
+            - RSA_SIGN_PSS_3072_SHA256
+            - RSA_SIGN_PSS_4096_SHA256
+            - RSA_SIGN_PSS_4096_SHA512
+            - RSA_SIGN_PKCS1_2048_SHA256
+            - RSA_SIGN_PKCS1_3072_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA512
+            - RSA_SIGN_RAW_PKCS1_2048
+            - RSA_SIGN_RAW_PKCS1_3072
+            - RSA_SIGN_RAW_PKCS1_4096
+            - RSA_DECRYPT_OAEP_2048_SHA256
+            - RSA_DECRYPT_OAEP_3072_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA512
+            - RSA_DECRYPT_OAEP_2048_SHA1
+            - RSA_DECRYPT_OAEP_3072_SHA1
+            - RSA_DECRYPT_OAEP_4096_SHA1
+            - EC_SIGN_P256_SHA256
+            - EC_SIGN_P384_SHA384
+            - EC_SIGN_SECP256K1_SHA256
+            - EC_SIGN_ED25519
+            - HMAC_SHA256
+            - HMAC_SHA1
+            - HMAC_SHA384
+            - HMAC_SHA512
+            - HMAC_SHA224
+            - EXTERNAL_SYMMETRIC_ENCRYPTION
+        attestation:
+          description: >-
+            Output only. Statement that was generated and signed by the HSM at
+            key creation time. Use this statement to verify attributes of the
+            key as stored on the HSM, independently of Google. Only provided for
+            key versions with protection_level HSM.
+          readOnly: true
+          $ref: '#/components/schemas/KeyOperationAttestation'
+        createTime:
+          description: Output only. The time at which this CryptoKeyVersion was created.
+          readOnly: true
+          type: string
+          format: google-datetime
+        generateTime:
+          description: >-
+            Output only. The time this CryptoKeyVersion's key material was
+            generated.
+          readOnly: true
+          type: string
+          format: google-datetime
+        destroyTime:
+          description: >-
+            Output only. The time this CryptoKeyVersion's key material is
+            scheduled for destruction. Only present if state is
+            DESTROY_SCHEDULED.
+          readOnly: true
+          type: string
+          format: google-datetime
+        destroyEventTime:
+          description: >-
+            Output only. The time this CryptoKeyVersion's key material was
+            destroyed. Only present if state is DESTROYED.
+          readOnly: true
+          type: string
+          format: google-datetime
+        importJob:
+          description: >-
+            Output only. The name of the ImportJob used in the most recent
+            import of this CryptoKeyVersion. Only present if the underlying key
+            material was imported.
+          readOnly: true
+          type: string
+        importTime:
+          description: >-
+            Output only. The time at which this CryptoKeyVersion's key material
+            was most recently imported.
+          readOnly: true
+          type: string
+          format: google-datetime
+        importFailureReason:
+          description: >-
+            Output only. The root cause of the most recent import failure. Only
+            present if state is IMPORT_FAILED.
+          readOnly: true
+          type: string
+        generationFailureReason:
+          description: >-
+            Output only. The root cause of the most recent generation failure.
+            Only present if state is GENERATION_FAILED.
+          readOnly: true
+          type: string
+        externalDestructionFailureReason:
+          description: >-
+            Output only. The root cause of the most recent external destruction
+            failure. Only present if state is EXTERNAL_DESTRUCTION_FAILED.
+          readOnly: true
+          type: string
+        externalProtectionLevelOptions:
+          description: >-
+            ExternalProtectionLevelOptions stores a group of additional fields
+            for configuring a CryptoKeyVersion that are specific to the EXTERNAL
+            protection level and EXTERNAL_VPC protection levels.
+          $ref: '#/components/schemas/ExternalProtectionLevelOptions'
+        reimportEligible:
+          description: >-
+            Output only. Whether or not this key version is eligible for
+            reimport, by being specified as a target in
+            ImportCryptoKeyVersionRequest.crypto_key_version.
+          readOnly: true
+          type: boolean
+    KeyOperationAttestation:
+      id: KeyOperationAttestation
+      description: >-
+        Contains an HSM-generated attestation about a key operation. For more
+        information, see [Verifying attestations]
+        (https://cloud.google.com/kms/docs/attest-key).
+      type: object
+      properties:
+        format:
+          description: Output only. The format of the attestation data.
+          readOnly: true
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - >-
+              Cavium HSM attestation compressed with gzip. Note that this format
+              is defined by Cavium and subject to change at any time. See
+              https://www.marvell.com/products/security-solutions/nitrox-hs-adapters/software-key-attestation.html.
+            - >-
+              Cavium HSM attestation V2 compressed with gzip. This is a new
+              format introduced in Cavium's version 3.2-08.
+          enum:
+            - ATTESTATION_FORMAT_UNSPECIFIED
+            - CAVIUM_V1_COMPRESSED
+            - CAVIUM_V2_COMPRESSED
+        content:
+          description: >-
+            Output only. The attestation data provided by the HSM when the key
+            operation was performed.
+          readOnly: true
+          type: string
+          format: byte
+        certChains:
+          description: >-
+            Output only. The certificate chains needed to validate the
+            attestation
+          readOnly: true
+          $ref: '#/components/schemas/CertificateChains'
+    CertificateChains:
+      id: CertificateChains
+      description: >-
+        Certificate chains needed to verify the attestation. Certificates in
+        chains are PEM-encoded and are ordered based on
+        https://tools.ietf.org/html/rfc5246#section-7.4.2.
+      type: object
+      properties:
+        caviumCerts:
+          description: Cavium certificate chain corresponding to the attestation.
+          type: array
+          items:
+            type: string
+        googleCardCerts:
+          description: Google card certificate chain corresponding to the attestation.
+          type: array
+          items:
+            type: string
+        googlePartitionCerts:
+          description: Google partition certificate chain corresponding to the attestation.
+          type: array
+          items:
+            type: string
+    ExternalProtectionLevelOptions:
+      id: ExternalProtectionLevelOptions
+      description: >-
+        ExternalProtectionLevelOptions stores a group of additional fields for
+        configuring a CryptoKeyVersion that are specific to the EXTERNAL
+        protection level and EXTERNAL_VPC protection levels.
+      type: object
+      properties:
+        externalKeyUri:
+          description: >-
+            The URI for an external resource that this CryptoKeyVersion
+            represents.
+          type: string
+        ekmConnectionKeyPath:
+          description: >-
+            The path to the external key material on the EKM when using
+            EkmConnection e.g., "v0/my/key". Set this field instead of
+            external_key_uri when using an EkmConnection.
+          type: string
+    CryptoKeyVersionTemplate:
+      id: CryptoKeyVersionTemplate
+      description: >-
+        A CryptoKeyVersionTemplate specifies the properties to use when creating
+        a new CryptoKeyVersion, either manually with CreateCryptoKeyVersion or
+        automatically as a result of auto-rotation.
+      type: object
+      properties:
+        protectionLevel:
+          description: >-
+            ProtectionLevel to use when creating a CryptoKeyVersion based on
+            this template. Immutable. Defaults to SOFTWARE.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+        algorithm:
+          description: >-
+            Required. Algorithm to use when creating a CryptoKeyVersion based on
+            this template. For backwards compatibility,
+            GOOGLE_SYMMETRIC_ENCRYPTION is implied if both this field is omitted
+            and CryptoKey.purpose is ENCRYPT_DECRYPT.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Creates symmetric encryption keys.
+            - AES-GCM (Galois Counter Mode) using 128-bit keys.
+            - AES-GCM (Galois Counter Mode) using 256-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 128-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 256-bit keys.
+            - AES-CTR (Counter Mode) using 128-bit keys.
+            - AES-CTR (Counter Mode) using 256-bit keys.
+            - RSASSA-PSS 2048 bit key with a SHA256 digest.
+            - RSASSA-PSS 3072 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 2048 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 3072 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 4096 bit key.
+            - RSAES-OAEP 2048 bit key with a SHA256 digest.
+            - RSAES-OAEP 3072 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA512 digest.
+            - RSAES-OAEP 2048 bit key with a SHA1 digest.
+            - RSAES-OAEP 3072 bit key with a SHA1 digest.
+            - RSAES-OAEP 4096 bit key with a SHA1 digest.
+            - >-
+              ECDSA on the NIST P-256 curve with a SHA256 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the NIST P-384 curve with a SHA384 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the non-NIST secp256k1 curve. This curve is only
+              supported for HSM protection level. Other hash functions can also
+              be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - EdDSA on the Curve25519 in pure mode (taking data as input).
+            - HMAC-SHA256 signing with a 256 bit key.
+            - HMAC-SHA1 signing with a 160 bit key.
+            - HMAC-SHA384 signing with a 384 bit key.
+            - HMAC-SHA512 signing with a 512 bit key.
+            - HMAC-SHA224 signing with a 224 bit key.
+            - >-
+              Algorithm representing symmetric encryption by an external key
+              manager.
+          enum:
+            - CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+            - GOOGLE_SYMMETRIC_ENCRYPTION
+            - AES_128_GCM
+            - AES_256_GCM
+            - AES_128_CBC
+            - AES_256_CBC
+            - AES_128_CTR
+            - AES_256_CTR
+            - RSA_SIGN_PSS_2048_SHA256
+            - RSA_SIGN_PSS_3072_SHA256
+            - RSA_SIGN_PSS_4096_SHA256
+            - RSA_SIGN_PSS_4096_SHA512
+            - RSA_SIGN_PKCS1_2048_SHA256
+            - RSA_SIGN_PKCS1_3072_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA512
+            - RSA_SIGN_RAW_PKCS1_2048
+            - RSA_SIGN_RAW_PKCS1_3072
+            - RSA_SIGN_RAW_PKCS1_4096
+            - RSA_DECRYPT_OAEP_2048_SHA256
+            - RSA_DECRYPT_OAEP_3072_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA512
+            - RSA_DECRYPT_OAEP_2048_SHA1
+            - RSA_DECRYPT_OAEP_3072_SHA1
+            - RSA_DECRYPT_OAEP_4096_SHA1
+            - EC_SIGN_P256_SHA256
+            - EC_SIGN_P384_SHA384
+            - EC_SIGN_SECP256K1_SHA256
+            - EC_SIGN_ED25519
+            - HMAC_SHA256
+            - HMAC_SHA1
+            - HMAC_SHA384
+            - HMAC_SHA512
+            - HMAC_SHA224
+            - EXTERNAL_SYMMETRIC_ENCRYPTION
+    ListCryptoKeyVersionsResponse:
+      id: ListCryptoKeyVersionsResponse
+      description: Response message for KeyManagementService.ListCryptoKeyVersions.
+      type: object
+      properties:
+        cryptoKeyVersions:
+          description: The list of CryptoKeyVersions.
+          type: array
+          items:
+            $ref: '#/components/schemas/CryptoKeyVersion'
+        nextPageToken:
+          description: >-
+            A token to retrieve next page of results. Pass this value in
+            ListCryptoKeyVersionsRequest.page_token to retrieve the next page of
+            results.
+          type: string
+        totalSize:
+          description: The total number of CryptoKeyVersions that matched the query.
+          type: integer
+          format: int32
+    ListImportJobsResponse:
+      id: ListImportJobsResponse
+      description: Response message for KeyManagementService.ListImportJobs.
+      type: object
+      properties:
+        importJobs:
+          description: The list of ImportJobs.
+          type: array
+          items:
+            $ref: '#/components/schemas/ImportJob'
+        nextPageToken:
+          description: >-
+            A token to retrieve next page of results. Pass this value in
+            ListImportJobsRequest.page_token to retrieve the next page of
+            results.
+          type: string
+        totalSize:
+          description: The total number of ImportJobs that matched the query.
+          type: integer
+          format: int32
+    ImportJob:
+      id: ImportJob
+      description: >-
+        An ImportJob can be used to create CryptoKeys and CryptoKeyVersions
+        using pre-existing key material, generated outside of Cloud KMS. When an
+        ImportJob is created, Cloud KMS will generate a "wrapping key", which is
+        a public/private key pair. You use the wrapping key to encrypt (also
+        known as wrap) the pre-existing key material to protect it during the
+        import process. The nature of the wrapping key depends on the choice of
+        import_method. When the wrapping key generation is complete, the state
+        will be set to ACTIVE and the public_key can be fetched. The fetched
+        public key can then be used to wrap your pre-existing key material. Once
+        the key material is wrapped, it can be imported into a new
+        CryptoKeyVersion in an existing CryptoKey by calling
+        ImportCryptoKeyVersion. Multiple CryptoKeyVersions can be imported with
+        a single ImportJob. Cloud KMS uses the private key portion of the
+        wrapping key to unwrap the key material. Only Cloud KMS has access to
+        the private key. An ImportJob expires 3 days after it is created. Once
+        expired, Cloud KMS will no longer be able to import or unwrap any key
+        material that was wrapped with the ImportJob's public key. For more
+        information, see [Importing a
+        key](https://cloud.google.com/kms/docs/importing-a-key).
+      type: object
+      properties:
+        name:
+          description: >-
+            Output only. The resource name for this ImportJob in the format
+            `projects/*/locations/*/keyRings/*/importJobs/*`.
+          readOnly: true
+          type: string
+        importMethod:
+          description: >-
+            Required. Immutable. The wrapping method to be used for incoming key
+            material.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - >-
+              This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
+              scheme defined in the PKCS #11 standard. In summary, this involves
+              wrapping the raw key with an ephemeral AES key, and wrapping the
+              ephemeral AES key with a 3072 bit RSA key. For more details, see
+              [RSA AES key wrap
+              mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
+            - >-
+              This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
+              scheme defined in the PKCS #11 standard. In summary, this involves
+              wrapping the raw key with an ephemeral AES key, and wrapping the
+              ephemeral AES key with a 4096 bit RSA key. For more details, see
+              [RSA AES key wrap
+              mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
+            - >-
+              This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
+              scheme defined in the PKCS #11 standard. In summary, this involves
+              wrapping the raw key with an ephemeral AES key, and wrapping the
+              ephemeral AES key with a 3072 bit RSA key. For more details, see
+              [RSA AES key wrap
+              mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
+            - >-
+              This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
+              scheme defined in the PKCS #11 standard. In summary, this involves
+              wrapping the raw key with an ephemeral AES key, and wrapping the
+              ephemeral AES key with a 4096 bit RSA key. For more details, see
+              [RSA AES key wrap
+              mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
+            - >-
+              This ImportMethod represents RSAES-OAEP with a 3072 bit RSA key.
+              The key material to be imported is wrapped directly with the RSA
+              key. Due to technical limitations of RSA wrapping, this method
+              cannot be used to wrap RSA keys for import.
+            - >-
+              This ImportMethod represents RSAES-OAEP with a 4096 bit RSA key.
+              The key material to be imported is wrapped directly with the RSA
+              key. Due to technical limitations of RSA wrapping, this method
+              cannot be used to wrap RSA keys for import.
+          enum:
+            - IMPORT_METHOD_UNSPECIFIED
+            - RSA_OAEP_3072_SHA1_AES_256
+            - RSA_OAEP_4096_SHA1_AES_256
+            - RSA_OAEP_3072_SHA256_AES_256
+            - RSA_OAEP_4096_SHA256_AES_256
+            - RSA_OAEP_3072_SHA256
+            - RSA_OAEP_4096_SHA256
+        protectionLevel:
+          description: >-
+            Required. Immutable. The protection level of the ImportJob. This
+            must match the protection_level of the version_template on the
+            CryptoKey you attempt to import into.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+        createTime:
+          description: Output only. The time at which this ImportJob was created.
+          readOnly: true
+          type: string
+          format: google-datetime
+        generateTime:
+          description: Output only. The time this ImportJob's key material was generated.
+          readOnly: true
+          type: string
+          format: google-datetime
+        expireTime:
+          description: >-
+            Output only. The time at which this ImportJob is scheduled for
+            expiration and can no longer be used to import key material.
+          readOnly: true
+          type: string
+          format: google-datetime
+        expireEventTime:
+          description: >-
+            Output only. The time this ImportJob expired. Only present if state
+            is EXPIRED.
+          readOnly: true
+          type: string
+          format: google-datetime
+        state:
+          description: >-
+            Output only. The current state of the ImportJob, indicating if it
+            can be used.
+          readOnly: true
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - >-
+              The wrapping key for this job is still being generated. It may not
+              be used. Cloud KMS will automatically mark this job as ACTIVE as
+              soon as the wrapping key is generated.
+            - >-
+              This job may be used in CreateCryptoKey and CreateCryptoKeyVersion
+              requests.
+            - >-
+              This job can no longer be used and may not leave this state once
+              entered.
+          enum:
+            - IMPORT_JOB_STATE_UNSPECIFIED
+            - PENDING_GENERATION
+            - ACTIVE
+            - EXPIRED
+        publicKey:
+          description: >-
+            Output only. The public key with which to wrap key material prior to
+            import. Only returned if state is ACTIVE.
+          readOnly: true
+          $ref: '#/components/schemas/WrappingPublicKey'
+        attestation:
+          description: >-
+            Output only. Statement that was generated and signed by the key
+            creator (for example, an HSM) at key creation time. Use this
+            statement to verify attributes of the key as stored on the HSM,
+            independently of Google. Only present if the chosen ImportMethod is
+            one with a protection level of HSM.
+          readOnly: true
+          $ref: '#/components/schemas/KeyOperationAttestation'
+    WrappingPublicKey:
+      id: WrappingPublicKey
+      description: >-
+        The public key component of the wrapping key. For details of the type of
+        key this public key corresponds to, see the ImportMethod.
+      type: object
+      properties:
+        pem:
+          description: >-
+            The public key, encoded in PEM format. For more information, see the
+            [RFC 7468](https://tools.ietf.org/html/rfc7468) sections for
+            [General
+            Considerations](https://tools.ietf.org/html/rfc7468#section-2) and
+            [Textual Encoding of Subject Public Key Info]
+            (https://tools.ietf.org/html/rfc7468#section-13).
+          type: string
+    PublicKey:
+      id: PublicKey
+      description: The public keys for a given CryptoKeyVersion. Obtained via GetPublicKey.
+      type: object
+      properties:
+        pem:
+          description: >-
+            The public key, encoded in PEM format. For more information, see the
+            [RFC 7468](https://tools.ietf.org/html/rfc7468) sections for
+            [General
+            Considerations](https://tools.ietf.org/html/rfc7468#section-2) and
+            [Textual Encoding of Subject Public Key Info]
+            (https://tools.ietf.org/html/rfc7468#section-13).
+          type: string
+        algorithm:
+          description: The Algorithm associated with this key.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Creates symmetric encryption keys.
+            - AES-GCM (Galois Counter Mode) using 128-bit keys.
+            - AES-GCM (Galois Counter Mode) using 256-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 128-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 256-bit keys.
+            - AES-CTR (Counter Mode) using 128-bit keys.
+            - AES-CTR (Counter Mode) using 256-bit keys.
+            - RSASSA-PSS 2048 bit key with a SHA256 digest.
+            - RSASSA-PSS 3072 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 2048 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 3072 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 4096 bit key.
+            - RSAES-OAEP 2048 bit key with a SHA256 digest.
+            - RSAES-OAEP 3072 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA512 digest.
+            - RSAES-OAEP 2048 bit key with a SHA1 digest.
+            - RSAES-OAEP 3072 bit key with a SHA1 digest.
+            - RSAES-OAEP 4096 bit key with a SHA1 digest.
+            - >-
+              ECDSA on the NIST P-256 curve with a SHA256 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the NIST P-384 curve with a SHA384 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the non-NIST secp256k1 curve. This curve is only
+              supported for HSM protection level. Other hash functions can also
+              be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - EdDSA on the Curve25519 in pure mode (taking data as input).
+            - HMAC-SHA256 signing with a 256 bit key.
+            - HMAC-SHA1 signing with a 160 bit key.
+            - HMAC-SHA384 signing with a 384 bit key.
+            - HMAC-SHA512 signing with a 512 bit key.
+            - HMAC-SHA224 signing with a 224 bit key.
+            - >-
+              Algorithm representing symmetric encryption by an external key
+              manager.
+          enum:
+            - CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+            - GOOGLE_SYMMETRIC_ENCRYPTION
+            - AES_128_GCM
+            - AES_256_GCM
+            - AES_128_CBC
+            - AES_256_CBC
+            - AES_128_CTR
+            - AES_256_CTR
+            - RSA_SIGN_PSS_2048_SHA256
+            - RSA_SIGN_PSS_3072_SHA256
+            - RSA_SIGN_PSS_4096_SHA256
+            - RSA_SIGN_PSS_4096_SHA512
+            - RSA_SIGN_PKCS1_2048_SHA256
+            - RSA_SIGN_PKCS1_3072_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA512
+            - RSA_SIGN_RAW_PKCS1_2048
+            - RSA_SIGN_RAW_PKCS1_3072
+            - RSA_SIGN_RAW_PKCS1_4096
+            - RSA_DECRYPT_OAEP_2048_SHA256
+            - RSA_DECRYPT_OAEP_3072_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA512
+            - RSA_DECRYPT_OAEP_2048_SHA1
+            - RSA_DECRYPT_OAEP_3072_SHA1
+            - RSA_DECRYPT_OAEP_4096_SHA1
+            - EC_SIGN_P256_SHA256
+            - EC_SIGN_P384_SHA384
+            - EC_SIGN_SECP256K1_SHA256
+            - EC_SIGN_ED25519
+            - HMAC_SHA256
+            - HMAC_SHA1
+            - HMAC_SHA384
+            - HMAC_SHA512
+            - HMAC_SHA224
+            - EXTERNAL_SYMMETRIC_ENCRYPTION
+        pemCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            PublicKey.pem. An integrity check of PublicKey.pem can be performed
+            by computing the CRC32C checksum of PublicKey.pem and comparing your
+            results to this field. Discard the response in case of non-matching
+            checksum values, and perform a limited number of retries. A
+            persistent mismatch may indicate an issue in your computation of the
+            CRC32C checksum. Note: This field is defined as int64 for reasons of
+            compatibility across different languages. However, it is a
+            non-negative integer, which will never exceed 2^32-1, and can be
+            safely downconverted to uint32 in languages that support this type.
+            NOTE: This field is in Beta.
+          type: string
+          format: int64
+        name:
+          description: >-
+            The name of the CryptoKeyVersion public key. Provided here for
+            verification. NOTE: This field is in Beta.
+          type: string
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion public key.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    ImportCryptoKeyVersionRequest:
+      id: ImportCryptoKeyVersionRequest
+      description: Request message for KeyManagementService.ImportCryptoKeyVersion.
+      type: object
+      properties:
+        cryptoKeyVersion:
+          description: >-
+            Optional. The optional name of an existing CryptoKeyVersion to
+            target for an import operation. If this field is not present, a new
+            CryptoKeyVersion containing the supplied key material is created. If
+            this field is present, the supplied key material is imported into
+            the existing CryptoKeyVersion. To import into an existing
+            CryptoKeyVersion, the CryptoKeyVersion must be a child of
+            ImportCryptoKeyVersionRequest.parent, have been previously created
+            via ImportCryptoKeyVersion, and be in DESTROYED or IMPORT_FAILED
+            state. The key material and algorithm must match the previous
+            CryptoKeyVersion exactly if the CryptoKeyVersion has ever contained
+            key material.
+          type: string
+        algorithm:
+          description: >-
+            Required. The algorithm of the key being imported. This does not
+            need to match the version_template of the CryptoKey this version
+            imports into.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Creates symmetric encryption keys.
+            - AES-GCM (Galois Counter Mode) using 128-bit keys.
+            - AES-GCM (Galois Counter Mode) using 256-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 128-bit keys.
+            - AES-CBC (Cipher Block Chaining Mode) using 256-bit keys.
+            - AES-CTR (Counter Mode) using 128-bit keys.
+            - AES-CTR (Counter Mode) using 256-bit keys.
+            - RSASSA-PSS 2048 bit key with a SHA256 digest.
+            - RSASSA-PSS 3072 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA256 digest.
+            - RSASSA-PSS 4096 bit key with a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
+            - RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 2048 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 3072 bit key.
+            - RSASSA-PKCS1-v1_5 signing without encoding, with a 4096 bit key.
+            - RSAES-OAEP 2048 bit key with a SHA256 digest.
+            - RSAES-OAEP 3072 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA256 digest.
+            - RSAES-OAEP 4096 bit key with a SHA512 digest.
+            - RSAES-OAEP 2048 bit key with a SHA1 digest.
+            - RSAES-OAEP 3072 bit key with a SHA1 digest.
+            - RSAES-OAEP 4096 bit key with a SHA1 digest.
+            - >-
+              ECDSA on the NIST P-256 curve with a SHA256 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the NIST P-384 curve with a SHA384 digest. Other hash
+              functions can also be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - >-
+              ECDSA on the non-NIST secp256k1 curve. This curve is only
+              supported for HSM protection level. Other hash functions can also
+              be used:
+              https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms
+            - EdDSA on the Curve25519 in pure mode (taking data as input).
+            - HMAC-SHA256 signing with a 256 bit key.
+            - HMAC-SHA1 signing with a 160 bit key.
+            - HMAC-SHA384 signing with a 384 bit key.
+            - HMAC-SHA512 signing with a 512 bit key.
+            - HMAC-SHA224 signing with a 224 bit key.
+            - >-
+              Algorithm representing symmetric encryption by an external key
+              manager.
+          enum:
+            - CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+            - GOOGLE_SYMMETRIC_ENCRYPTION
+            - AES_128_GCM
+            - AES_256_GCM
+            - AES_128_CBC
+            - AES_256_CBC
+            - AES_128_CTR
+            - AES_256_CTR
+            - RSA_SIGN_PSS_2048_SHA256
+            - RSA_SIGN_PSS_3072_SHA256
+            - RSA_SIGN_PSS_4096_SHA256
+            - RSA_SIGN_PSS_4096_SHA512
+            - RSA_SIGN_PKCS1_2048_SHA256
+            - RSA_SIGN_PKCS1_3072_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA256
+            - RSA_SIGN_PKCS1_4096_SHA512
+            - RSA_SIGN_RAW_PKCS1_2048
+            - RSA_SIGN_RAW_PKCS1_3072
+            - RSA_SIGN_RAW_PKCS1_4096
+            - RSA_DECRYPT_OAEP_2048_SHA256
+            - RSA_DECRYPT_OAEP_3072_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA256
+            - RSA_DECRYPT_OAEP_4096_SHA512
+            - RSA_DECRYPT_OAEP_2048_SHA1
+            - RSA_DECRYPT_OAEP_3072_SHA1
+            - RSA_DECRYPT_OAEP_4096_SHA1
+            - EC_SIGN_P256_SHA256
+            - EC_SIGN_P384_SHA384
+            - EC_SIGN_SECP256K1_SHA256
+            - EC_SIGN_ED25519
+            - HMAC_SHA256
+            - HMAC_SHA1
+            - HMAC_SHA384
+            - HMAC_SHA512
+            - HMAC_SHA224
+            - EXTERNAL_SYMMETRIC_ENCRYPTION
+        importJob:
+          description: >-
+            Required. The name of the ImportJob that was used to wrap this key
+            material.
+          type: string
+        wrappedKey:
+          description: >-
+            Optional. The wrapped key material to import. Before wrapping, key
+            material must be formatted. If importing symmetric key material, the
+            expected key material format is plain bytes. If importing asymmetric
+            key material, the expected key material format is PKCS#8-encoded DER
+            (the PrivateKeyInfo structure from RFC 5208). When wrapping with
+            import methods (RSA_OAEP_3072_SHA1_AES_256 or
+            RSA_OAEP_4096_SHA1_AES_256 or RSA_OAEP_3072_SHA256_AES_256 or
+            RSA_OAEP_4096_SHA256_AES_256), this field must contain the
+            concatenation of: 1. An ephemeral AES-256 wrapping key wrapped with
+            the public_key using RSAES-OAEP with SHA-1/SHA-256, MGF1 with
+            SHA-1/SHA-256, and an empty label. 2. The formatted key to be
+            imported, wrapped with the ephemeral AES-256 key using AES-KWP (RFC
+            5649). This format is the same as the format produced by PKCS#11
+            mechanism CKM_RSA_AES_KEY_WRAP. When wrapping with import methods
+            (RSA_OAEP_3072_SHA256 or RSA_OAEP_4096_SHA256), this field must
+            contain the formatted key to be imported, wrapped with the
+            public_key using RSAES-OAEP with SHA-256, MGF1 with SHA-256, and an
+            empty label.
+          type: string
+          format: byte
+        rsaAesWrappedKey:
+          description: >-
+            Optional. This field has the same meaning as wrapped_key. Prefer to
+            use that field in new work. Either that field or this field (but not
+            both) must be specified.
+          type: string
+          format: byte
+    UpdateCryptoKeyPrimaryVersionRequest:
+      id: UpdateCryptoKeyPrimaryVersionRequest
+      description: Request message for KeyManagementService.UpdateCryptoKeyPrimaryVersion.
+      type: object
+      properties:
+        cryptoKeyVersionId:
+          description: Required. The id of the child CryptoKeyVersion to use as primary.
+          type: string
+    DestroyCryptoKeyVersionRequest:
+      id: DestroyCryptoKeyVersionRequest
+      description: Request message for KeyManagementService.DestroyCryptoKeyVersion.
+      type: object
+      properties: {}
+    RestoreCryptoKeyVersionRequest:
+      id: RestoreCryptoKeyVersionRequest
+      description: Request message for KeyManagementService.RestoreCryptoKeyVersion.
+      type: object
+      properties: {}
+    EncryptRequest:
+      id: EncryptRequest
+      description: Request message for KeyManagementService.Encrypt.
+      type: object
+      properties:
+        plaintext:
+          description: >-
+            Required. The data to encrypt. Must be no larger than 64KiB. The
+            maximum size depends on the key version's protection_level. For
+            SOFTWARE, EXTERNAL, and EXTERNAL_VPC keys, the plaintext must be no
+            larger than 64KiB. For HSM keys, the combined length of the
+            plaintext and additional_authenticated_data fields must be no larger
+            than 8KiB.
+          type: string
+          format: byte
+        additionalAuthenticatedData:
+          description: >-
+            Optional. Optional data that, if specified, must also be provided
+            during decryption through
+            DecryptRequest.additional_authenticated_data. The maximum size
+            depends on the key version's protection_level. For SOFTWARE,
+            EXTERNAL, and EXTERNAL_VPC keys the AAD must be no larger than
+            64KiB. For HSM keys, the combined length of the plaintext and
+            additional_authenticated_data fields must be no larger than 8KiB.
+          type: string
+          format: byte
+        plaintextCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            EncryptRequest.plaintext. If specified, KeyManagementService will
+            verify the integrity of the received EncryptRequest.plaintext using
+            this checksum. KeyManagementService will report an error if the
+            checksum verification fails. If you receive a checksum error, your
+            client should verify that CRC32C(EncryptRequest.plaintext) is equal
+            to EncryptRequest.plaintext_crc32c, and if so, perform a limited
+            number of retries. A persistent mismatch may indicate an issue in
+            your computation of the CRC32C checksum. Note: This field is defined
+            as int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        additionalAuthenticatedDataCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            EncryptRequest.additional_authenticated_data. If specified,
+            KeyManagementService will verify the integrity of the received
+            EncryptRequest.additional_authenticated_data using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that
+            CRC32C(EncryptRequest.additional_authenticated_data) is equal to
+            EncryptRequest.additional_authenticated_data_crc32c, and if so,
+            perform a limited number of retries. A persistent mismatch may
+            indicate an issue in your computation of the CRC32C checksum. Note:
+            This field is defined as int64 for reasons of compatibility across
+            different languages. However, it is a non-negative integer, which
+            will never exceed 2^32-1, and can be safely downconverted to uint32
+            in languages that support this type.
+          type: string
+          format: int64
+    EncryptResponse:
+      id: EncryptResponse
+      description: Response message for KeyManagementService.Encrypt.
+      type: object
+      properties:
+        name:
+          description: >-
+            The resource name of the CryptoKeyVersion used in encryption. Check
+            this field to verify that the intended resource was used for
+            encryption.
+          type: string
+        ciphertext:
+          description: The encrypted data.
+          type: string
+          format: byte
+        ciphertextCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            EncryptResponse.ciphertext. An integrity check of
+            EncryptResponse.ciphertext can be performed by computing the CRC32C
+            checksum of EncryptResponse.ciphertext and comparing your results to
+            this field. Discard the response in case of non-matching checksum
+            values, and perform a limited number of retries. A persistent
+            mismatch may indicate an issue in your computation of the CRC32C
+            checksum. Note: This field is defined as int64 for reasons of
+            compatibility across different languages. However, it is a
+            non-negative integer, which will never exceed 2^32-1, and can be
+            safely downconverted to uint32 in languages that support this type.
+          type: string
+          format: int64
+        verifiedPlaintextCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            EncryptRequest.plaintext_crc32c was received by KeyManagementService
+            and used for the integrity verification of the plaintext. A false
+            value of this field indicates either that
+            EncryptRequest.plaintext_crc32c was left unset or that it was not
+            delivered to KeyManagementService. If you've set
+            EncryptRequest.plaintext_crc32c but this field is still false,
+            discard the response and perform a limited number of retries.
+          type: boolean
+        verifiedAdditionalAuthenticatedDataCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            EncryptRequest.additional_authenticated_data_crc32c was received by
+            KeyManagementService and used for the integrity verification of the
+            AAD. A false value of this field indicates either that
+            EncryptRequest.additional_authenticated_data_crc32c was left unset
+            or that it was not delivered to KeyManagementService. If you've set
+            EncryptRequest.additional_authenticated_data_crc32c but this field
+            is still false, discard the response and perform a limited number of
+            retries.
+          type: boolean
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used in encryption.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    DecryptRequest:
+      id: DecryptRequest
+      description: Request message for KeyManagementService.Decrypt.
+      type: object
+      properties:
+        ciphertext:
+          description: >-
+            Required. The encrypted data originally returned in
+            EncryptResponse.ciphertext.
+          type: string
+          format: byte
+        additionalAuthenticatedData:
+          description: >-
+            Optional. Optional data that must match the data originally supplied
+            in EncryptRequest.additional_authenticated_data.
+          type: string
+          format: byte
+        ciphertextCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            DecryptRequest.ciphertext. If specified, KeyManagementService will
+            verify the integrity of the received DecryptRequest.ciphertext using
+            this checksum. KeyManagementService will report an error if the
+            checksum verification fails. If you receive a checksum error, your
+            client should verify that CRC32C(DecryptRequest.ciphertext) is equal
+            to DecryptRequest.ciphertext_crc32c, and if so, perform a limited
+            number of retries. A persistent mismatch may indicate an issue in
+            your computation of the CRC32C checksum. Note: This field is defined
+            as int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        additionalAuthenticatedDataCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            DecryptRequest.additional_authenticated_data. If specified,
+            KeyManagementService will verify the integrity of the received
+            DecryptRequest.additional_authenticated_data using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that
+            CRC32C(DecryptRequest.additional_authenticated_data) is equal to
+            DecryptRequest.additional_authenticated_data_crc32c, and if so,
+            perform a limited number of retries. A persistent mismatch may
+            indicate an issue in your computation of the CRC32C checksum. Note:
+            This field is defined as int64 for reasons of compatibility across
+            different languages. However, it is a non-negative integer, which
+            will never exceed 2^32-1, and can be safely downconverted to uint32
+            in languages that support this type.
+          type: string
+          format: int64
+    DecryptResponse:
+      id: DecryptResponse
+      description: Response message for KeyManagementService.Decrypt.
+      type: object
+      properties:
+        plaintext:
+          description: The decrypted data originally supplied in EncryptRequest.plaintext.
+          type: string
+          format: byte
+        plaintextCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            DecryptResponse.plaintext. An integrity check of
+            DecryptResponse.plaintext can be performed by computing the CRC32C
+            checksum of DecryptResponse.plaintext and comparing your results to
+            this field. Discard the response in case of non-matching checksum
+            values, and perform a limited number of retries. A persistent
+            mismatch may indicate an issue in your computation of the CRC32C
+            checksum. Note: receiving this response message indicates that
+            KeyManagementService is able to successfully decrypt the ciphertext.
+            Note: This field is defined as int64 for reasons of compatibility
+            across different languages. However, it is a non-negative integer,
+            which will never exceed 2^32-1, and can be safely downconverted to
+            uint32 in languages that support this type.
+          type: string
+          format: int64
+        usedPrimary:
+          description: Whether the Decryption was performed using the primary key version.
+          type: boolean
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used in decryption.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    RawEncryptRequest:
+      id: RawEncryptRequest
+      description: Request message for KeyManagementService.RawEncrypt.
+      type: object
+      properties:
+        plaintext:
+          description: >-
+            Required. The data to encrypt. Must be no larger than 64KiB. The
+            maximum size depends on the key version's protection_level. For
+            SOFTWARE keys, the plaintext must be no larger than 64KiB. For HSM
+            keys, the combined length of the plaintext and
+            additional_authenticated_data fields must be no larger than 8KiB.
+          type: string
+          format: byte
+        additionalAuthenticatedData:
+          description: >-
+            Optional. Optional data that, if specified, must also be provided
+            during decryption through
+            RawDecryptRequest.additional_authenticated_data. This field may only
+            be used in conjunction with an algorithm that accepts additional
+            authenticated data (for example, AES-GCM). The maximum size depends
+            on the key version's protection_level. For SOFTWARE keys, the
+            plaintext must be no larger than 64KiB. For HSM keys, the combined
+            length of the plaintext and additional_authenticated_data fields
+            must be no larger than 8KiB.
+          type: string
+          format: byte
+        plaintextCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            RawEncryptRequest.plaintext. If specified, KeyManagementService will
+            verify the integrity of the received plaintext using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(plaintext) is equal to plaintext_crc32c,
+            and if so, perform a limited number of retries. A persistent
+            mismatch may indicate an issue in your computation of the CRC32C
+            checksum. Note: This field is defined as int64 for reasons of
+            compatibility across different languages. However, it is a
+            non-negative integer, which will never exceed 2^32-1, and can be
+            safely downconverted to uint32 in languages that support this type.
+          type: string
+          format: int64
+        additionalAuthenticatedDataCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            RawEncryptRequest.additional_authenticated_data. If specified,
+            KeyManagementService will verify the integrity of the received
+            additional_authenticated_data using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(additional_authenticated_data) is equal to
+            additional_authenticated_data_crc32c, and if so, perform a limited
+            number of retries. A persistent mismatch may indicate an issue in
+            your computation of the CRC32C checksum. Note: This field is defined
+            as int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        initializationVector:
+          description: >-
+            Optional. A customer-supplied initialization vector that will be
+            used for encryption. If it is not provided for AES-CBC and AES-CTR,
+            one will be generated. It will be returned in
+            RawEncryptResponse.initialization_vector.
+          type: string
+          format: byte
+        initializationVectorCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            RawEncryptRequest.initialization_vector. If specified,
+            KeyManagementService will verify the integrity of the received
+            initialization_vector using this checksum. KeyManagementService will
+            report an error if the checksum verification fails. If you receive a
+            checksum error, your client should verify that
+            CRC32C(initialization_vector) is equal to
+            initialization_vector_crc32c, and if so, perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+    RawEncryptResponse:
+      id: RawEncryptResponse
+      description: Response message for KeyManagementService.RawEncrypt.
+      type: object
+      properties:
+        ciphertext:
+          description: >-
+            The encrypted data. In the case of AES-GCM, the authentication tag
+            is the tag_length bytes at the end of this field.
+          type: string
+          format: byte
+        initializationVector:
+          description: >-
+            The initialization vector (IV) generated by the service during
+            encryption. This value must be stored and provided in
+            RawDecryptRequest.initialization_vector at decryption time.
+          type: string
+          format: byte
+        tagLength:
+          description: >-
+            The length of the authentication tag that is appended to the end of
+            the ciphertext.
+          type: integer
+          format: int32
+        ciphertextCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            RawEncryptResponse.ciphertext. An integrity check of ciphertext can
+            be performed by computing the CRC32C checksum of ciphertext and
+            comparing your results to this field. Discard the response in case
+            of non-matching checksum values, and perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        initializationVectorCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            RawEncryptResponse.initialization_vector. An integrity check of
+            initialization_vector can be performed by computing the CRC32C
+            checksum of initialization_vector and comparing your results to this
+            field. Discard the response in case of non-matching checksum values,
+            and perform a limited number of retries. A persistent mismatch may
+            indicate an issue in your computation of the CRC32C checksum. Note:
+            This field is defined as int64 for reasons of compatibility across
+            different languages. However, it is a non-negative integer, which
+            will never exceed 2^32-1, and can be safely downconverted to uint32
+            in languages that support this type.
+          type: string
+          format: int64
+        verifiedPlaintextCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            RawEncryptRequest.plaintext_crc32c was received by
+            KeyManagementService and used for the integrity verification of the
+            plaintext. A false value of this field indicates either that
+            RawEncryptRequest.plaintext_crc32c was left unset or that it was not
+            delivered to KeyManagementService. If you've set
+            RawEncryptRequest.plaintext_crc32c but this field is still false,
+            discard the response and perform a limited number of retries.
+          type: boolean
+        verifiedAdditionalAuthenticatedDataCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            RawEncryptRequest.additional_authenticated_data_crc32c was received
+            by KeyManagementService and used for the integrity verification of
+            additional_authenticated_data. A false value of this field indicates
+            either that //
+            RawEncryptRequest.additional_authenticated_data_crc32c was left
+            unset or that it was not delivered to KeyManagementService. If
+            you've set RawEncryptRequest.additional_authenticated_data_crc32c
+            but this field is still false, discard the response and perform a
+            limited number of retries.
+          type: boolean
+        verifiedInitializationVectorCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            RawEncryptRequest.initialization_vector_crc32c was received by
+            KeyManagementService and used for the integrity verification of
+            initialization_vector. A false value of this field indicates either
+            that RawEncryptRequest.initialization_vector_crc32c was left unset
+            or that it was not delivered to KeyManagementService. If you've set
+            RawEncryptRequest.initialization_vector_crc32c but this field is
+            still false, discard the response and perform a limited number of
+            retries.
+          type: boolean
+        name:
+          description: >-
+            The resource name of the CryptoKeyVersion used in encryption. Check
+            this field to verify that the intended resource was used for
+            encryption.
+          type: string
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used in encryption.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    RawDecryptRequest:
+      id: RawDecryptRequest
+      description: Request message for KeyManagementService.RawDecrypt.
+      type: object
+      properties:
+        ciphertext:
+          description: >-
+            Required. The encrypted data originally returned in
+            RawEncryptResponse.ciphertext.
+          type: string
+          format: byte
+        additionalAuthenticatedData:
+          description: >-
+            Optional. Optional data that must match the data originally supplied
+            in RawEncryptRequest.additional_authenticated_data.
+          type: string
+          format: byte
+        initializationVector:
+          description: >-
+            Required. The initialization vector (IV) used during encryption,
+            which must match the data originally provided in
+            RawEncryptResponse.initialization_vector.
+          type: string
+          format: byte
+        tagLength:
+          description: >-
+            The length of the authentication tag that is appended to the end of
+            the ciphertext. If unspecified (0), the default value for the key's
+            algorithm will be used (for AES-GCM, the default value is 16).
+          type: integer
+          format: int32
+        ciphertextCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            RawDecryptRequest.ciphertext. If specified, KeyManagementService
+            will verify the integrity of the received ciphertext using this
+            checksum. KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(ciphertext) is equal to ciphertext_crc32c,
+            and if so, perform a limited number of retries. A persistent
+            mismatch may indicate an issue in your computation of the CRC32C
+            checksum. Note: This field is defined as int64 for reasons of
+            compatibility across different languages. However, it is a
+            non-negative integer, which will never exceed 2^32-1, and can be
+            safely downconverted to uint32 in languages that support this type.
+          type: string
+          format: int64
+        additionalAuthenticatedDataCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            RawDecryptRequest.additional_authenticated_data. If specified,
+            KeyManagementService will verify the integrity of the received
+            additional_authenticated_data using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(additional_authenticated_data) is equal to
+            additional_authenticated_data_crc32c, and if so, perform a limited
+            number of retries. A persistent mismatch may indicate an issue in
+            your computation of the CRC32C checksum. Note: This field is defined
+            as int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        initializationVectorCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            RawDecryptRequest.initialization_vector. If specified,
+            KeyManagementService will verify the integrity of the received
+            initialization_vector using this checksum. KeyManagementService will
+            report an error if the checksum verification fails. If you receive a
+            checksum error, your client should verify that
+            CRC32C(initialization_vector) is equal to
+            initialization_vector_crc32c, and if so, perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+    RawDecryptResponse:
+      id: RawDecryptResponse
+      description: Response message for KeyManagementService.RawDecrypt.
+      type: object
+      properties:
+        plaintext:
+          description: The decrypted data.
+          type: string
+          format: byte
+        plaintextCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            RawDecryptResponse.plaintext. An integrity check of plaintext can be
+            performed by computing the CRC32C checksum of plaintext and
+            comparing your results to this field. Discard the response in case
+            of non-matching checksum values, and perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: receiving this response
+            message indicates that KeyManagementService is able to successfully
+            decrypt the ciphertext. Note: This field is defined as int64 for
+            reasons of compatibility across different languages. However, it is
+            a non-negative integer, which will never exceed 2^32-1, and can be
+            safely downconverted to uint32 in languages that support this type.
+          type: string
+          format: int64
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used in decryption.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+        verifiedCiphertextCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            RawDecryptRequest.ciphertext_crc32c was received by
+            KeyManagementService and used for the integrity verification of the
+            ciphertext. A false value of this field indicates either that
+            RawDecryptRequest.ciphertext_crc32c was left unset or that it was
+            not delivered to KeyManagementService. If you've set
+            RawDecryptRequest.ciphertext_crc32c but this field is still false,
+            discard the response and perform a limited number of retries.
+          type: boolean
+        verifiedAdditionalAuthenticatedDataCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            RawDecryptRequest.additional_authenticated_data_crc32c was received
+            by KeyManagementService and used for the integrity verification of
+            additional_authenticated_data. A false value of this field indicates
+            either that //
+            RawDecryptRequest.additional_authenticated_data_crc32c was left
+            unset or that it was not delivered to KeyManagementService. If
+            you've set RawDecryptRequest.additional_authenticated_data_crc32c
+            but this field is still false, discard the response and perform a
+            limited number of retries.
+          type: boolean
+        verifiedInitializationVectorCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            RawDecryptRequest.initialization_vector_crc32c was received by
+            KeyManagementService and used for the integrity verification of
+            initialization_vector. A false value of this field indicates either
+            that RawDecryptRequest.initialization_vector_crc32c was left unset
+            or that it was not delivered to KeyManagementService. If you've set
+            RawDecryptRequest.initialization_vector_crc32c but this field is
+            still false, discard the response and perform a limited number of
+            retries.
+          type: boolean
+    AsymmetricSignRequest:
+      id: AsymmetricSignRequest
+      description: Request message for KeyManagementService.AsymmetricSign.
+      type: object
+      properties:
+        digest:
+          description: >-
+            Optional. The digest of the data to sign. The digest must be
+            produced with the same digest algorithm as specified by the key
+            version's algorithm. This field may not be supplied if
+            AsymmetricSignRequest.data is supplied.
+          $ref: '#/components/schemas/Digest'
+        digestCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            AsymmetricSignRequest.digest. If specified, KeyManagementService
+            will verify the integrity of the received
+            AsymmetricSignRequest.digest using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(AsymmetricSignRequest.digest) is equal to
+            AsymmetricSignRequest.digest_crc32c, and if so, perform a limited
+            number of retries. A persistent mismatch may indicate an issue in
+            your computation of the CRC32C checksum. Note: This field is defined
+            as int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        data:
+          description: >-
+            Optional. The data to sign. It can't be supplied if
+            AsymmetricSignRequest.digest is supplied.
+          type: string
+          format: byte
+        dataCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            AsymmetricSignRequest.data. If specified, KeyManagementService will
+            verify the integrity of the received AsymmetricSignRequest.data
+            using this checksum. KeyManagementService will report an error if
+            the checksum verification fails. If you receive a checksum error,
+            your client should verify that CRC32C(AsymmetricSignRequest.data) is
+            equal to AsymmetricSignRequest.data_crc32c, and if so, perform a
+            limited number of retries. A persistent mismatch may indicate an
+            issue in your computation of the CRC32C checksum. Note: This field
+            is defined as int64 for reasons of compatibility across different
+            languages. However, it is a non-negative integer, which will never
+            exceed 2^32-1, and can be safely downconverted to uint32 in
+            languages that support this type.
+          type: string
+          format: int64
+    Digest:
+      id: Digest
+      description: A Digest holds a cryptographic message digest.
+      type: object
+      properties:
+        sha256:
+          description: A message digest produced with the SHA-256 algorithm.
+          type: string
+          format: byte
+        sha384:
+          description: A message digest produced with the SHA-384 algorithm.
+          type: string
+          format: byte
+        sha512:
+          description: A message digest produced with the SHA-512 algorithm.
+          type: string
+          format: byte
+    AsymmetricSignResponse:
+      id: AsymmetricSignResponse
+      description: Response message for KeyManagementService.AsymmetricSign.
+      type: object
+      properties:
+        signature:
+          description: The created signature.
+          type: string
+          format: byte
+        signatureCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            AsymmetricSignResponse.signature. An integrity check of
+            AsymmetricSignResponse.signature can be performed by computing the
+            CRC32C checksum of AsymmetricSignResponse.signature and comparing
+            your results to this field. Discard the response in case of
+            non-matching checksum values, and perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        verifiedDigestCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            AsymmetricSignRequest.digest_crc32c was received by
+            KeyManagementService and used for the integrity verification of the
+            digest. A false value of this field indicates either that
+            AsymmetricSignRequest.digest_crc32c was left unset or that it was
+            not delivered to KeyManagementService. If you've set
+            AsymmetricSignRequest.digest_crc32c but this field is still false,
+            discard the response and perform a limited number of retries.
+          type: boolean
+        name:
+          description: >-
+            The resource name of the CryptoKeyVersion used for signing. Check
+            this field to verify that the intended resource was used for
+            signing.
+          type: string
+        verifiedDataCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            AsymmetricSignRequest.data_crc32c was received by
+            KeyManagementService and used for the integrity verification of the
+            data. A false value of this field indicates either that
+            AsymmetricSignRequest.data_crc32c was left unset or that it was not
+            delivered to KeyManagementService. If you've set
+            AsymmetricSignRequest.data_crc32c but this field is still false,
+            discard the response and perform a limited number of retries.
+          type: boolean
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used for signing.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    AsymmetricDecryptRequest:
+      id: AsymmetricDecryptRequest
+      description: Request message for KeyManagementService.AsymmetricDecrypt.
+      type: object
+      properties:
+        ciphertext:
+          description: >-
+            Required. The data encrypted with the named CryptoKeyVersion's
+            public key using OAEP.
+          type: string
+          format: byte
+        ciphertextCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the
+            AsymmetricDecryptRequest.ciphertext. If specified,
+            KeyManagementService will verify the integrity of the received
+            AsymmetricDecryptRequest.ciphertext using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(AsymmetricDecryptRequest.ciphertext) is
+            equal to AsymmetricDecryptRequest.ciphertext_crc32c, and if so,
+            perform a limited number of retries. A persistent mismatch may
+            indicate an issue in your computation of the CRC32C checksum. Note:
+            This field is defined as int64 for reasons of compatibility across
+            different languages. However, it is a non-negative integer, which
+            will never exceed 2^32-1, and can be safely downconverted to uint32
+            in languages that support this type.
+          type: string
+          format: int64
+    AsymmetricDecryptResponse:
+      id: AsymmetricDecryptResponse
+      description: Response message for KeyManagementService.AsymmetricDecrypt.
+      type: object
+      properties:
+        plaintext:
+          description: >-
+            The decrypted data originally encrypted with the matching public
+            key.
+          type: string
+          format: byte
+        plaintextCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            AsymmetricDecryptResponse.plaintext. An integrity check of
+            AsymmetricDecryptResponse.plaintext can be performed by computing
+            the CRC32C checksum of AsymmetricDecryptResponse.plaintext and
+            comparing your results to this field. Discard the response in case
+            of non-matching checksum values, and perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        verifiedCiphertextCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            AsymmetricDecryptRequest.ciphertext_crc32c was received by
+            KeyManagementService and used for the integrity verification of the
+            ciphertext. A false value of this field indicates either that
+            AsymmetricDecryptRequest.ciphertext_crc32c was left unset or that it
+            was not delivered to KeyManagementService. If you've set
+            AsymmetricDecryptRequest.ciphertext_crc32c but this field is still
+            false, discard the response and perform a limited number of retries.
+          type: boolean
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used in decryption.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    MacSignRequest:
+      id: MacSignRequest
+      description: Request message for KeyManagementService.MacSign.
+      type: object
+      properties:
+        data:
+          description: >-
+            Required. The data to sign. The MAC tag is computed over this data
+            field based on the specific algorithm.
+          type: string
+          format: byte
+        dataCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the MacSignRequest.data. If
+            specified, KeyManagementService will verify the integrity of the
+            received MacSignRequest.data using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(MacSignRequest.data) is equal to
+            MacSignRequest.data_crc32c, and if so, perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+    MacSignResponse:
+      id: MacSignResponse
+      description: Response message for KeyManagementService.MacSign.
+      type: object
+      properties:
+        name:
+          description: >-
+            The resource name of the CryptoKeyVersion used for signing. Check
+            this field to verify that the intended resource was used for
+            signing.
+          type: string
+        mac:
+          description: The created signature.
+          type: string
+          format: byte
+        macCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            MacSignResponse.mac. An integrity check of MacSignResponse.mac can
+            be performed by computing the CRC32C checksum of MacSignResponse.mac
+            and comparing your results to this field. Discard the response in
+            case of non-matching checksum values, and perform a limited number
+            of retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        verifiedDataCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            MacSignRequest.data_crc32c was received by KeyManagementService and
+            used for the integrity verification of the data. A false value of
+            this field indicates either that MacSignRequest.data_crc32c was left
+            unset or that it was not delivered to KeyManagementService. If
+            you've set MacSignRequest.data_crc32c but this field is still false,
+            discard the response and perform a limited number of retries.
+          type: boolean
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used for signing.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    MacVerifyRequest:
+      id: MacVerifyRequest
+      description: Request message for KeyManagementService.MacVerify.
+      type: object
+      properties:
+        data:
+          description: >-
+            Required. The data used previously as a MacSignRequest.data to
+            generate the MAC tag.
+          type: string
+          format: byte
+        dataCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the MacVerifyRequest.data.
+            If specified, KeyManagementService will verify the integrity of the
+            received MacVerifyRequest.data using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(MacVerifyRequest.data) is equal to
+            MacVerifyRequest.data_crc32c, and if so, perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+        mac:
+          description: Required. The signature to verify.
+          type: string
+          format: byte
+        macCrc32c:
+          description: >-
+            Optional. An optional CRC32C checksum of the MacVerifyRequest.mac.
+            If specified, KeyManagementService will verify the integrity of the
+            received MacVerifyRequest.mac using this checksum.
+            KeyManagementService will report an error if the checksum
+            verification fails. If you receive a checksum error, your client
+            should verify that CRC32C(MacVerifyRequest.tag) is equal to
+            MacVerifyRequest.mac_crc32c, and if so, perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+    MacVerifyResponse:
+      id: MacVerifyResponse
+      description: Response message for KeyManagementService.MacVerify.
+      type: object
+      properties:
+        name:
+          description: >-
+            The resource name of the CryptoKeyVersion used for verification.
+            Check this field to verify that the intended resource was used for
+            verification.
+          type: string
+        success:
+          description: >-
+            This field indicates whether or not the verification operation for
+            MacVerifyRequest.mac over MacVerifyRequest.data was successful.
+          type: boolean
+        verifiedDataCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            MacVerifyRequest.data_crc32c was received by KeyManagementService
+            and used for the integrity verification of the data. A false value
+            of this field indicates either that MacVerifyRequest.data_crc32c was
+            left unset or that it was not delivered to KeyManagementService. If
+            you've set MacVerifyRequest.data_crc32c but this field is still
+            false, discard the response and perform a limited number of retries.
+          type: boolean
+        verifiedMacCrc32c:
+          description: >-
+            Integrity verification field. A flag indicating whether
+            MacVerifyRequest.mac_crc32c was received by KeyManagementService and
+            used for the integrity verification of the data. A false value of
+            this field indicates either that MacVerifyRequest.mac_crc32c was
+            left unset or that it was not delivered to KeyManagementService. If
+            you've set MacVerifyRequest.mac_crc32c but this field is still
+            false, discard the response and perform a limited number of retries.
+          type: boolean
+        verifiedSuccessIntegrity:
+          description: >-
+            Integrity verification field. This value is used for the integrity
+            verification of [MacVerifyResponse.success]. If the value of this
+            field contradicts the value of [MacVerifyResponse.success], discard
+            the response and perform a limited number of retries.
+          type: boolean
+        protectionLevel:
+          description: The ProtectionLevel of the CryptoKeyVersion used for verification.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    GenerateRandomBytesRequest:
+      id: GenerateRandomBytesRequest
+      description: Request message for KeyManagementService.GenerateRandomBytes.
+      type: object
+      properties:
+        lengthBytes:
+          description: >-
+            The length in bytes of the amount of randomness to retrieve. Minimum
+            8 bytes, maximum 1024 bytes.
+          type: integer
+          format: int32
+        protectionLevel:
+          description: >-
+            The ProtectionLevel to use when generating the random data.
+            Currently, only HSM protection level is supported.
+          type: string
+          enumDescriptions:
+            - Not specified.
+            - Crypto operations are performed in software.
+            - Crypto operations are performed in a Hardware Security Module.
+            - Crypto operations are performed by an external key manager.
+            - Crypto operations are performed in an EKM-over-VPC backend.
+          enum:
+            - PROTECTION_LEVEL_UNSPECIFIED
+            - SOFTWARE
+            - HSM
+            - EXTERNAL
+            - EXTERNAL_VPC
+    GenerateRandomBytesResponse:
+      id: GenerateRandomBytesResponse
+      description: Response message for KeyManagementService.GenerateRandomBytes.
+      type: object
+      properties:
+        data:
+          description: The generated data.
+          type: string
+          format: byte
+        dataCrc32c:
+          description: >-
+            Integrity verification field. A CRC32C checksum of the returned
+            GenerateRandomBytesResponse.data. An integrity check of
+            GenerateRandomBytesResponse.data can be performed by computing the
+            CRC32C checksum of GenerateRandomBytesResponse.data and comparing
+            your results to this field. Discard the response in case of
+            non-matching checksum values, and perform a limited number of
+            retries. A persistent mismatch may indicate an issue in your
+            computation of the CRC32C checksum. Note: This field is defined as
+            int64 for reasons of compatibility across different languages.
+            However, it is a non-negative integer, which will never exceed
+            2^32-1, and can be safely downconverted to uint32 in languages that
+            support this type.
+          type: string
+          format: int64
+    ListLocationsResponse:
+      id: ListLocationsResponse
+      description: The response message for Locations.ListLocations.
+      type: object
+      properties:
+        locations:
+          description: >-
+            A list of locations that matches the specified filter in the
+            request.
+          type: array
+          items:
+            $ref: '#/components/schemas/Location'
+        nextPageToken:
+          description: The standard List next-page token.
+          type: string
+    Location:
+      id: Location
+      description: A resource that represents a Google Cloud location.
+      type: object
+      properties:
+        name:
+          description: >-
+            Resource name for the location, which may vary between
+            implementations. For example:
+            `"projects/example-project/locations/us-east1"`
+          type: string
+        locationId:
+          description: 'The canonical id for this location. For example: `"us-east1"`.'
+          type: string
+        displayName:
+          description: >-
+            The friendly name for this location, typically a nearby city name.
+            For example, "Tokyo".
+          type: string
+        labels:
+          description: >-
+            Cross-service attributes for the location. For example
+            {"cloud.googleapis.com/region": "us-east1"}
+          type: object
+          additionalProperties:
+            type: string
+        metadata:
+          description: >-
+            Service-specific metadata. For example the available capacity at the
+            given location.
+          type: object
+          additionalProperties:
+            type: any
+            description: Properties of the object. Contains field @type with type URL.
+    SetIamPolicyRequest:
+      id: SetIamPolicyRequest
+      description: Request message for `SetIamPolicy` method.
+      type: object
+      properties:
+        policy:
+          description: >-
+            REQUIRED: The complete policy to be applied to the `resource`. The
+            size of the policy is limited to a few 10s of KB. An empty policy is
+            a valid policy but certain Google Cloud services (such as Projects)
+            might reject them.
+          $ref: '#/components/schemas/Policy'
+        updateMask:
+          description: >-
+            OPTIONAL: A FieldMask specifying which fields of the policy to
+            modify. Only the fields in the mask will be modified. If no mask is
+            provided, the following default mask is used: `paths: "bindings,
+            etag"`
+          type: string
+          format: google-fieldmask
+    Policy:
+      id: Policy
+      description: >-
+        An Identity and Access Management (IAM) policy, which specifies access
+        controls for Google Cloud resources. A `Policy` is a collection of
+        `bindings`. A `binding` binds one or more `members`, or principals, to a
+        single `role`. Principals can be user accounts, service accounts, Google
+        groups, and domains (such as G Suite). A `role` is a named list of
+        permissions; each `role` can be an IAM predefined role or a user-created
+        custom role. For some types of Google Cloud resources, a `binding` can
+        also specify a `condition`, which is a logical expression that allows
+        access to a resource only if the expression evaluates to `true`. A
+        condition can add constraints based on attributes of the request, the
+        resource, or both. To learn which resources support conditions in their
+        IAM policies, see the [IAM
+        documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
+        **JSON example:** ``` { "bindings": [ { "role":
+        "roles/resourcemanager.organizationAdmin", "members": [
+        "user:mike@example.com", "group:admins@example.com",
+        "domain:google.com",
+        "serviceAccount:my-project-id@appspot.gserviceaccount.com" ] }, {
+        "role": "roles/resourcemanager.organizationViewer", "members": [
+        "user:eve@example.com" ], "condition": { "title": "expirable access",
+        "description": "Does not grant access after Sep 2020", "expression":
+        "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } ], "etag":
+        "BwWWja0YfJA=", "version": 3 } ``` **YAML example:** ``` bindings: -
+        members: - user:mike@example.com - group:admins@example.com -
+        domain:google.com -
+        serviceAccount:my-project-id@appspot.gserviceaccount.com role:
+        roles/resourcemanager.organizationAdmin - members: -
+        user:eve@example.com role: roles/resourcemanager.organizationViewer
+        condition: title: expirable access description: Does not grant access
+        after Sep 2020 expression: request.time <
+        timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ```
+        For a description of IAM and its features, see the [IAM
+        documentation](https://cloud.google.com/iam/docs/).
+      type: object
+      properties:
+        version:
+          description: >-
+            Specifies the format of the policy. Valid values are `0`, `1`, and
+            `3`. Requests that specify an invalid value are rejected. Any
+            operation that affects conditional role bindings must specify
+            version `3`. This requirement applies to the following operations: *
+            Getting a policy that includes a conditional role binding * Adding a
+            conditional role binding to a policy * Changing a conditional role
+            binding in a policy * Removing any role binding, with or without a
+            condition, from a policy that includes conditions **Important:** If
+            you use IAM Conditions, you must include the `etag` field whenever
+            you call `setIamPolicy`. If you omit this field, then IAM allows you
+            to overwrite a version `3` policy with a version `1` policy, and all
+            of the conditions in the version `3` policy are lost. If a policy
+            does not include any conditions, operations on that policy may
+            specify any valid version or leave the field unset. To learn which
+            resources support conditions in their IAM policies, see the [IAM
+            documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
+          type: integer
+          format: int32
+        bindings:
+          description: >-
+            Associates a list of `members`, or principals, with a `role`.
+            Optionally, may specify a `condition` that determines how and when
+            the `bindings` are applied. Each of the `bindings` must contain at
+            least one principal. The `bindings` in a `Policy` can refer to up to
+            1,500 principals; up to 250 of these principals can be Google
+            groups. Each occurrence of a principal counts towards these limits.
+            For example, if the `bindings` grant 50 different roles to
+            `user:alice@example.com`, and not to any other principal, then you
+            can add another 1,450 principals to the `bindings` in the `Policy`.
+          type: array
+          items:
+            $ref: '#/components/schemas/Binding'
+        auditConfigs:
+          description: Specifies cloud audit logging configuration for this policy.
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditConfig'
+        etag:
+          description: >-
+            `etag` is used for optimistic concurrency control as a way to help
+            prevent simultaneous updates of a policy from overwriting each
+            other. It is strongly suggested that systems make use of the `etag`
+            in the read-modify-write cycle to perform policy updates in order to
+            avoid race conditions: An `etag` is returned in the response to
+            `getIamPolicy`, and systems are expected to put that etag in the
+            request to `setIamPolicy` to ensure that their change will be
+            applied to the same version of the policy. **Important:** If you use
+            IAM Conditions, you must include the `etag` field whenever you call
+            `setIamPolicy`. If you omit this field, then IAM allows you to
+            overwrite a version `3` policy with a version `1` policy, and all of
+            the conditions in the version `3` policy are lost.
+          type: string
+          format: byte
+    Binding:
+      id: Binding
+      description: Associates `members`, or principals, with a `role`.
+      type: object
+      properties:
+        role:
+          description: >-
+            Role that is assigned to the list of `members`, or principals. For
+            example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an
+            overview of the IAM roles and permissions, see the [IAM
+            documentation](https://cloud.google.com/iam/docs/roles-overview).
+            For a list of the available pre-defined roles, see
+            [here](https://cloud.google.com/iam/docs/understanding-roles).
+          type: string
+        members:
+          description: >-
+            Specifies the principals requesting access for a Google Cloud
+            resource. `members` can have the following values: * `allUsers`: A
+            special identifier that represents anyone who is on the internet;
+            with or without a Google account. * `allAuthenticatedUsers`: A
+            special identifier that represents anyone who is authenticated with
+            a Google account or a service account. Does not include identities
+            that come from external identity providers (IdPs) through identity
+            federation. * `user:{emailid}`: An email address that represents a
+            specific Google account. For example, `alice@example.com` . *
+            `serviceAccount:{emailid}`: An email address that represents a
+            Google service account. For example,
+            `my-other-app@appspot.gserviceaccount.com`. *
+            `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`:
+            An identifier for a [Kubernetes service
+            account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts).
+            For example,
+            `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. *
+            `group:{emailid}`: An email address that represents a Google group.
+            For example, `admins@example.com`. * `domain:{domain}`: The G Suite
+            domain (primary) that represents all the users of that domain. For
+            example, `google.com` or `example.com`. *
+            `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`:
+            A single identity in a workforce identity pool. *
+            `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`:
+            All workforce identities in a group. *
+            `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`:
+            All workforce identities with a specific attribute value. *
+            `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`:
+            All identities in a workforce identity pool. *
+            `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`:
+            A single identity in a workload identity pool. *
+            `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`:
+            A workload identity pool group. *
+            `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`:
+            All identities in a workload identity pool with a certain attribute.
+            *
+            `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`:
+            All identities in a workload identity pool. *
+            `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus
+            unique identifier) representing a user that has been recently
+            deleted. For example, `alice@example.com?uid=123456789012345678901`.
+            If the user is recovered, this value reverts to `user:{emailid}` and
+            the recovered user retains the role in the binding. *
+            `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address
+            (plus unique identifier) representing a service account that has
+            been recently deleted. For example,
+            `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.
+            If the service account is undeleted, this value reverts to
+            `serviceAccount:{emailid}` and the undeleted service account retains
+            the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`:
+            An email address (plus unique identifier) representing a Google
+            group that has been recently deleted. For example,
+            `admins@example.com?uid=123456789012345678901`. If the group is
+            recovered, this value reverts to `group:{emailid}` and the recovered
+            group retains the role in the binding. *
+            `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`:
+            Deleted single identity in a workforce identity pool. For example,
+            `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`.
+          type: array
+          items:
+            type: string
+        condition:
+          description: >-
+            The condition that is associated with this binding. If the condition
+            evaluates to `true`, then this binding applies to the current
+            request. If the condition evaluates to `false`, then this binding
+            does not apply to the current request. However, a different role
+            binding might grant the same role to one or more of the principals
+            in this binding. To learn which resources support conditions in
+            their IAM policies, see the [IAM
+            documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
+          $ref: '#/components/schemas/Expr'
+    Expr:
+      id: Expr
+      description: >-
+        Represents a textual expression in the Common Expression Language (CEL)
+        syntax. CEL is a C-like expression language. The syntax and semantics of
+        CEL are documented at https://github.com/google/cel-spec. Example
+        (Comparison): title: "Summary size limit" description: "Determines if a
+        summary is less than 100 chars" expression: "document.summary.size() <
+        100" Example (Equality): title: "Requestor is owner" description:
+        "Determines if requestor is the document owner" expression:
+        "document.owner == request.auth.claims.email" Example (Logic): title:
+        "Public documents" description: "Determine whether the document should
+        be publicly visible" expression: "document.type != 'private' &&
+        document.type != 'internal'" Example (Data Manipulation): title:
+        "Notification string" description: "Create a notification string with a
+        timestamp." expression: "'New message received at ' +
+        string(document.create_time)" The exact variables and functions that may
+        be referenced within an expression are determined by the service that
+        evaluates it. See the service documentation for additional information.
+      type: object
+      properties:
+        expression:
+          description: >-
+            Textual representation of an expression in Common Expression
+            Language syntax.
+          type: string
+        title:
+          description: >-
+            Optional. Title for the expression, i.e. a short string describing
+            its purpose. This can be used e.g. in UIs which allow to enter the
+            expression.
+          type: string
+        description:
+          description: >-
+            Optional. Description of the expression. This is a longer text which
+            describes the expression, e.g. when hovered over it in a UI.
+          type: string
+        location:
+          description: >-
+            Optional. String indicating the location of the expression for error
+            reporting, e.g. a file name and a position in the file.
+          type: string
+    AuditConfig:
+      id: AuditConfig
+      description: >-
+        Specifies the audit configuration for a service. The configuration
+        determines which permission types are logged, and what identities, if
+        any, are exempted from logging. An AuditConfig must have one or more
+        AuditLogConfigs. If there are AuditConfigs for both `allServices` and a
+        specific service, the union of the two AuditConfigs is used for that
+        service: the log_types specified in each AuditConfig are enabled, and
+        the exempted_members in each AuditLogConfig are exempted. Example Policy
+        with multiple AuditConfigs: { "audit_configs": [ { "service":
+        "allServices", "audit_log_configs": [ { "log_type": "DATA_READ",
+        "exempted_members": [ "user:jose@example.com" ] }, { "log_type":
+        "DATA_WRITE" }, { "log_type": "ADMIN_READ" } ] }, { "service":
+        "sampleservice.googleapis.com", "audit_log_configs": [ { "log_type":
+        "DATA_READ" }, { "log_type": "DATA_WRITE", "exempted_members": [
+        "user:aliya@example.com" ] } ] } ] } For sampleservice, this policy
+        enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts
+        `jose@example.com` from DATA_READ logging, and `aliya@example.com` from
+        DATA_WRITE logging.
+      type: object
+      properties:
+        service:
+          description: >-
+            Specifies a service that will be enabled for audit logging. For
+            example, `storage.googleapis.com`, `cloudsql.googleapis.com`.
+            `allServices` is a special value that covers all services.
+          type: string
+        auditLogConfigs:
+          description: The configuration for logging of each type of permission.
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLogConfig'
+    AuditLogConfig:
+      id: AuditLogConfig
+      description: >-
+        Provides the configuration for logging a type of permissions. Example: {
+        "audit_log_configs": [ { "log_type": "DATA_READ", "exempted_members": [
+        "user:jose@example.com" ] }, { "log_type": "DATA_WRITE" } ] } This
+        enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting
+        jose@example.com from DATA_READ logging.
+      type: object
+      properties:
+        logType:
+          description: The log type that this config enables.
+          type: string
+          enumDescriptions:
+            - Default case. Should never be this.
+            - 'Admin reads. Example: CloudIAM getIamPolicy'
+            - 'Data writes. Example: CloudSQL Users create'
+            - 'Data reads. Example: CloudSQL Users list'
+          enum:
+            - LOG_TYPE_UNSPECIFIED
+            - ADMIN_READ
+            - DATA_WRITE
+            - DATA_READ
+        exemptedMembers:
+          description: >-
+            Specifies the identities that do not cause logging for this type of
+            permission. Follows the same format of Binding.members.
+          type: array
+          items:
+            type: string
+    TestIamPermissionsRequest:
+      id: TestIamPermissionsRequest
+      description: Request message for `TestIamPermissions` method.
+      type: object
+      properties:
+        permissions:
+          description: >-
+            The set of permissions to check for the `resource`. Permissions with
+            wildcards (such as `*` or `storage.*`) are not allowed. For more
+            information see [IAM
+            Overview](https://cloud.google.com/iam/docs/overview#permissions).
+          type: array
+          items:
+            type: string
+    TestIamPermissionsResponse:
+      id: TestIamPermissionsResponse
+      description: Response message for `TestIamPermissions` method.
+      type: object
+      properties:
+        permissions:
+          description: >-
+            A subset of `TestPermissionsRequest.permissions` that the caller is
+            allowed.
+          type: array
+          items:
+            type: string
+    LocationMetadata:
+      id: LocationMetadata
+      description: Cloud KMS metadata for the given google.cloud.location.Location.
+      type: object
+      properties:
+        hsmAvailable:
+          description: >-
+            Indicates whether CryptoKeys with protection_level HSM can be
+            created in this location.
+          type: boolean
+        ekmAvailable:
+          description: >-
+            Indicates whether CryptoKeys with protection_level EXTERNAL can be
+            created in this location.
+          type: boolean
+  parameters:
+    access_token:
+      description: OAuth access token.
+      in: query
+      name: access_token
+      schema:
+        type: string
+    alt:
+      description: Data format for response.
+      in: query
+      name: alt
+      schema:
+        type: string
+        enum:
+          - json
+          - media
+          - proto
+    callback:
+      description: JSONP
+      in: query
+      name: callback
+      schema:
+        type: string
+    fields:
+      description: Selector specifying which fields to include in a partial response.
+      in: query
+      name: fields
+      schema:
+        type: string
+    key:
+      description: >-
+        API key. Your API key identifies your project and provides you with API
+        access, quota, and reports. Required unless you provide an OAuth 2.0
+        token.
+      in: query
+      name: key
+      schema:
+        type: string
+    oauth_token:
+      description: OAuth 2.0 token for the current user.
+      in: query
+      name: oauth_token
+      schema:
+        type: string
+    prettyPrint:
+      description: Returns response with indentations and line breaks.
+      in: query
+      name: prettyPrint
+      schema:
+        type: boolean
+    quotaUser:
+      description: >-
+        Available to use for quota purposes for server-side applications. Can be
+        any arbitrary string assigned to a user, but should not exceed 40
+        characters.
+      in: query
+      name: quotaUser
+      schema:
+        type: string
+    upload_protocol:
+      description: Upload protocol for media (e.g. "raw", "multipart").
+      in: query
+      name: upload_protocol
+      schema:
+        type: string
+    uploadType:
+      description: Legacy upload protocol for media (e.g. "media", "multipart").
+      in: query
+      name: uploadType
+      schema:
+        type: string
+    _.xgafv:
+      description: V1 error format.
+      in: query
+      name: $.xgafv
+      schema:
+        type: string
+        enum:
+          - '1'
+          - '2'
+  x-stackQL-resources:
+    autokey_config:
+      id: cloudkms.autokey_config
+      name: autokey_config
+      title: Autokey_config
+      methods:
+        update_autokey_config:
+          operation:
+            $ref: '#/paths/~1v1~1folders~1{foldersId}~1autokeyConfig/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get_autokey_config:
+          operation:
+            $ref: '#/paths/~1v1~1folders~1{foldersId}~1autokeyConfig/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: >-
+              #/components/x-stackQL-resources/autokey_config/methods/get_autokey_config
+        insert: []
+        update: []
+        delete: []
+    projects:
+      id: cloudkms.projects
+      name: projects
+      title: Projects
+      methods:
+        show_effective_autokey_config:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}:showEffectiveAutokeyConfig/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select: []
+        insert: []
+        update: []
+        delete: []
+    ekm_config:
+      id: cloudkms.ekm_config
+      name: ekm_config
+      title: Ekm_config
+      methods:
+        get_ekm_config:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConfig/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        update_ekm_config:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConfig/patch
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/ekm_config/methods/get_ekm_config'
+        insert: []
+        update: []
+        delete: []
+    locations:
+      id: cloudkms.locations
+      name: locations
+      title: Locations
+      methods:
+        generate_random_bytes:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}:generateRandomBytes/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        _list:
+          operation: &ref_1
+            $ref: '#/paths/~1v1~1projects~1{projectsId}~1locations/get'
+          response: &ref_2
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.locations
+        list:
+          operation: *ref_1
+          response: *ref_2
+        get:
+          operation:
+            $ref: '#/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/locations/methods/list'
+          - $ref: '#/components/x-stackQL-resources/locations/methods/get'
+        insert: []
+        update: []
+        delete: []
+    operations:
+      id: cloudkms.operations
+      name: operations
+      title: Operations
+      methods:
+        get:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1operations~1{operationsId}/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/operations/methods/get'
+        insert: []
+        update: []
+        delete: []
+    key_handles:
+      id: cloudkms.key_handles
+      name: key_handles
+      title: Key_handles
+      methods:
+        create:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyHandles/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyHandles/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyHandles~1{keyHandlesId}/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/key_handles/methods/list'
+          - $ref: '#/components/x-stackQL-resources/key_handles/methods/get'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/key_handles/methods/create'
+        update: []
+        delete: []
+    ekm_connections:
+      id: cloudkms.ekm_connections
+      name: ekm_connections
+      title: Ekm_connections
+      methods:
+        _list:
+          operation: &ref_3
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections/get
+          response: &ref_4
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.ekmConnections
+        list:
+          operation: *ref_3
+          response: *ref_4
+        create:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections~1{ekmConnectionsId}/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        patch:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections~1{ekmConnectionsId}/patch
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        verify_connectivity:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections~1{ekmConnectionsId}:verifyConnectivity/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/ekm_connections/methods/list'
+          - $ref: '#/components/x-stackQL-resources/ekm_connections/methods/get'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/ekm_connections/methods/create'
+        update: []
+        delete: []
+    ekm_connections_iam_policies:
+      id: cloudkms.ekm_connections_iam_policies
+      name: ekm_connections_iam_policies
+      title: Ekm_connections_iam_policies
+      methods:
+        set_iam_policy:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections~1{ekmConnectionsId}:setIamPolicy/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        _get_iam_policy:
+          operation: &ref_5
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections~1{ekmConnectionsId}:getIamPolicy/get
+          response: &ref_6
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.bindings
+        get_iam_policy:
+          operation: *ref_5
+          response: *ref_6
+        test_iam_permissions:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConnections~1{ekmConnectionsId}:testIamPermissions/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: >-
+              #/components/x-stackQL-resources/ekm_connections_iam_policies/methods/get_iam_policy
+        insert: []
+        update: []
+        delete: []
+    key_rings:
+      id: cloudkms.key_rings
+      name: key_rings
+      title: Key_rings
+      methods:
+        _list:
+          operation: &ref_7
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings/get
+          response: &ref_8
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.keyRings
+        list:
+          operation: *ref_7
+          response: *ref_8
+        create:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/key_rings/methods/list'
+          - $ref: '#/components/x-stackQL-resources/key_rings/methods/get'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/key_rings/methods/create'
+        update: []
+        delete: []
+    key_rings_iam_policies:
+      id: cloudkms.key_rings_iam_policies
+      name: key_rings_iam_policies
+      title: Key_rings_iam_policies
+      methods:
+        set_iam_policy:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}:setIamPolicy/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        _get_iam_policy:
+          operation: &ref_9
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}:getIamPolicy/get
+          response: &ref_10
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.bindings
+        get_iam_policy:
+          operation: *ref_9
+          response: *ref_10
+        test_iam_permissions:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}:testIamPermissions/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: >-
+              #/components/x-stackQL-resources/key_rings_iam_policies/methods/get_iam_policy
+        insert: []
+        update: []
+        delete: []
+    crypto_keys:
+      id: cloudkms.crypto_keys
+      name: crypto_keys
+      title: Crypto_keys
+      methods:
+        _list:
+          operation: &ref_11
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys/get
+          response: &ref_12
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.cryptoKeys
+        list:
+          operation: *ref_11
+          response: *ref_12
+        create:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        patch:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}/patch
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        encrypt:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}:encrypt/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        decrypt:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}:decrypt/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/crypto_keys/methods/list'
+          - $ref: '#/components/x-stackQL-resources/crypto_keys/methods/get'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/crypto_keys/methods/create'
+        update: []
+        delete: []
+    crypto_keys_primary_version:
+      id: cloudkms.crypto_keys_primary_version
+      name: crypto_keys_primary_version
+      title: Crypto_keys_primary_version
+      methods:
+        update_primary_version:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}:updatePrimaryVersion/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select: []
+        insert: []
+        update: []
+        delete: []
+    crypto_keys_iam_policies:
+      id: cloudkms.crypto_keys_iam_policies
+      name: crypto_keys_iam_policies
+      title: Crypto_keys_iam_policies
+      methods:
+        set_iam_policy:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}:setIamPolicy/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        _get_iam_policy:
+          operation: &ref_13
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}:getIamPolicy/get
+          response: &ref_14
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.bindings
+        get_iam_policy:
+          operation: *ref_13
+          response: *ref_14
+        test_iam_permissions:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}:testIamPermissions/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: >-
+              #/components/x-stackQL-resources/crypto_keys_iam_policies/methods/get_iam_policy
+        insert: []
+        update: []
+        delete: []
+    crypto_key_versions:
+      id: cloudkms.crypto_key_versions
+      name: crypto_key_versions
+      title: Crypto_key_versions
+      methods:
+        _list:
+          operation: &ref_15
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions/get
+          response: &ref_16
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.cryptoKeyVersions
+        list:
+          operation: *ref_15
+          response: *ref_16
+        create:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        patch:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}/patch
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        import:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions:import/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        destroy:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:destroy/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        restore:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:restore/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        raw_encrypt:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:rawEncrypt/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        raw_decrypt:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:rawDecrypt/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        asymmetric_sign:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:asymmetricSign/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        asymmetric_decrypt:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:asymmetricDecrypt/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        mac_sign:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:macSign/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        mac_verify:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}:macVerify/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/crypto_key_versions/methods/list'
+          - $ref: '#/components/x-stackQL-resources/crypto_key_versions/methods/get'
+        insert:
+          - $ref: >-
+              #/components/x-stackQL-resources/crypto_key_versions/methods/create
+        update: []
+        delete: []
+    crypto_key_versions_public_key:
+      id: cloudkms.crypto_key_versions_public_key
+      name: crypto_key_versions_public_key
+      title: Crypto_key_versions_public_key
+      methods:
+        get_public_key:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1cryptoKeys~1{cryptoKeysId}~1cryptoKeyVersions~1{cryptoKeyVersionsId}~1publicKey/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: >-
+              #/components/x-stackQL-resources/crypto_key_versions_public_key/methods/get_public_key
+        insert: []
+        update: []
+        delete: []
+    import_jobs:
+      id: cloudkms.import_jobs
+      name: import_jobs
+      title: Import_jobs
+      methods:
+        _list:
+          operation: &ref_17
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1importJobs/get
+          response: &ref_18
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.importJobs
+        list:
+          operation: *ref_17
+          response: *ref_18
+        create:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1importJobs/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1importJobs~1{importJobsId}/get
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/import_jobs/methods/list'
+          - $ref: '#/components/x-stackQL-resources/import_jobs/methods/get'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/import_jobs/methods/create'
+        update: []
+        delete: []
+    import_jobs_iam_policies:
+      id: cloudkms.import_jobs_iam_policies
+      name: import_jobs_iam_policies
+      title: Import_jobs_iam_policies
+      methods:
+        set_iam_policy:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1importJobs~1{importJobsId}:setIamPolicy/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        _get_iam_policy:
+          operation: &ref_19
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1importJobs~1{importJobsId}:getIamPolicy/get
+          response: &ref_20
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.bindings
+        get_iam_policy:
+          operation: *ref_19
+          response: *ref_20
+        test_iam_permissions:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1keyRings~1{keyRingsId}~1importJobs~1{importJobsId}:testIamPermissions/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: >-
+              #/components/x-stackQL-resources/import_jobs_iam_policies/methods/get_iam_policy
+        insert: []
+        update: []
+        delete: []
+    ekm_config_iam_policies:
+      id: cloudkms.ekm_config_iam_policies
+      name: ekm_config_iam_policies
+      title: Ekm_config_iam_policies
+      methods:
+        set_iam_policy:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConfig:setIamPolicy/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        _get_iam_policy:
+          operation: &ref_21
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConfig:getIamPolicy/get
+          response: &ref_22
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.bindings
+        get_iam_policy:
+          operation: *ref_21
+          response: *ref_22
+        test_iam_permissions:
+          operation:
+            $ref: >-
+              #/paths/~1v1~1projects~1{projectsId}~1locations~1{locationsId}~1ekmConfig:testIamPermissions/post
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: >-
+              #/components/x-stackQL-resources/ekm_config_iam_policies/methods/get_iam_policy
+        insert: []
+        update: []
+        delete: []
+paths:
+  /v1/folders/{foldersId}/autokeyConfig:
+    parameters: &ref_23
+      - $ref: '#/components/parameters/access_token'
+      - $ref: '#/components/parameters/alt'
+      - $ref: '#/components/parameters/callback'
+      - $ref: '#/components/parameters/fields'
+      - $ref: '#/components/parameters/key'
+      - $ref: '#/components/parameters/oauth_token'
+      - $ref: '#/components/parameters/prettyPrint'
+      - $ref: '#/components/parameters/quotaUser'
+      - $ref: '#/components/parameters/upload_protocol'
+      - $ref: '#/components/parameters/uploadType'
+      - $ref: '#/components/parameters/_.xgafv'
+    patch:
+      description: >-
+        Updates the AutokeyConfig for a folder. The caller must have both
+        `cloudkms.autokeyConfigs.update` permission on the parent folder and
+        `cloudkms.cryptoKeys.setIamPolicy` permission on the provided key
+        project. A KeyHandle creation in the folder's descendant projects will
+        use this configuration to determine where to create the resulting
+        CryptoKey.
+      operationId: cloudkms.folders.updateAutokeyConfig
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AutokeyConfig'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutokeyConfig'
+      parameters:
+        - in: path
+          name: foldersId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: updateMask
+          schema:
+            type: string
+            format: google-fieldmask
+    get:
+      description: Returns the AutokeyConfig for a folder.
+      operationId: cloudkms.folders.getAutokeyConfig
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutokeyConfig'
+      parameters:
+        - in: path
+          name: foldersId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}:showEffectiveAutokeyConfig:
+    parameters: *ref_23
+    get:
+      description: >-
+        Returns the effective Cloud KMS Autokey configuration for a given
+        project.
+      operationId: cloudkms.projects.showEffectiveAutokeyConfig
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShowEffectiveAutokeyConfigResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConfig:
+    parameters: *ref_23
+    get:
+      description: >-
+        Returns the EkmConfig singleton resource for a given project and
+        location.
+      operationId: cloudkms.projects.locations.getEkmConfig
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EkmConfig'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+    patch:
+      description: >-
+        Updates the EkmConfig singleton resource for a given project and
+        location.
+      operationId: cloudkms.projects.locations.updateEkmConfig
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EkmConfig'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EkmConfig'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: updateMask
+          schema:
+            type: string
+            format: google-fieldmask
+  /v1/projects/{projectsId}/locations/{locationsId}:generateRandomBytes:
+    parameters: *ref_23
+    post:
+      description: >-
+        Generate random bytes using the Cloud KMS randomness source in the
+        provided location.
+      operationId: cloudkms.projects.locations.generateRandomBytes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateRandomBytesRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateRandomBytesResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations:
+    parameters: *ref_23
+    get:
+      description: Lists information about the supported locations for this service.
+      operationId: cloudkms.projects.locations.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListLocationsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: filter
+          schema:
+            type: string
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: pageToken
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}:
+    parameters: *ref_23
+    get:
+      description: Gets information about a location.
+      operationId: cloudkms.projects.locations.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Location'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}:
+    parameters: *ref_23
+    get:
+      description: >-
+        Gets the latest state of a long-running operation. Clients can use this
+        method to poll the operation result at intervals as recommended by the
+        API service.
+      operationId: cloudkms.projects.locations.operations.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Operation'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: operationsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyHandles:
+    parameters: *ref_23
+    post:
+      description: >-
+        Creates a new KeyHandle, triggering the provisioning of a new CryptoKey
+        for CMEK use with the given resource type in the configured key project
+        and the same location. GetOperation should be used to resolve the
+        resulting long-running operation and get the resulting KeyHandle and
+        CryptoKey.
+      operationId: cloudkms.projects.locations.keyHandles.create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KeyHandle'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Operation'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: keyHandleId
+          schema:
+            type: string
+    get:
+      description: Lists KeyHandles.
+      operationId: cloudkms.projects.locations.keyHandles.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListKeyHandlesResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: filter
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyHandles/{keyHandlesId}:
+    parameters: *ref_23
+    get:
+      description: Returns the KeyHandle.
+      operationId: cloudkms.projects.locations.keyHandles.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyHandle'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyHandlesId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConnections:
+    parameters: *ref_23
+    get:
+      description: Lists EkmConnections.
+      operationId: cloudkms.projects.locations.ekmConnections.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListEkmConnectionsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: pageToken
+          schema:
+            type: string
+        - in: query
+          name: filter
+          schema:
+            type: string
+        - in: query
+          name: orderBy
+          schema:
+            type: string
+    post:
+      description: Creates a new EkmConnection in a given Project and Location.
+      operationId: cloudkms.projects.locations.ekmConnections.create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EkmConnection'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EkmConnection'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: ekmConnectionId
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConnections/{ekmConnectionsId}:
+    parameters: *ref_23
+    get:
+      description: Returns metadata for a given EkmConnection.
+      operationId: cloudkms.projects.locations.ekmConnections.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EkmConnection'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: ekmConnectionsId
+          required: true
+          schema:
+            type: string
+    patch:
+      description: Updates an EkmConnection's metadata.
+      operationId: cloudkms.projects.locations.ekmConnections.patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EkmConnection'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EkmConnection'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: ekmConnectionsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: updateMask
+          schema:
+            type: string
+            format: google-fieldmask
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConnections/{ekmConnectionsId}:verifyConnectivity:
+    parameters: *ref_23
+    get:
+      description: >-
+        Verifies that Cloud KMS can successfully connect to the external key
+        manager specified by an EkmConnection. If there is an error connecting
+        to the EKM, this method returns a FAILED_PRECONDITION status containing
+        structured information as described at
+        https://cloud.google.com/kms/docs/reference/ekm_errors.
+      operationId: cloudkms.projects.locations.ekmConnections.verifyConnectivity
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyConnectivityResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: ekmConnectionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConnections/{ekmConnectionsId}:setIamPolicy:
+    parameters: *ref_23
+    post:
+      description: >-
+        Sets the access control policy on the specified resource. Replaces any
+        existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and
+        `PERMISSION_DENIED` errors.
+      operationId: cloudkms.projects.locations.ekmConnections.setIamPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetIamPolicyRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: ekmConnectionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConnections/{ekmConnectionsId}:getIamPolicy:
+    parameters: *ref_23
+    get:
+      description: >-
+        Gets the access control policy for a resource. Returns an empty policy
+        if the resource exists and does not have a policy set.
+      operationId: cloudkms.projects.locations.ekmConnections.getIamPolicy
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: ekmConnectionsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: options.requestedPolicyVersion
+          schema:
+            type: integer
+            format: int32
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConnections/{ekmConnectionsId}:testIamPermissions:
+    parameters: *ref_23
+    post:
+      description: >-
+        Returns permissions that a caller has on the specified resource. If the
+        resource does not exist, this will return an empty set of permissions,
+        not a `NOT_FOUND` error. Note: This operation is designed to be used for
+        building permission-aware UIs and command-line tools, not for
+        authorization checking. This operation may "fail open" without warning.
+      operationId: cloudkms.projects.locations.ekmConnections.testIamPermissions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestIamPermissionsRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestIamPermissionsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: ekmConnectionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings:
+    parameters: *ref_23
+    get:
+      description: Lists KeyRings.
+      operationId: cloudkms.projects.locations.keyRings.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListKeyRingsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: pageToken
+          schema:
+            type: string
+        - in: query
+          name: filter
+          schema:
+            type: string
+        - in: query
+          name: orderBy
+          schema:
+            type: string
+    post:
+      description: Create a new KeyRing in a given Project and Location.
+      operationId: cloudkms.projects.locations.keyRings.create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KeyRing'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyRing'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: keyRingId
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}:
+    parameters: *ref_23
+    get:
+      description: Returns metadata for a given KeyRing.
+      operationId: cloudkms.projects.locations.keyRings.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyRing'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}:setIamPolicy:
+    parameters: *ref_23
+    post:
+      description: >-
+        Sets the access control policy on the specified resource. Replaces any
+        existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and
+        `PERMISSION_DENIED` errors.
+      operationId: cloudkms.projects.locations.keyRings.setIamPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetIamPolicyRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}:getIamPolicy:
+    parameters: *ref_23
+    get:
+      description: >-
+        Gets the access control policy for a resource. Returns an empty policy
+        if the resource exists and does not have a policy set.
+      operationId: cloudkms.projects.locations.keyRings.getIamPolicy
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: options.requestedPolicyVersion
+          schema:
+            type: integer
+            format: int32
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}:testIamPermissions:
+    parameters: *ref_23
+    post:
+      description: >-
+        Returns permissions that a caller has on the specified resource. If the
+        resource does not exist, this will return an empty set of permissions,
+        not a `NOT_FOUND` error. Note: This operation is designed to be used for
+        building permission-aware UIs and command-line tools, not for
+        authorization checking. This operation may "fail open" without warning.
+      operationId: cloudkms.projects.locations.keyRings.testIamPermissions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestIamPermissionsRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestIamPermissionsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys:
+    parameters: *ref_23
+    get:
+      description: Lists CryptoKeys.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListCryptoKeysResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: pageToken
+          schema:
+            type: string
+        - in: query
+          name: versionView
+          schema:
+            type: string
+        - in: query
+          name: filter
+          schema:
+            type: string
+        - in: query
+          name: orderBy
+          schema:
+            type: string
+    post:
+      description: >-
+        Create a new CryptoKey within a KeyRing. CryptoKey.purpose and
+        CryptoKey.version_template.algorithm are required.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CryptoKey'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKey'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: cryptoKeyId
+          schema:
+            type: string
+        - in: query
+          name: skipInitialVersionCreation
+          schema:
+            type: boolean
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}:
+    parameters: *ref_23
+    get:
+      description: >-
+        Returns metadata for a given CryptoKey, as well as its primary
+        CryptoKeyVersion.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKey'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+    patch:
+      description: Update a CryptoKey.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CryptoKey'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKey'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: updateMask
+          schema:
+            type: string
+            format: google-fieldmask
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}:updatePrimaryVersion:
+    parameters: *ref_23
+    post:
+      description: >-
+        Update the version of a CryptoKey that will be used in Encrypt. Returns
+        an error if called on a key whose purpose is not ENCRYPT_DECRYPT.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.updatePrimaryVersion
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCryptoKeyPrimaryVersionRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKey'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}:encrypt:
+    parameters: *ref_23
+    post:
+      description: >-
+        Encrypts data, so that it can only be recovered by a call to Decrypt.
+        The CryptoKey.purpose must be ENCRYPT_DECRYPT.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.encrypt
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncryptRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncryptResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}:decrypt:
+    parameters: *ref_23
+    post:
+      description: >-
+        Decrypts data that was protected by Encrypt. The CryptoKey.purpose must
+        be ENCRYPT_DECRYPT.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.decrypt
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DecryptRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecryptResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}:setIamPolicy:
+    parameters: *ref_23
+    post:
+      description: >-
+        Sets the access control policy on the specified resource. Replaces any
+        existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and
+        `PERMISSION_DENIED` errors.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.setIamPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetIamPolicyRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}:getIamPolicy:
+    parameters: *ref_23
+    get:
+      description: >-
+        Gets the access control policy for a resource. Returns an empty policy
+        if the resource exists and does not have a policy set.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.getIamPolicy
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: options.requestedPolicyVersion
+          schema:
+            type: integer
+            format: int32
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}:testIamPermissions:
+    parameters: *ref_23
+    post:
+      description: >-
+        Returns permissions that a caller has on the specified resource. If the
+        resource does not exist, this will return an empty set of permissions,
+        not a `NOT_FOUND` error. Note: This operation is designed to be used for
+        building permission-aware UIs and command-line tools, not for
+        authorization checking. This operation may "fail open" without warning.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.testIamPermissions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestIamPermissionsRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestIamPermissionsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions:
+    parameters: *ref_23
+    get:
+      description: Lists CryptoKeyVersions.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListCryptoKeyVersionsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: pageToken
+          schema:
+            type: string
+        - in: query
+          name: view
+          schema:
+            type: string
+        - in: query
+          name: filter
+          schema:
+            type: string
+        - in: query
+          name: orderBy
+          schema:
+            type: string
+    post:
+      description: >-
+        Create a new CryptoKeyVersion in a CryptoKey. The server will assign the
+        next sequential id. If unset, state will be set to ENABLED.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CryptoKeyVersion'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKeyVersion'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:
+    parameters: *ref_23
+    get:
+      description: Returns metadata for a given CryptoKeyVersion.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKeyVersion'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+    patch:
+      description: >-
+        Update a CryptoKeyVersion's metadata. state may be changed between
+        ENABLED and DISABLED using this method. See DestroyCryptoKeyVersion and
+        RestoreCryptoKeyVersion to move between other states.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CryptoKeyVersion'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKeyVersion'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: updateMask
+          schema:
+            type: string
+            format: google-fieldmask
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}/publicKey:
+    parameters: *ref_23
+    get:
+      description: >-
+        Returns the public key for the given CryptoKeyVersion. The
+        CryptoKey.purpose must be ASYMMETRIC_SIGN or ASYMMETRIC_DECRYPT.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.getPublicKey
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicKey'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions:import:
+    parameters: *ref_23
+    post:
+      description: >-
+        Import wrapped key material into a CryptoKeyVersion. All requests must
+        specify a CryptoKey. If a CryptoKeyVersion is additionally specified in
+        the request, key material will be reimported into that version.
+        Otherwise, a new version will be created, and will be assigned the next
+        sequential id within the CryptoKey.
+      operationId: cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.import
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportCryptoKeyVersionRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKeyVersion'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:destroy:
+    parameters: *ref_23
+    post:
+      description: >-
+        Schedule a CryptoKeyVersion for destruction. Upon calling this method,
+        CryptoKeyVersion.state will be set to DESTROY_SCHEDULED, and
+        destroy_time will be set to the time destroy_scheduled_duration in the
+        future. At that time, the state will automatically change to DESTROYED,
+        and the key material will be irrevocably destroyed. Before the
+        destroy_time is reached, RestoreCryptoKeyVersion may be called to
+        reverse the process.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.destroy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DestroyCryptoKeyVersionRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKeyVersion'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:restore:
+    parameters: *ref_23
+    post:
+      description: >-
+        Restore a CryptoKeyVersion in the DESTROY_SCHEDULED state. Upon
+        restoration of the CryptoKeyVersion, state will be set to DISABLED, and
+        destroy_time will be cleared.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.restore
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RestoreCryptoKeyVersionRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CryptoKeyVersion'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:rawEncrypt:
+    parameters: *ref_23
+    post:
+      description: >-
+        Encrypts data using portable cryptographic primitives. Most users should
+        choose Encrypt and Decrypt rather than their raw counterparts. The
+        CryptoKey.purpose must be RAW_ENCRYPT_DECRYPT.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.rawEncrypt
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RawEncryptRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawEncryptResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:rawDecrypt:
+    parameters: *ref_23
+    post:
+      description: >-
+        Decrypts data that was originally encrypted using a raw cryptographic
+        mechanism. The CryptoKey.purpose must be RAW_ENCRYPT_DECRYPT.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.rawDecrypt
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RawDecryptRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawDecryptResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:asymmetricSign:
+    parameters: *ref_23
+    post:
+      description: >-
+        Signs data using a CryptoKeyVersion with CryptoKey.purpose
+        ASYMMETRIC_SIGN, producing a signature that can be verified with the
+        public key retrieved from GetPublicKey.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.asymmetricSign
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AsymmetricSignRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsymmetricSignResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:asymmetricDecrypt:
+    parameters: *ref_23
+    post:
+      description: >-
+        Decrypts data that was encrypted with a public key retrieved from
+        GetPublicKey corresponding to a CryptoKeyVersion with CryptoKey.purpose
+        ASYMMETRIC_DECRYPT.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.asymmetricDecrypt
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AsymmetricDecryptRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsymmetricDecryptResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:macSign:
+    parameters: *ref_23
+    post:
+      description: >-
+        Signs data using a CryptoKeyVersion with CryptoKey.purpose MAC,
+        producing a tag that can be verified by another source with the same
+        key.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.macSign
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacSignRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacSignResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/cryptoKeys/{cryptoKeysId}/cryptoKeyVersions/{cryptoKeyVersionsId}:macVerify:
+    parameters: *ref_23
+    post:
+      description: >-
+        Verifies MAC tag using a CryptoKeyVersion with CryptoKey.purpose MAC,
+        and returns a response that indicates whether or not the verification
+        was successful.
+      operationId: >-
+        cloudkms.projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.macVerify
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MacVerifyRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MacVerifyResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeysId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: cryptoKeyVersionsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/importJobs:
+    parameters: *ref_23
+    get:
+      description: Lists ImportJobs.
+      operationId: cloudkms.projects.locations.keyRings.importJobs.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListImportJobsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: pageToken
+          schema:
+            type: string
+        - in: query
+          name: filter
+          schema:
+            type: string
+        - in: query
+          name: orderBy
+          schema:
+            type: string
+    post:
+      description: >-
+        Create a new ImportJob within a KeyRing. ImportJob.import_method is
+        required.
+      operationId: cloudkms.projects.locations.keyRings.importJobs.create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportJob'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: importJobId
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/importJobs/{importJobsId}:
+    parameters: *ref_23
+    get:
+      description: Returns metadata for a given ImportJob.
+      operationId: cloudkms.projects.locations.keyRings.importJobs.get
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJob'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: importJobsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/importJobs/{importJobsId}:setIamPolicy:
+    parameters: *ref_23
+    post:
+      description: >-
+        Sets the access control policy on the specified resource. Replaces any
+        existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and
+        `PERMISSION_DENIED` errors.
+      operationId: cloudkms.projects.locations.keyRings.importJobs.setIamPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetIamPolicyRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: importJobsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/importJobs/{importJobsId}:getIamPolicy:
+    parameters: *ref_23
+    get:
+      description: >-
+        Gets the access control policy for a resource. Returns an empty policy
+        if the resource exists and does not have a policy set.
+      operationId: cloudkms.projects.locations.keyRings.importJobs.getIamPolicy
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: importJobsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: options.requestedPolicyVersion
+          schema:
+            type: integer
+            format: int32
+  /v1/projects/{projectsId}/locations/{locationsId}/keyRings/{keyRingsId}/importJobs/{importJobsId}:testIamPermissions:
+    parameters: *ref_23
+    post:
+      description: >-
+        Returns permissions that a caller has on the specified resource. If the
+        resource does not exist, this will return an empty set of permissions,
+        not a `NOT_FOUND` error. Note: This operation is designed to be used for
+        building permission-aware UIs and command-line tools, not for
+        authorization checking. This operation may "fail open" without warning.
+      operationId: cloudkms.projects.locations.keyRings.importJobs.testIamPermissions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestIamPermissionsRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestIamPermissionsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: keyRingsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: importJobsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConfig:setIamPolicy:
+    parameters: *ref_23
+    post:
+      description: >-
+        Sets the access control policy on the specified resource. Replaces any
+        existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and
+        `PERMISSION_DENIED` errors.
+      operationId: cloudkms.projects.locations.ekmConfig.setIamPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetIamPolicyRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConfig:getIamPolicy:
+    parameters: *ref_23
+    get:
+      description: >-
+        Gets the access control policy for a resource. Returns an empty policy
+        if the resource exists and does not have a policy set.
+      operationId: cloudkms.projects.locations.ekmConfig.getIamPolicy
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Policy'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: options.requestedPolicyVersion
+          schema:
+            type: integer
+            format: int32
+  /v1/projects/{projectsId}/locations/{locationsId}/ekmConfig:testIamPermissions:
+    parameters: *ref_23
+    post:
+      description: >-
+        Returns permissions that a caller has on the specified resource. If the
+        resource does not exist, this will return an empty set of permissions,
+        not a `NOT_FOUND` error. Note: This operation is designed to be used for
+        building permission-aware UIs and command-line tools, not for
+        authorization checking. This operation may "fail open" without warning.
+      operationId: cloudkms.projects.locations.ekmConfig.testIamPermissions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestIamPermissionsRequest'
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloud-platform
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloudkms
+          Oauth2c:
+            - https://www.googleapis.com/auth/cloudkms
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestIamPermissionsResponse'
+      parameters:
+        - in: path
+          name: projectsId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: locationsId
+          required: true
+          schema:
+            type: string

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -4111,3 +4111,49 @@ External Postgres Data Source Inner Join Ordered Query
     ...    select rtg.table_catalog, rtg.table_schema, rtg.table_name, rtg.privilege_type, rtg.is_grantable, ar.is_grantable as role_is_grantable from pgi.information_schema.role_table_grants rtg inner join pgi.information_schema.applicable_roles ar on rtg.grantee \= ar.grantee where rtg.table_name \= 'pg_statistic' order by privilege_type desc;
     ...    ${SELECT_EXTERNAL_INFORMATION_SCHEMA_INNER_JOIN_EXPECTED}
     ...    ${CURDIR}/tmp/External-Postgres-Data-Source-Inner-Join-Ordered-Query.tmp
+
+Empty Response 200 Missing Jsonpath Search Key Should Return Empty Table on GCP KMS Key Rings
+    ${inputStr} =    Catenate
+    ...    select * from  google.cloudkms.key_rings where projectsId = 'testing-project' and locationsId = 'australia-southeast1';
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------|------|
+    ...    |${SPACE}createTime${SPACE}|${SPACE}name${SPACE}|
+    ...    |------------|------|
+    ${stdErrStr} =    Catenate    SEPARATOR=\n
+    ...    error processing response: unknown key keyRings
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${stdErrStr}
+    ...    stdout=${CURDIR}/tmp/Empty-Response-200-Missing-Jsonpath-Search-Key-Should-Return-Empty-Table-on-GCP-KMS-Key-Rings.tmp
+    ...    stderr=${CURDIR}/tmp/Empty-Response-200-Missing-Jsonpath-Search-Key-Should-Return-Empty-Table-on-GCP-KMS-Key-Rings-stderr.tmp
+
+Normal Response 200 Should Return Populated Table on GCP KMS Key Rings
+    ${inputStr} =    Catenate
+    ...    select * from  google.cloudkms.key_rings where projectsId = 'testing-project' and locationsId = 'global';
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |-------------------------------|------------------------------------------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}createTime${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |-------------------------------|------------------------------------------------------------|
+    ...    |${SPACE}2022-02-02T02:02:02.02000000Z${SPACE}|${SPACE}projects/testing-project/locations/global/keyRings/testing${SPACE}|
+    ...    |-------------------------------|------------------------------------------------------------|
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Normal-Response-200-Should-Return-Populated-Table-on-GCP-KMS-Key-Rings.tmp
+    ...    stderr=${CURDIR}/tmp/Normal-Response-200-Should-Return-Populated-Table-on-GCP-KMS-Key-Rings-stderr.tmp


### PR DESCRIPTION
## Description

- Empty response will generate empty table, even in the face of `jsonpath` error.
- Added robot test `Empty Response 200 Missing Jsonpath Search Key Should Return Empty Table on GCP KMS Key Rings`.
- Added robot test `Normal Response 200 Should Return Populated Table on GCP KMS Key Rings`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Empty Response 200 Missing Jsonpath Search Key Should Return Empty Table on GCP KMS Key Rings`.
- Added robot test `Normal Response 200 Should Return Populated Table on GCP KMS Key Rings`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
