### PR TITLE
join-dependency-corner-cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stackql/go-sqlite3 v0.0.3-stackqlalpha02
 	github.com/stackql/go-suffix-map v0.0.1-alpha01
 	github.com/stackql/psql-wire v0.1.1-alpha07
-	github.com/stackql/stackql-parser v0.0.13-beta25
+	github.com/stackql/stackql-parser v0.0.13-beta29
 	github.com/stretchr/testify v1.8.4
 	github.com/xo/dburl v0.12.4
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/stackql/psql-wire v0.1.1-alpha07 h1:LQWVUlx4Bougk6dztDNG5tmXxpIVeeTSs
 github.com/stackql/psql-wire v0.1.1-alpha07/go.mod h1:a44Wd8kDC3irFLpGutarKDBqhJ/aqXlj1aMzO5bVJYg=
 github.com/stackql/readline v0.0.2-alpha05 h1:ID4QzGdplFBsrSnTuz8pvKzWw96JbrJg8fsLry2UriU=
 github.com/stackql/readline v0.0.2-alpha05/go.mod h1:OFAYOdXk/X4+5GYiDXFfaGrk+bCN6Qv0SYY5HNzD2E0=
-github.com/stackql/stackql-parser v0.0.13-beta25 h1:rZ8WBSMXJAQ9IFgAZ3GHFVpkw7wITs6qjvM2NeA6vzE=
-github.com/stackql/stackql-parser v0.0.13-beta25/go.mod h1:iyB47SvRS+Fvpn7joF7mHAkeiWSq83TbUhglRmLzPLQ=
+github.com/stackql/stackql-parser v0.0.13-beta29 h1:NBcAuGo+vNqRN+4GgEZMerfTV4wLyLnhlKCrSf5uoAo=
+github.com/stackql/stackql-parser v0.0.13-beta29/go.mod h1:iyB47SvRS+Fvpn7joF7mHAkeiWSq83TbUhglRmLzPLQ=
 github.com/stackql/stackql-provider-registry v0.0.1-rc06 h1:MgroWOr0bSqjSTDGnXB0UoZGFXpW3SRtN0EFkzB8Rpo=
 github.com/stackql/stackql-provider-registry v0.0.1-rc06/go.mod h1:87rVxnS2aRASK20lBQgoYA0o7FSJTZBGGRaWFR7IDm4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/stackql/dataflow/relation.go
+++ b/internal/stackql/dataflow/relation.go
@@ -62,7 +62,7 @@ func (dr *standardDataFlowRelation) GetSelectExpr() (sqlparser.SelectExpr, error
 }
 
 func (dr *standardDataFlowRelation) GetColumnDescriptor() (anysdk.ColumnDescriptor, error) {
-	decoratedColumn := fmt.Sprintf(`%s AS %s`, sqlparser.String(dr.sourceExpr), dr.destColumn.Name.GetRawVal())
+	decoratedColumn := fmt.Sprintf(`%s AS %s`, sqlparser.ColDelimitedString(dr.sourceExpr), dr.destColumn.Name.GetRawVal())
 	cd := anysdk.NewColumnDescriptor(dr.destColumn.Name.GetRawVal(), "", "", decoratedColumn, nil, nil, nil)
 	return cd, nil
 }

--- a/internal/stackql/docparser/doc_parser.go
+++ b/internal/stackql/docparser/doc_parser.go
@@ -70,10 +70,11 @@ func OpenapiStackQLTabulationsPersistor(
 			return discoveryGenerationID, displayErr
 		}
 		for _, q := range ddl {
+			logging.GetLogger().Infof("DDL about to run: '''%q'''", q)
 			_, err = txn.Exec(q)
 			if err != nil {
 				displayErr := fmt.Errorf("aborting DDL run for query '''%s''' with error: %w", q, err)
-				logging.GetLogger().Infof("aborting DDL run for query '''%s''' with error: %s\n", q, err.Error())
+				logging.GetLogger().Infof("aborting DDL run for query '''%s''' with error: %s", q, err.Error())
 				txn.Rollback() //nolint:errcheck // TODO: investigate
 				return discoveryGenerationID, displayErr
 			}

--- a/internal/stackql/driver/driver.go
+++ b/internal/stackql/driver/driver.go
@@ -143,7 +143,7 @@ func (dr *basicStackQLDriver) HandleSimpleQuery(ctx context.Context, query strin
 	}
 	r := res[0]
 	if r.GetError() != nil {
-		return nil, r.GetError()
+		return nil, fmt.Errorf("query returns error: %w", r.GetError())
 	}
 	return r.GetSQLResult(), nil
 }

