### PR TITLE
multi-data-flow

### DIFF
--- a/internal/stackql/dataflow/collection.go
+++ b/internal/stackql/dataflow/collection.go
@@ -72,8 +72,19 @@ func (dc *standardDataFlowCollection) getVertex(
 	tableExpr sqlparser.TableExpr,
 ) (Vertex, bool) {
 	for v := range dc.vertices {
-		if v.GetAnnotation() == annotation && v.GetTableExpr() == tableExpr {
+		rhsAnnotation := v.GetAnnotation()
+		rhsTableExpr := v.GetTableExpr()
+		annotationMatch := rhsAnnotation.Equals(annotation)
+		tableExprMatch := rhsTableExpr == tableExpr
+		if annotationMatch && tableExprMatch {
 			return v, true
+		}
+		if annotationMatch || tableExprMatch {
+			logging.GetLogger().Infof(
+				"data flow error: vertex with annotation '%v' and tableExpr '%v' has **almost** been found",
+				rhsAnnotation,
+				rhsTableExpr,
+			)
 		}
 	}
 	return nil, false

--- a/internal/stackql/parserutil/parameter_metadata.go
+++ b/internal/stackql/parserutil/parameter_metadata.go
@@ -18,6 +18,7 @@ type ParameterMetadata interface {
 	GetTable() sqlparser.SQLNode
 	GetOrdinal() int
 	SetTable(sqlparser.SQLNode) error
+	Equals(ParameterMetadata) bool
 }
 
 type StandardComparisonParameterMetadata struct {
@@ -44,6 +45,29 @@ func NewPlaceholderParameterMetadata(ordinal int) ParameterMetadata {
 	return &PlaceholderParameterMetadata{
 		ordinal: ordinal,
 	}
+}
+
+func (pm *StandardComparisonParameterMetadata) Equals(rhs ParameterMetadata) bool {
+	if rhs == nil {
+		return false
+	}
+	if _, ok := rhs.(*StandardComparisonParameterMetadata); !ok {
+		return false
+	}
+	ordinalComparison := pm.GetOrdinal() == rhs.GetOrdinal()
+	parentComparison := pm.GetParent() == rhs.GetParent()
+	valComparison := pm.GetVal() == rhs.GetVal()
+	return ordinalComparison && parentComparison && valComparison
+}
+
+func (pm *PlaceholderParameterMetadata) Equals(rhs ParameterMetadata) bool {
+	if rhs == nil {
+		return false
+	}
+	if _, ok := rhs.(*PlaceholderParameterMetadata); !ok {
+		return false
+	}
+	return pm.GetOrdinal() == rhs.GetOrdinal()
 }
 
 func (pm *PlaceholderParameterMetadata) GetOrdinal() int {

--- a/internal/stackql/router/combination_composer.go
+++ b/internal/stackql/router/combination_composer.go
@@ -1,0 +1,76 @@
+package router
+
+var (
+	_ combinationComposer = &standardCombinationComposer{}
+)
+
+type parameterPack map[string][]any
+
+type combinationComposer interface {
+	analyse(parameterPack) error
+	getCombinations() []map[string]any
+	getIsAnythingSplit() bool
+}
+
+type standardCombinationComposer struct {
+	isAnythingSplit bool
+	combinations    []map[string]any
+}
+
+func newCombinationComposer() combinationComposer {
+	return &standardCombinationComposer{}
+}
+
+func (sc *standardCombinationComposer) getCombinations() []map[string]any {
+	return sc.combinations
+}
+
+func (sc *standardCombinationComposer) getIsAnythingSplit() bool {
+	return sc.isAnythingSplit
+}
+
+func (sc *standardCombinationComposer) getPi(pp parameterPack, keys []string) int {
+	var pi int = 1 //nolint:revive,stylecheck // prefer explicit
+	for _, k := range keys {
+		pi *= len(pp[k])
+	}
+	return pi
+}
+
+func (sc *standardCombinationComposer) getRotation(x int, piMMinusOne int) int {
+	return x / piMMinusOne // this is floor division for golang int type
+}
+
+func (sc *standardCombinationComposer) getModularOrdinal(x int, piM int, piMMinusOne int) int {
+	// demi rotation modulo floor quotient of pi of M and pi of M exlusive of the current parameter
+	return sc.getRotation(x, piMMinusOne) % (piM / piMMinusOne)
+}
+
+func (sc *standardCombinationComposer) analyse(
+	pp parameterPack,
+) error {
+	var keyOrdering []string
+	for k := range pp {
+		keyOrdering = append(keyOrdering, k)
+	}
+	totalCombinationCount := sc.getPi(pp, keyOrdering)
+	if totalCombinationCount > 1 {
+		sc.isAnythingSplit = true
+	}
+	var modularOrdinals []map[string]int
+	for x := 0; x < totalCombinationCount; x++ {
+		modularOrdinalIter := make(map[string]int)
+		for i, key := range keyOrdering {
+			modularOrdinalIter[key] = sc.getModularOrdinal(x, sc.getPi(pp, keyOrdering[:i+1]), sc.getPi(pp, keyOrdering[:i]))
+		}
+		modularOrdinals = append(modularOrdinals, modularOrdinalIter)
+	}
+	for _, mo := range modularOrdinals {
+		combination := make(map[string]any)
+		for k, v := range mo {
+			combination[k] = pp[k][v]
+		}
+		sc.combinations = append(sc.combinations, combination)
+	}
+	return nil
+}

--- a/internal/stackql/tablemetadata/extended_table_metadata.go
+++ b/internal/stackql/tablemetadata/extended_table_metadata.go
@@ -63,6 +63,7 @@ type ExtendedTableMetadata interface {
 	IsMaterializedView() bool
 	GetServerVariables() (map[string]*openapi3.ServerVariable, bool)
 	Clone() ExtendedTableMetadata
+	Equals(ExtendedTableMetadata) bool
 }
 
 type standardExtendedTableMetadata struct {
@@ -93,6 +94,38 @@ func (ex *standardExtendedTableMetadata) Clone() ExtendedTableMetadata {
 		sqlDataSource:       ex.sqlDataSource,
 		isOnClauseHoistable: ex.isOnClauseHoistable,
 	}
+}
+
+func (ex *standardExtendedTableMetadata) Equals(other ExtendedTableMetadata) bool {
+	otherStandard, isStandard := other.(*standardExtendedTableMetadata)
+	if !isStandard {
+		return false
+	}
+	if ex.heirarchyObjects != otherStandard.heirarchyObjects {
+		return false
+	}
+	if ex.isLocallyExecutable != otherStandard.isLocallyExecutable {
+		return false
+	}
+	if ex.selectItemsKey != otherStandard.selectItemsKey {
+		return false
+	}
+	if ex.alias != otherStandard.alias {
+		return false
+	}
+	if ex.inputTableName != otherStandard.inputTableName {
+		return false
+	}
+	if ex.indirect != otherStandard.indirect {
+		return false
+	}
+	if ex.sqlDataSource != otherStandard.sqlDataSource {
+		return false
+	}
+	if ex.isOnClauseHoistable != otherStandard.isOnClauseHoistable {
+		return false
+	}
+	return true
 }
 
 func (ex *standardExtendedTableMetadata) GetServerVariables() (map[string]*openapi3.ServerVariable, bool) {

--- a/test/mockserver/expectations/staging.json
+++ b/test/mockserver/expectations/staging.json
@@ -1,100 +1,210 @@
-[
-
+[  
   {
     "httpRequest": {
-      "method": "POST",
-      "path": "/",
       "headers": {
-        "Authorization": ["^.*us-west-2.*SignedHeaders=accept;content-type;host;x-amz-date;x-amz-target.*$" ],
-        "X-Amz-Target": [ "CloudApiService.ListResources" ]
+        "accept": [ "application/json" ]
       },
-      "body": {
-        "type": "JSON",
-        "json": {
-          "TypeName":"AWS::KMS::Key"
-        },
-        "matchType": "ONLY_MATCHING_FIELDS"
-      }
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/global/keyRings/testing-three/cryptoKeys"
     },
     "httpResponse": {
-      "headers": {
-        "content-type": [ "application/x-amz-json-1.0" ]
-      },
       "statusCode": 200,
       "body": {
-        "ResourceDescriptions":[
+        "cryptoKeys": [
           {
-            "Identifier":"00001-0001-0001-0001-00000000000009",
-            "Properties":"{\"KeyId\":\"00001-0001-0001-0001-00000000000009\"}"
+            "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key",
+            "primary": {
+              "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
           },
           {
-            "Identifier":"00001-0001-0001-0001-00000000000010",
-            "Properties":"{\"KeyId\":\"00001-0001-0001-0001-00000000000010\"}"
+            "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
           }
         ],
-        "TypeName":"AWS::KMS::Key"
+        "totalSize": 3
       }
     }
   },
   {
     "httpRequest": {
-      "method": "POST",
-      "path": "/",
       "headers": {
-        "Authorization": ["^.*us-west-2.*SignedHeaders=.*content-type;host;x-amz-date;x-amz-target.*$" ],
-        "X-Amz-Target": [ "CloudApiService.GetResource" ]
+        "accept": [ "application/json" ]
       },
-      "body": {
-        "type": "JSON",
-        "json": {
-          "TypeName":"AWS::KMS::Key",
-          "Identifier": "00001-0001-0001-0001-00000000000009"
-        },
-        "matchType": "ONLY_MATCHING_FIELDS"
-      }
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/australia-southeast2/keyRings/big-m-testing-three/cryptoKeys"
     },
     "httpResponse": {
-      "headers": {
-        "content-type": [ "application/x-amz-json-1.0" ]
-      },
       "statusCode": 200,
       "body": {
-        "ResourceDescription": {
-          "Identifier":"00001-0001-0001-0001-00000000000009",
-          "Properties":"{\"Origin\":\"AWS_KMS\",\"MultiRegion\":false,\"Description\":\"Default key that protects my Lightsail signing keys when no other key is defined\",\"KeyPolicy\":{\"Version\":\"2012-10-17\",\"Statement\":[{\"Condition\":{\"StringEquals\":{\"kms:CallerAccount\":\"0000000001\",\"kms:ViaService\":\"lightsail.us-west-2.amazonaws.com\"}},\"Action\":[\"kms:Encrypt\",\"kms:Decrypt\",\"kms:ReEncrypt*\",\"kms:GenerateDataKey*\",\"kms:DescribeKey\"],\"Resource\":\"*\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Sid\":\"Allow access through Lightsail for all principals in the account that are authorized to use Lightsail\"},{\"Action\":[\"kms:Describe*\",\"kms:Get*\",\"kms:List*\"],\"Resource\":\"*\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::0000000001:root\"},\"Sid\":\"Allow direct access to key metadata to the account\"},{\"Action\":[\"kms:Describe*\",\"kms:Get*\",\"kms:List*\"],\"Resource\":\"*\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lightsail.amazonaws.com\"},\"Sid\":\"Allow Lightsail with service principal name lightsail.amazonaws.com to describe the key directly\"}],\"Id\":\"auto-lightsail-3\"},\"KeySpec\":\"SYMMETRIC_DEFAULT\",\"Enabled\":true,\"EnableKeyRotation\":true,\"KeyUsage\":\"ENCRYPT_DECRYPT\",\"KeyId\":\"00001-0001-0001-0001-00000000000009\",\"Arn\":\"arn:aws:kms:us-west-2:000000001:key/00001-0001-0001-0001-00000000000009\",\"Tags\":[]}"
-        },
-        "TypeName":"AWS::KMS::Key"
+        "cryptoKeys": [
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key",
+            "primary": {
+              "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          }
+        ],
+        "totalSize": 3
       }
     }
   },
   {
     "httpRequest": {
-      "method": "POST",
-      "path": "/",
       "headers": {
-        "Authorization": ["^.*us-west-2.*SignedHeaders=.*content-type;host;x-amz-date;x-amz-target.*$" ],
-        "X-Amz-Target": [ "CloudApiService.GetResource" ]
+        "accept": [ "application/json" ]
       },
-      "body": {
-        "type": "JSON",
-        "json": {
-          "TypeName":"AWS::KMS::Key",
-          "Identifier": "00001-0001-0001-0001-00000000000010"
-        },
-        "matchType": "ONLY_MATCHING_FIELDS"
-      }
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/australia-southeast1/keyRings"
     },
     "httpResponse": {
+      "statusCode": 200,
+      "body": {}
+    }
+  },
+  {
+    "httpRequest": {
       "headers": {
-        "content-type": [ "application/x-amz-json-1.0" ]
+        "accept": [ "application/json" ]
       },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/global/keyRings"
+    },
+    "httpResponse": {
       "statusCode": 200,
       "body": {
-        "ResourceDescription": {
-          "Identifier":"00001-0001-0001-0001-00000000000010",
-          "Properties":"{\"Origin\":\"AWS_KMS\",\"MultiRegion\":false,\"Description\":\"Default key that protects my Lightsail signing keys when no other key is defined\",\"KeyPolicy\":{\"Version\":\"2012-10-17\",\"Statement\":[{\"Condition\":{\"StringEquals\":{\"kms:CallerAccount\":\"0000000001\",\"kms:ViaService\":\"lightsail.us-west-2.amazonaws.com\"}},\"Action\":[\"kms:Encrypt\",\"kms:Decrypt\",\"kms:ReEncrypt*\",\"kms:GenerateDataKey*\",\"kms:DescribeKey\"],\"Resource\":\"*\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Sid\":\"Allow access through Lightsail for all principals in the account that are authorized to use Lightsail\"},{\"Action\":[\"kms:Describe*\",\"kms:Get*\",\"kms:List*\"],\"Resource\":\"*\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::0000000001:root\"},\"Sid\":\"Allow direct access to key metadata to the account\"},{\"Action\":[\"kms:Describe*\",\"kms:Get*\",\"kms:List*\"],\"Resource\":\"*\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lightsail.amazonaws.com\"},\"Sid\":\"Allow Lightsail with service principal name lightsail.amazonaws.com to describe the key directly\"}],\"Id\":\"auto-lightsail-4\"},\"KeySpec\":\"SYMMETRIC_DEFAULT\",\"Enabled\":true,\"EnableKeyRotation\":true,\"KeyUsage\":\"ENCRYPT_DECRYPT\",\"KeyId\":\"00001-0001-0001-0001-00000000000010\",\"Arn\":\"arn:aws:kms:us-west-2:000000001:key/00001-0001-0001-0001-00000000000010\",\"Tags\":[]}"
-        },
-        "TypeName":"AWS::KMS::Key"
+        "keyRings": [
+          {
+            "name": "projects/testing-project-three/locations/global/keyRings/testing-three",
+            "createTime": "2022-02-02T02:02:02.02000000Z"
+          }
+        ],
+        "totalSize": 1
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/australia-southeast2/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "keyRings": [
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/big-m-testing-three",
+            "createTime": "2022-02-02T02:02:02.02000000Z"
+          }
+        ],
+        "totalSize": 1
       }
     }
   }

--- a/test/mockserver/expectations/static-gcp-expectations.json
+++ b/test/mockserver/expectations/static-gcp-expectations.json
@@ -5,6 +5,424 @@
         "accept": [ "application/json" ]
       },
       "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/global/keyRings/testing-three/cryptoKeys"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "cryptoKeys": [
+          {
+            "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key",
+            "primary": {
+              "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/global/keyRings/testing/cryptoKeys/testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          }
+        ],
+        "totalSize": 3
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/australia-southeast2/keyRings/big-m-testing-three/cryptoKeys"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "cryptoKeys": [
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key",
+            "primary": {
+              "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-three-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          }
+        ],
+        "totalSize": 3
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/australia-southeast1/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {}
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/global/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "keyRings": [
+          {
+            "name": "projects/testing-project-three/locations/global/keyRings/testing-three",
+            "createTime": "2022-02-02T02:02:02.02000000Z"
+          }
+        ],
+        "totalSize": 1
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-three/locations/australia-southeast2/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "keyRings": [
+          {
+            "name": "projects/testing-project-three/locations/australia-southeast2/keyRings/big-m-testing-three",
+            "createTime": "2022-02-02T02:02:02.02000000Z"
+          }
+        ],
+        "totalSize": 1
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-two/locations/global/keyRings/testing-two/cryptoKeys"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "cryptoKeys": [
+          {
+            "name": "projects/testing-project-two/locations/global/keyRings/testing/cryptoKeys/testing-two-demo-key",
+            "primary": {
+              "name": "projects/testing-project-two/locations/global/keyRings/testing/cryptoKeys/testing-two-demo-key/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-two/locations/global/keyRings/testing/cryptoKeys/testing-two-demo-key-two",
+            "primary": {
+              "name": "projects/testing-project-two/locations/global/keyRings/testing/cryptoKeys/testing-two-demo-key-two/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-two/locations/global/keyRings/testing/cryptoKeys/testing-two-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-two/locations/global/keyRings/testing/cryptoKeys/testing-two-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          }
+        ],
+        "totalSize": 3
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-two/locations/australia-southeast2/keyRings/big-m-testing-two/cryptoKeys"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "cryptoKeys": [
+          {
+            "name": "projects/testing-project-two/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-two-demo-key",
+            "primary": {
+              "name": "projects/testing-project-two/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-two-demo-key/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-two/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-two-demo-key-two",
+            "primary": {
+              "name": "projects/testing-project-two/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-two-demo-key-two/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          },
+          {
+            "name": "projects/testing-project-two/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-two-demo-key-three",
+            "primary": {
+              "name": "projects/testing-project-two/locations/australia-southeast2/keyRings/testing/cryptoKeys/big-m-testing-two-demo-key-three/cryptoKeyVersions/6",
+              "state": "ENABLED",
+              "createTime": "2024-05-22T14:00:00.000000000Z",
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+              "generateTime": "2024-05-22T14:00:00.000000000Z"
+            },
+            "purpose": "ENCRYPT_DECRYPT",
+            "createTime": "2023-02-04T03:03:03.000000000Z",
+            "nextRotationTime": "2025-03-03T14:00:00.000000000Z",
+            "rotationPeriod": "7776000s",
+            "versionTemplate": {
+              "protectionLevel": "SOFTWARE",
+              "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+            },
+            "destroyScheduledDuration": "86400s"
+          }
+        ],
+        "totalSize": 3
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-two/locations/australia-southeast1/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {}
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-two/locations/global/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "keyRings": [
+          {
+            "name": "projects/testing-project-two/locations/global/keyRings/testing-two",
+            "createTime": "2022-02-02T02:02:02.02000000Z"
+          }
+        ],
+        "totalSize": 1
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/v1/projects/testing-project-two/locations/australia-southeast2/keyRings"
+    },
+    "httpResponse": {
+      "statusCode": 200,
+      "body": {
+        "keyRings": [
+          {
+            "name": "projects/testing-project-two/locations/australia-southeast2/keyRings/big-m-testing-two",
+            "createTime": "2022-02-02T02:02:02.02000000Z"
+          }
+        ],
+        "totalSize": 1
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
       "path": "/v1/projects/testing-project/locations/global/keyRings/testing/cryptoKeys"
     },
     "httpResponse": {

--- a/test/registry/src/googleapis.com/v0.1.2/services/cloudkms-v1.yaml
+++ b/test/registry/src/googleapis.com/v0.1.2/services/cloudkms-v1.yaml
@@ -3344,8 +3344,8 @@ components:
             openAPIDocKey: '200'
       sqlVerbs:
         select:
-          - $ref: '#/components/x-stackQL-resources/key_rings/methods/list'
           - $ref: '#/components/x-stackQL-resources/key_rings/methods/get'
+          - $ref: '#/components/x-stackQL-resources/key_rings/methods/list'
         insert:
           - $ref: '#/components/x-stackQL-resources/key_rings/methods/create'
         update: []

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -245,8 +245,8 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       supplied_args.append('--output=text')
       supplied_args.append('-H')
     if cfg.pop('stackql_dataflow_permissive', False):
-      supplied_args.append('--dataflow.dependency.max=10')
-      supplied_args.append('--dataflow.components.max=10')
+      supplied_args.append('--dataflow.dependency.max=50')
+      supplied_args.append('--dataflow.components.max=50')
     if cfg.pop('stackql_debug_http', False):
       supplied_args.append("--http.log.enabled=true")
     if cfg.pop('stackql_dryrun', False):
@@ -343,8 +343,8 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       supplied_args.append('--output=text')
       supplied_args.append('-H')
     if cfg.pop('stackql_dataflow_permissive', False):
-      supplied_args.append('--dataflow.dependency.max=10')
-      supplied_args.append('--dataflow.components.max=10')
+      supplied_args.append('--dataflow.dependency.max=50')
+      supplied_args.append('--dataflow.components.max=50')
     if cfg.pop('stackql_debug_http', False):
       supplied_args.append("--http.log.enabled=true")
     registry_cfg_str = registry_cfg.get_config_str('docker')
@@ -430,8 +430,8 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       supplied_args.append('--output=text')
       supplied_args.append('-H')
     if cfg.pop('stackql_dataflow_permissive', False):
-      supplied_args.append('--dataflow.dependency.max=10')
-      supplied_args.append('--dataflow.components.max=10')
+      supplied_args.append('--dataflow.dependency.max=50')
+      supplied_args.append('--dataflow.components.max=50')
     if cfg.pop('stackql_debug_http', False):
       supplied_args.append("--http.log.enabled=true")
     if cfg.pop('stackql_dryrun', False):
@@ -495,8 +495,8 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       supplied_args.append('--output=text')
       supplied_args.append('-H')
     if cfg.pop('stackql_dataflow_permissive', False):
-      supplied_args.append('--dataflow.dependency.max=10')
-      supplied_args.append('--dataflow.components.max=10')
+      supplied_args.append('--dataflow.dependency.max=50')
+      supplied_args.append('--dataflow.components.max=50')
     if cfg.pop('stackql_debug_http', False):
       supplied_args.append("--http.log.enabled=true")
     registry_cfg_str = registry_cfg.get_config_str('native')


### PR DESCRIPTION

## Description

- Support for >1 dataflow dimensions through `IN` clauses.
- Prime motivation is per-project, per-locality queries in `google`.
- Added robot test `Poly Dependency In Clause Split of List And Sublist Dimensions Dataflow View Works As Exemplified By AWS KMS Key Cloud Control`.
- Added robot test `Materialized View Beware Keywords of Poly Dependency In Clause Split of List And Sublist Dimensions Dataflow View Works As Exemplified By AWS KMS Key Cloud Control`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Poly Dependency In Clause Split of List And Sublist Dimensions Dataflow View Works As Exemplified By AWS KMS Key Cloud Control`.
- Added robot test `Materialized View Beware Keywords of Poly Dependency In Clause Split of List And Sublist Dimensions Dataflow View Works As Exemplified By AWS KMS Key Cloud Control`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
