### PR TITLE
lifecycle-ec2

### DIFF
--- a/test/mockserver/expectations/static-aws-expectations.json
+++ b/test/mockserver/expectations/static-aws-expectations.json
@@ -1357,6 +1357,33 @@
       "body" : {
         "type" : "PARAMETERS",
         "parameters": {
+          "Action": [ "^StartInstances$" ],
+          "Version": [ "^2016\\-11\\-15$" ],
+          "InstanceId.1": [ "id-001" ]
+        }
+      }
+    },
+    "httpResponse": {
+      "headers": {
+        "content-type": [ "text/xml" ]
+      },
+      "statusCode": 200,
+      "body": {
+        "type": "STRING",
+        "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?> <StartInstancesResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">   <requestId>0000001-0001-0001-0001-0000000001</requestId>   <instancesSet>       <item>           <instanceId>id-001</instanceId>           <currentState>               <code>0</code>               <name>pending</name>           </currentState>           <previousState>               <code>80</code>               <name>stopped</name>           </previousState>       </item>   </instancesSet> </StartInstancesResponse>"
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "method": "POST",
+      "path": "/",
+      "headers": {
+        "Authorization": ["^.*SignedHeaders=.*content-type;host;x-amz-date.*$" ]
+      },
+      "body" : {
+        "type" : "PARAMETERS",
+        "parameters": {
           "Action": [ "^ModifyVolume$" ],
           "Version": [ "^2016\\-11\\-15$" ],
           "Size": ["^12$"],

--- a/test/registry/src/aws/v0.1.0/services/ec2.yaml
+++ b/test/registry/src/aws/v0.1.0/services/ec2.yaml
@@ -39560,10 +39560,7 @@ paths:
           schema:
             type: array
             items:
-              allOf:
-                - $ref: '#/components/schemas/InstanceId'
-                - xml:
-                    name: InstanceId
+              $ref: '#/components/schemas/InstanceId'
         - name: AdditionalInfo
           in: query
           required: false
@@ -42475,6 +42472,9 @@ components:
         instances_Start:
           operation:
             $ref: '#/paths/~1?Action=StartInstances&Version=2016-11-15/get'
+          # request:
+          #   mediaType: text/xml
+          #   xmlRootAnnotation: 'xmlns="http://ec2.amazonaws.com/doc/2016-11-15/"'
           response:
             mediaType: text/xml
             openAPIDocKey: '200'
@@ -42502,8 +42502,28 @@ components:
         insert: []
         select:
         - $ref: '#/components/x-stackQL-resources/instances/methods/instances_Describe'
+        update:
+        - $ref: '#/components/x-stackQL-resources/instances/methods/instances_Start'
+    instances_start:
+      name: instances_start
+      methods:
+        instances_Start:
+          operation:
+            $ref: '#/paths/~1?Action=StartInstances&Version=2016-11-15/get'
+          # request:
+          #   mediaType: text/xml
+          #   xmlRootAnnotation: 'xmlns="http://ec2.amazonaws.com/doc/2016-11-15/"'
+          response:
+            mediaType: text/xml
+            openAPIDocKey: '200'
+      id: aws.ec2.instances
+      sqlVerbs:
+        delete: []
+        insert:
+        - $ref: '#/components/x-stackQL-resources/instances/methods/instances_Start'
+        select: []
         update: []
-      title: instances
+      title: instances_Start
     internet_gateways:
       name: internet_gateways
       methods:
@@ -78373,13 +78393,9 @@ components:
       title: StartInstancesRequest
       properties:
         InstanceId:
-          allOf:
-            - $ref: '#/components/schemas/InstanceIdStringList'
-            - description: The IDs of the instances.
+          $ref: '#/components/schemas/InstanceIdStringList'
         additionalInfo:
-          allOf:
-            - $ref: '#/components/schemas/String'
-            - description: Reserved.
+          $ref: '#/components/schemas/String'
         dryRun:
           allOf:
             - $ref: '#/components/schemas/Boolean'

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -707,6 +707,53 @@ AWS Route53 Create Record Set Simple Exemplifies XML Request Body
     ...    stdout=${CURDIR}/tmp/AWS-Route53-Create-Record-Set-Simple-Exemplifies-XML-Request-Body.tmp
     ...    stderr=${CURDIR}/tmp/AWS-Route53-Create-Record-Set-Simple-Exemplifies-XML-Request-Body-stderr.tmp
 
+AWS EC2 Insert Start Instance Exemplifies Lifecycle Insert Verb Form Encoded Request
+    ${inputStr} =    Catenate
+    ...    insert into 
+    ...    aws.ec2.instances_start
+    ...    (InstanceId, region)
+    ...    select 
+    ...    JSON('[ "id-001" ]'), 
+    ...    'ap-southeast-2' 
+    ...    ;
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${EMPTY}
+    ...    The operation was despatched successfully
+    ...    stdout=${CURDIR}/tmp/AWS-EC2-Insert-Start-Instance-Exemplifies-Lifecycle-Insert-Verb-Form-Encoded-Request.tmp
+    ...    stderr=${CURDIR}/tmp/AWS-EC2-Insert-Start-Instance-Exemplifies-Lifecycle-Insert-Verb-Form-Encoded-Request-stderr.tmp
+
+
+AWS EC2 Update Start Instance Exemplifies Lifecycle Update Verb Form Encoded Request
+    ${inputStr} =    Catenate
+    ...    update 
+    ...    aws.ec2.instances
+    ...    set 
+    ...    InstanceId = JSON('[ "id-001" ]'), 
+    ...    region = 'ap-southeast-2' 
+    ...    ;
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${EMPTY}
+    ...    The operation was despatched successfully
+    ...    stdout=${CURDIR}/tmp/AWS-EC2-Update-Start-Instance-Exemplifies-Lifecycle-Update-Verb-Form-Encoded-Request.tmp
+    ...    stderr=${CURDIR}/tmp/AWS-EC2-Update-Start-Instance-Exemplifies-Lifecycle-Update-Verb-Form-Encoded-Request-stderr.tmp
+
+
 AWS Route53 Create Record Set CNAME Simple Exemplifies XML Request Body In Real Life
     ${inputStr} =    Catenate
     ...    insert into 


### PR DESCRIPTION
## Description

- `ec2` lifecycle methods through no code changes.
- Added robot test `AWS EC2 Insert Start Instance Exemplifies Lifecycle Insert Verb Form Encoded Request`.
- Added robot test `AWS EC2 Update Start Instance Exemplifies Lifecycle Update Verb Form Encoded Request`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Explanation**: Regression tests for lifecycle methods in SQL verbs in `ec2` service, which uses url form encoded request bodies.  **No code changes**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `AWS EC2 Insert Start Instance Exemplifies Lifecycle Insert Verb Form Encoded Request`.
- Added robot test `AWS EC2 Update Start Instance Exemplifies Lifecycle Update Verb Form Encoded Request`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is added in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