--- a/internal/stackql/internal_data_transfer/internaldto/db_table.go
+++ b/internal/stackql/internal_data_transfer/internaldto/db_table.go
@@ -14,7 +14,9 @@ type DBTable interface {
 	GetHeirarchyIdentifiers() HeirarchyIdentifiers
 	IsAnalytics() bool
 	GetName() string
+	GetNameSpace() string
 	GetNameStump() string
+	WithNameSpace(string) DBTable
 }
 
 type standardDBTable struct {
@@ -50,6 +52,15 @@ func newDBTable(
 		hIDs:        hIDs,
 		namespace:   namespace,
 	}
+}
+
+func (dbt *standardDBTable) WithNameSpace(ns string) DBTable {
+	dbt.namespace = ns
+	return dbt
+}
+
+func (dbt *standardDBTable) GetNameSpace() string {
+	return dbt.namespace
 }
 
 func (dbt *standardDBTable) GetName() string {

--- a/internal/stackql/parserutil/parser_util.go
+++ b/internal/stackql/parserutil/parser_util.go
@@ -17,6 +17,25 @@ const (
 	FloatBitSize int = 64
 )
 
+//nolint:gocritic,staticcheck // TODO: clean up this and other tech debt
+func ExtractLHSTable(sqlFunc *sqlparser.FuncExpr) (*sqlparser.ColName, bool) {
+	if sqlFunc == nil {
+		return nil, false
+	}
+	funcNameLowered := strings.ToLower(sqlFunc.Name.GetRawVal())
+	switch funcNameLowered {
+	default:
+		switch ex := sqlFunc.Exprs[0].(type) {
+		case *sqlparser.AliasedExpr:
+			switch ex2 := ex.Expr.(type) {
+			case *sqlparser.ColName:
+				return ex2, true
+			}
+		}
+	}
+	return nil, false
+}
+
 // These null "dual" tables are some vitess artifact.
 func IsNullTable(node sqlparser.TableExpr) bool {
 	return isNullTable(node)

--- a/internal/stackql/primitivebuilder/single_select_acquire.go
+++ b/internal/stackql/primitivebuilder/single_select_acquire.go
@@ -293,7 +293,8 @@ func (ss *SingleSelectAcquire) Build() error {
 
 								logging.GetLogger().Infoln(
 									fmt.Sprintf(
-										"running insert with control parameters: %v",
+										"running insert with query = '''%s''', control parameters: %v",
+										ss.insertPreparedStatementCtx.GetQuery(),
 										ss.insertPreparedStatementCtx.GetGCCtrlCtrs(),
 									),
 								)

--- a/internal/stackql/router/parameter_router.go
+++ b/internal/stackql/router/parameter_router.go
@@ -199,6 +199,9 @@ func (pr *standardParameterRouter) GetOnConditionDataFlows() (dataflow.Collectio
 			dependencyTable = te
 		}
 		switch r := k.Right.(type) {
+		case *sqlparser.SQLVal:
+			// no dataflow dependency, do zero
+			continue
 		case *sqlparser.ColName:
 			rhr, candidateTable, err := pr.extractDataFlowDependency(r)
 			if err != nil {

--- a/internal/stackql/sql_system/postgres.go
+++ b/internal/stackql/sql_system/postgres.go
@@ -1046,12 +1046,13 @@ func (eng *postgresSystem) ComposeSelectQuery(
 	hoistedTableAliases []string,
 	fromString string,
 	rewrittenWhere string,
+	selectQualifier string,
 	selectSuffix string,
 	parameterOffset int,
 ) (string, error) {
 	return eng.composeSelectQuery(
 		columns, tableAliases,
-		hoistedTableAliases, fromString, rewrittenWhere, selectSuffix, parameterOffset)
+		hoistedTableAliases, fromString, rewrittenWhere, selectQualifier, selectSuffix, parameterOffset)
 }
 
 func (eng *postgresSystem) composeSelectQuery(
@@ -1060,6 +1061,7 @@ func (eng *postgresSystem) composeSelectQuery(
 	hoistedTableAliases []string,
 	fromString string,
 	rewrittenWhere string,
+	selectQualifier string,
 	selectSuffix string,
 	parameterOffset int,
 ) (string, error) {
@@ -1108,7 +1110,7 @@ func (eng *postgresSystem) composeSelectQuery(
 	}
 	whereExprsStr := wq.String()
 
-	q.WriteString(fmt.Sprintf(`SELECT %s `, strings.Join(quotedColNames, ", ")))
+	q.WriteString(fmt.Sprintf(`SELECT %s %s `, selectQualifier, strings.Join(quotedColNames, ", ")))
 	if fromString != "" {
 		q.WriteString(fmt.Sprintf(`FROM %s `, fromString))
 	}
@@ -1619,7 +1621,7 @@ func (eng *postgresSystem) getTable(
 		tableHeirarchyIDs.GetTableName(),
 		discoveryID,
 		tableHeirarchyIDs,
-	), err
+	).WithNameSpace(eng.tableSchema), err
 }
 
 func (eng *postgresSystem) GetCurrentTable(

--- a/internal/stackql/sql_system/sql_system.go
+++ b/internal/stackql/sql_system/sql_system.go
@@ -21,7 +21,7 @@ import (
 )
 
 type SQLSystem interface {
-	ComposeSelectQuery([]typing.RelationalColumn, []string, []string, string, string, string, int) (string, error)
+	ComposeSelectQuery([]typing.RelationalColumn, []string, []string, string, string, string, string, int) (string, error)
 	DelimitGroupByColumn(term string) string
 	DelimitOrderByColumn(term string) string
 	// GCAdd() will record a Txn as active

--- a/internal/stackql/sql_system/sqlite.go
+++ b/internal/stackql/sql_system/sqlite.go
@@ -1176,10 +1176,12 @@ func (eng *sqLiteSystem) ComposeSelectQuery(
 	hoistedTableAliases []string,
 	fromString string,
 	rewrittenWhere string,
+	selectQualifier string,
 	selectSuffix string,
 	parameterOffset int,
 ) (string, error) {
-	return eng.composeSelectQuery(columns, tableAliases, hoistedTableAliases, fromString, rewrittenWhere, selectSuffix)
+	return eng.composeSelectQuery(
+		columns, tableAliases, hoistedTableAliases, fromString, rewrittenWhere, selectQualifier, selectSuffix)
 }
 
 func (eng *sqLiteSystem) composeSelectQuery(
@@ -1188,6 +1190,7 @@ func (eng *sqLiteSystem) composeSelectQuery(
 	hoistedTableAliases []string,
 	fromString string,
 	rewrittenWhere string,
+	selectQualifier string,
 	selectSuffix string,
 ) (string, error) {
 	var q strings.Builder
@@ -1238,7 +1241,7 @@ func (eng *sqLiteSystem) composeSelectQuery(
 	}
 	whereExprsStr := wq.String()
 
-	q.WriteString(fmt.Sprintf(`SELECT %s `, strings.Join(quotedColNames, ", ")))
+	q.WriteString(fmt.Sprintf(`SELECT %s %s `, selectQualifier, strings.Join(quotedColNames, ", ")))
 	if fromString != "" {
 		q.WriteString(fmt.Sprintf(`FROM %s `, fromString))
 	}

--- a/internal/stackql/taxonomy/annotation_context.go
+++ b/internal/stackql/taxonomy/annotation_context.go
@@ -104,6 +104,7 @@ func (ac *standardAnnotationCtx) Prepare(
 	if err != nil {
 		return err
 	}
+	params := ac.GetParameters()
 	// LAZY EVAL if dynamic
 	if ac.isDynamic {
 		viewDTO, isView := ac.GetView()
@@ -132,7 +133,7 @@ func (ac *standardAnnotationCtx) Prepare(
 		)
 		return nil
 	}
-	params := ac.GetParameters()
+
 	ac.tableMeta.WithGetHTTPArmoury(
 		func() (anysdk.HTTPArmoury, error) {
 			// need to dynamically generate stream, otherwise repeated calls result in empty body

--- a/test/mockserver/expectations/static-gcp-expectations.json
+++ b/test/mockserver/expectations/static-gcp-expectations.json
@@ -5,6 +5,43 @@
         "accept": [ "application/json" ]
       },
       "method": "GET",
+      "path": "/v1/projects/testing-project/locations/global/keyRings/testing/cryptoKeys"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "cryptoKeys": [
+          {
+            "name": "projects/testing-project/locations/global/keyRings/testing/cryptoKeys/testing-demo-key",
+            "primary": {
+              "name": "projects/testing-project/locations/global/keyRings/testing/cryptoKeys/testing-demo-key/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          }
+        ],
+        "totalSize": 1
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
       "path": "/v1/projects/testing-project/locations/australia-southeast1/keyRings"
     },
     "httpResponse": {

--- a/test/registry/src/googleapis.com/v0.1.2/services/cloudkms-v1.yaml
+++ b/test/registry/src/googleapis.com/v0.1.2/services/cloudkms-v1.yaml
@@ -3440,8 +3440,8 @@ components:
             openAPIDocKey: '200'
       sqlVerbs:
         select:
-          - $ref: '#/components/x-stackQL-resources/crypto_keys/methods/list'
           - $ref: '#/components/x-stackQL-resources/crypto_keys/methods/get'
+          - $ref: '#/components/x-stackQL-resources/crypto_keys/methods/list'
         insert:
           - $ref: '#/components/x-stackQL-resources/crypto_keys/methods/create'
         update: []

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -2260,6 +2260,98 @@ Left Outer Join Network Infra
     ...    ${outputStr}
     ...    stdout=${CURDIR}/tmp/Left-Outer-Join-Network-Infra.tmp
 
+
+
+Left Outer Join Network Infra Enforce Dependency
+    ${inputStr} =    Catenate
+    ...    select 
+    ...    nw.name as network_name, 
+    ...    sn.name as subnetwork_name, 
+    ...    split_part(sn.network, '/', 10) as sn_fuzz  
+    ...    from 
+    ...    google.compute.networks nw 
+    ...    LEFT OUTER JOIN 
+    ...    google.compute.subnetworks sn  
+    ...    on 
+    ...    lower(nw.name) = lower(split_part(sn.network, '/', 10))   
+    ...    and sn.project = split_part(nw.selfLink, '/', 7) 
+    ...    where nw.project = 'testing-project' and sn.region = 'australia-southeast1'
+    ...    order by 
+    ...    network_name, subnetwork_name
+    ...    ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}network_name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}subnetwork_name${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}sn_fuzz${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}demo-disk-xx5${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}demo-disk-xx5${SPACE}${SPACE}${SPACE}|${SPACE}demo-disk-xx5${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}k8s-01-vpc${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}aus-sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}aus-sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}kubernetes-the-hard-way-vpc2${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}testing-network-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Left-Outer-Join-Network-Infra-Enforce-Dependency.tmp
+
+Left Outer Join Network Infra Scalar in ON Condition
+    ${inputStr} =    Catenate
+    ...    select 
+    ...    nw.name as network_name, 
+    ...    sn.name as subnetwork_name, 
+    ...    split_part(sn.network, '/', 10) as sn_fuzz  
+    ...    from 
+    ...    google.compute.networks nw 
+    ...    LEFT OUTER JOIN 
+    ...    google.compute.subnetworks sn  
+    ...    on 
+    ...    lower(nw.name) = lower(split_part(sn.network, '/', 10))   
+    ...    and sn.project = 'testing-project' 
+    ...    where nw.project = 'testing-project' and sn.region = 'australia-southeast1'
+    ...    order by 
+    ...    network_name, subnetwork_name
+    ...    ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}network_name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}subnetwork_name${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}sn_fuzz${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}demo-disk-xx5${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}demo-disk-xx5${SPACE}${SPACE}${SPACE}|${SPACE}demo-disk-xx5${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}k8s-01-vpc${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}aus-sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}aus-sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}kubernetes-the-hard-way-vpc2${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    ...    |${SPACE}testing-network-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------------------|-----------------|---------------|
+    Should Stackql Exec Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    stdout=${CURDIR}/tmp/Left-Outer-Join-Network-Infra-Scalar-in-ON-Condition.tmp
+
 Left Inner Join Users
     ${sqliteInputStr} =    Catenate
     ...    select 
@@ -4157,3 +4249,69 @@ Normal Response 200 Should Return Populated Table on GCP KMS Key Rings
     ...    ${EMPTY}
     ...    stdout=${CURDIR}/tmp/Normal-Response-200-Should-Return-Populated-Table-on-GCP-KMS-Key-Rings.tmp
     ...    stderr=${CURDIR}/tmp/Normal-Response-200-Should-Return-Populated-Table-on-GCP-KMS-Key-Rings-stderr.tmp
+
+Verify Data Flow Replication in ON Conditions Is Mitigated Using Example of Networks Subnetworks Join Aggregate
+    ${inputStr} =    Catenate
+    ...    select nw.name as network_name, sn.name as subnetwork_name, count(1) as subnet_count 
+    ...    from google.compute.networks nw LEFT OUTER JOIN google.compute.subnetworks sn 
+    ...    on lower(nw.name) = lower(split_part(sn.network, '/', 10)) and sn.project = split_part(nw.selfLink, '/', 7) 
+    ...    where nw.project = 'testing-project' and sn.region = 'australia-southeast1' 
+    ...    group by network_name, subnetwork_name ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------------------------|-----------------|--------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}network_name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}subnetwork_name${SPACE}|${SPACE}subnet_count${SPACE}|
+    ...    |------------------------------|-----------------|--------------|
+    ...    |${SPACE}demo-disk-xx5${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}demo-disk-xx5${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |------------------------------|-----------------|--------------|
+    ...    |${SPACE}k8s-01-vpc${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |------------------------------|-----------------|--------------|
+    ...    |${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}aus-sn-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |------------------------------|-----------------|--------------|
+    ...    |${SPACE}kr-vpc-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}aus-sn-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |------------------------------|-----------------|--------------|
+    ...    |${SPACE}kubernetes-the-hard-way-vpc2${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |------------------------------|-----------------|--------------|
+    ...    |${SPACE}testing-network-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}null${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |------------------------------|-----------------|--------------|
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Verify-Data-Flow-Replication-in-ON-Conditions-Is-Mitigated-Using-Example-of-Networks-Subnetworks-Join-Aggregate.tmp
+    ...    stderr=${CURDIR}/tmp/Verify-Data-Flow-Replication-in-ON-Conditions-Is-Mitigated-Using-Example-of-Networks-Subnetworks-Join-Aggregate-stderr.tmp
+
+Verify Data Flow ON Conditions With Functions Do NOT Halt Analysis Using Example of GCP KMS Keyrings to Keys Join
+    ${inputStr} =    Catenate
+    ...    select split_part(rings.name, '/', -1) 
+    ...    from google.cloudkms.key_rings rings inner join google.cloudkms.crypto_keys keys 
+    ...    on keys.keyRingsId = split_part(rings.name, '/', -1) and keys.projectsId = 'testing-project' 
+    ...    where rings.projectsId = 'testing-project' and rings.locationsId = 'global' and keys.locationsId = 'global';
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |---------|
+    ...    |${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}|
+    ...    |---------|
+    ...    |${SPACE}testing${SPACE}|
+    ...    |---------|
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Verify-Data-Flow-ON-Conditions-With-Functions-Do-NOT-Halt-Analysis-Using-Example-of-GCP-KMS-Keyrings-to-Keys-Join.tmp
+    ...    stderr=${CURDIR}/tmp/Verify-Data-Flow-ON-Conditions-With-Functions-Do-NOT-Halt-Analysis-Using-Example-of-GCP-KMS-Keyrings-to-Keys-Join-stderr.tmp
+
+
+


### PR DESCRIPTION
## Description

- Fixed error caused by scalar in ON condition.
- Deduplication in dataflows for `ON` conditions.
- Fix bug wherein data flow `ON` conditions with functions silently halt analysis.
- Added robot test `Left Outer Join Network Infra Scalar in ON Condition`.
- Added robot test `Left Outer Join Network Infra Enforce Dependency`.
- Added robot test `Verify Data Flow Replication in ON Conditions Is Mitigated Using Example of Networks Subnetworks Join Aggregate`.
- Added robot test `Verify Data Flow ON Conditions With Functions Do NOT Halt Analysis Using Example of GCP KMS Keyrings to Keys Join`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Left Outer Join Network Infra Scalar in ON Condition`.
- Added robot test `Left Outer Join Network Infra Enforce Dependency`.
- Added robot test `Verify Data Flow Replication in ON Conditions Is Mitigated Using Example of Networks Subnetworks Join Aggregate`.
- Added robot test `Verify Data Flow ON Conditions With Functions Do NOT Halt Analysis Using Example of GCP KMS Keyrings to Keys Join`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

The function `ExtractLHSTable` in module `parserutil` has been added to [the tech debt register](https://github.com/stackql/stackql/wiki/Tech-Debt-Register).

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
