### PR TITLE
multiple-dataflows-departing-and-arriving

### DIFF
--- a/internal/stackql/dataflow/component.go
+++ b/internal/stackql/dataflow/component.go
@@ -65,6 +65,15 @@ func (wc *standardDataFlowWeaklyConnectedComponent) GetEdges() ([]Edge, error) {
 	return rv, nil
 }
 
+func (wc *standardDataFlowWeaklyConnectedComponent) isAlreadyInOrderedNodes(rhs graph.Node) bool {
+	for _, n := range wc.orderedNodes {
+		if n.ID() == rhs.ID() {
+			return true
+		}
+	}
+	return false
+}
+
 func (wc *standardDataFlowWeaklyConnectedComponent) Analyze() error {
 	// This algorithm underlying this analyisis
 	// is defective; or would be were it not halted early.
@@ -83,12 +92,17 @@ func (wc *standardDataFlowWeaklyConnectedComponent) Analyze() error {
 		for {
 			itemPresent := incidentNodes.Next()
 			if !itemPresent {
+				// wc.orderedNodes = append(wc.orderedNodes, node)
+				// wc.idsVisited[node.ID()] = struct{}{}
 				break
 			}
 			fromNode := incidentNodes.Node()
 			_, ok := wc.idsVisited[fromNode.ID()]
 			if ok {
-				wc.orderedNodes = append(wc.orderedNodes, node)
+				isAlreadyInOrderedNodes := wc.isAlreadyInOrderedNodes(node)
+				if !isAlreadyInOrderedNodes {
+					wc.orderedNodes = append(wc.orderedNodes, node)
+				}
 				wc.idsVisited[node.ID()] = struct{}{}
 				incidentEdge := wc.collection.g.WeightedEdge(fromNode.ID(), node.ID())
 				if incidentEdge == nil {
@@ -111,6 +125,10 @@ func (wc *standardDataFlowWeaklyConnectedComponent) AddEdge(e Edge) {
 }
 
 func (wc *standardDataFlowWeaklyConnectedComponent) PushBack(v Vertex) {
+	isAlreadyInOrderedNodes := wc.isAlreadyInOrderedNodes(v)
+	if isAlreadyInOrderedNodes {
+		return
+	}
 	wc.orderedNodes = append(wc.orderedNodes, v)
 }
 

--- a/internal/stackql/dependencyplanner/stream_collection.go
+++ b/internal/stackql/dependencyplanner/stream_collection.go
@@ -1,0 +1,54 @@
+package dependencyplanner
+
+import (
+	"github.com/stackql/stackql/internal/stackql/streaming"
+)
+
+type StreamDependecyCollection interface {
+	// Add adds a stream to the collection
+	// departingID is the ID of the stream that is departing
+	// arrivingID is the ID of the stream that is arriving
+	// stream is the stream that is being added
+	Add(departingID int64, arrivingID int64, stream streaming.MapStream)
+	GetArriving(int64) streaming.MapStreamCollection
+	GetDeparting(int64) streaming.MapStreamCollection
+}
+
+type streamDependencyCollection struct {
+	departingStreams map[int64][]streaming.MapStream
+	arrivingStreams  map[int64][]streaming.MapStream
+}
+
+func NewStreamDependecyCollection() StreamDependecyCollection {
+	return &streamDependencyCollection{
+		departingStreams: make(map[int64][]streaming.MapStream),
+		arrivingStreams:  make(map[int64][]streaming.MapStream),
+	}
+}
+
+func (sdc *streamDependencyCollection) Add(departingID int64, arrivingID int64, stream streaming.MapStream) {
+	sdc.departingStreams[departingID] = append(sdc.departingStreams[departingID], stream)
+	sdc.arrivingStreams[arrivingID] = append(sdc.arrivingStreams[arrivingID], stream)
+}
+
+func (sdc *streamDependencyCollection) GetArriving(id int64) streaming.MapStreamCollection {
+	rv := streaming.NewStandardMapStreamCollection()
+	for _, stream := range sdc.arrivingStreams[id] {
+		rv.Push(stream)
+	}
+	if rv.Len() == 0 {
+		rv.Push(streaming.NewStandardMapStream())
+	}
+	return rv
+}
+
+func (sdc *streamDependencyCollection) GetDeparting(id int64) streaming.MapStreamCollection {
+	rv := streaming.NewStandardMapStreamCollection()
+	for _, stream := range sdc.departingStreams[id] {
+		rv.Push(stream)
+	}
+	if rv.Len() == 0 {
+		rv.Push(streaming.NewNopMapStream())
+	}
+	return rv
+}

--- a/internal/stackql/drm/drm_cfg.go
+++ b/internal/stackql/drm/drm_cfg.go
@@ -779,7 +779,7 @@ func (dc *staticDRMConfig) QueryDML(
 	}
 	query := prepStmt.GetRawQuery()
 	varArgs := prepStmt.GetArgs()
-	logging.GetLogger().Infoln(fmt.Sprintf("query = %s", query))
+	logging.GetLogger().Infoln(fmt.Sprintf("query = %s, varArgs = %v", query, varArgs))
 	return querier.Query(query, varArgs...)
 }
 

--- a/internal/stackql/httpmiddleware/httpmiddleware.go
+++ b/internal/stackql/httpmiddleware/httpmiddleware.go
@@ -112,6 +112,8 @@ func HTTPApiCallFromRequest(
 	}
 	walObj, _ := handlerCtx.GetTSM()
 	logging.GetLogger().Debugf("Proof of invariant: walObj = %v", walObj)
+	urlString := translatedRequest.URL.String()
+	logging.GetLogger().Debugf("HTTP request: URL = '''%s'''", urlString)
 	r, err := httpClient.Do(translatedRequest)
 	responseErrorBodyToPublish, reponseParseErr := parseReponseBodyIfErroneous(r)
 	if reponseParseErr != nil {

--- a/internal/stackql/primitivebuilder/single_select_acquire.go
+++ b/internal/stackql/primitivebuilder/single_select_acquire.go
@@ -109,7 +109,7 @@ func (ss *SingleSelectAcquire) GetTail() primitivegraph.PrimitiveNode {
 	return ss.root
 }
 
-//nolint:funlen,gocognit,gocyclo,cyclop,nestif // TODO: investigate
+//nolint:funlen,gocognit,gocyclo,cyclop,nestif,revive // TODO: investigate
 func (ss *SingleSelectAcquire) Build() error {
 	prov, err := ss.tableMeta.GetProvider()
 	if err != nil {
@@ -123,7 +123,6 @@ func (ss *SingleSelectAcquire) Build() error {
 	if err != nil {
 		return err
 	}
-	//nolint:revive // acceptable for now
 	ex := func(pc primitive.IPrimitiveCtx) internaldto.ExecutorOutput {
 		logging.GetLogger().Infof("SingleSelectAcquire.Execute() beginning execution for table %s", tableName)
 		currentTcc := ss.insertPreparedStatementCtx.GetGCCtrlCtrs().Clone()
@@ -132,6 +131,15 @@ func (ss *SingleSelectAcquire) Build() error {
 		// TODO: instrument for split source vertices !!!important!!!
 		httpArmoury, armouryErr := ss.tableMeta.GetHTTPArmoury()
 		if armouryErr != nil {
+			//nolint:errcheck // TODO: fix
+			ss.handlerCtx.GetOutErrFile().Write([]byte(
+				fmt.Sprintf(
+					"error assembling http aspects for resource '%s': %s\n",
+					m.GetResource().GetID(),
+					armouryErr.Error(),
+				),
+			),
+			)
 			return internaldto.NewErroneousExecutorOutput(armouryErr)
 		}
 		if mr != nil {
@@ -152,7 +160,12 @@ func (ss *SingleSelectAcquire) Build() error {
 		}
 		reqParams := httpArmoury.GetRequestParams()
 		logging.GetLogger().Infof("SingleSelectAcquire.Execute() req param count = %d", len(reqParams))
-		for _, rc := range reqParams {
+		for i, rc := range reqParams {
+			var urlStringForLogging string
+			if rc.GetRequest() != nil && rc.GetRequest().URL != nil {
+				urlStringForLogging = rc.GetRequest().URL.String()
+			}
+			logging.GetLogger().Infof("SingleSelectAcquire.Execute() executing request %d: %s", i, urlStringForLogging)
 			reqCtx := rc
 			paramsUsed, paramErr := reqCtx.ToFlatMap()
 			if paramErr != nil {
@@ -195,6 +208,10 @@ func (ss *SingleSelectAcquire) Build() error {
 					reqCtx.GetRequest().Context(),
 				),
 			)
+			// TODO: refactor into package !!TECH_DEBT!!
+			if response != nil && response.StatusCode >= 400 {
+				continue
+			}
 			housekeepingDone := false
 			npt := prov.InferNextPageResponseElement(ss.tableMeta.GetHeirarchyObjects())
 			nptRequest := prov.InferNextPageRequestElement(ss.tableMeta.GetHeirarchyObjects())

--- a/internal/stackql/sqlengine/sqlite_embedded.go
+++ b/internal/stackql/sqlengine/sqlite_embedded.go
@@ -276,7 +276,7 @@ func (se sqLiteEmbeddedEngine) Query(query string, varArgs ...interface{}) (*sql
 }
 
 func (se sqLiteEmbeddedEngine) query(query string, varArgs ...interface{}) (*sql.Rows, error) {
-	// logging.GetLogger().Infoln(fmt.Sprintf("query = %s", query))
+	logging.GetLogger().Debugln(fmt.Sprintf("sqlite embedded raw query = %s, varArgs = %v", query, varArgs))
 	res, err := se.db.Query(query, varArgs...)
 	// logging.GetLogger().Infoln(fmt.Sprintf("res= %v, err = %v", res, err))
 	return res, err

--- a/internal/stackql/sqlstream/sql_map_stream.go
+++ b/internal/stackql/sqlstream/sql_map_stream.go
@@ -64,8 +64,8 @@ func (ss *SimpleSQLMapStream) Read() ([]map[string]interface{}, error) {
 		keyArr = append(keyArr, x.GetIdentifier())
 		i++
 	}
+	i = 0
 	if r != nil {
-		i := 0 //nolint:govet // ok with this
 		for r.Next() {
 			errScan := r.Scan(ifArr...)
 			if errScan != nil {
@@ -81,8 +81,13 @@ func (ss *SimpleSQLMapStream) Read() ([]map[string]interface{}, error) {
 				im[key] = ev
 			}
 			rv = append(rv, im)
+			logging.GetLogger().Infof(
+				"sql map stream query returning row '''%v''' for query: '''%s'''", im, ss.selectCtx.GetQuery())
 			i++
 		}
+	}
+	if i == 0 {
+		logging.GetLogger().Infof("sql map stream query returned no rows for query: '''%s'''", ss.selectCtx.GetQuery())
 	}
 	return rv, io.EOF
 }

--- a/internal/stackql/streaming/map_stream_collection.go
+++ b/internal/stackql/streaming/map_stream_collection.go
@@ -1,0 +1,89 @@
+package streaming
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/stackql/stackql/pkg/maths"
+)
+
+type MapStreamCollection interface {
+	MapStream
+	Push(MapStream)
+	Len() int
+}
+
+func NewStandardMapStreamCollection() MapStreamCollection {
+	return &standardMapStreamCollection{}
+}
+
+type standardMapStreamCollection struct {
+	store   []map[string]interface{}
+	streams []MapStream
+}
+
+func (sc *standardMapStreamCollection) Push(stream MapStream) {
+	sc.streams = append(sc.streams, stream)
+}
+
+func (sc *standardMapStreamCollection) Write(input []map[string]interface{}) error {
+	// sc.store = append(sc.store, input...)
+	var errSlice []error
+	for _, stream := range sc.streams {
+		if err := stream.Write(input); err != nil {
+			errSlice = append(errSlice, err)
+		}
+	}
+	if len(errSlice) > 0 {
+		var sb strings.Builder
+		for _, err := range errSlice {
+			sb.WriteString(err.Error())
+			sb.WriteString(";")
+		}
+		return fmt.Errorf(sb.String())
+	}
+	return nil
+}
+
+func (sc *standardMapStreamCollection) Len() int {
+	streamLen := len(sc.streams)
+	storeLen := len(sc.store)
+	if streamLen > storeLen {
+		return streamLen
+	}
+	return storeLen
+}
+
+func (sc *standardMapStreamCollection) Read() ([]map[string]interface{}, error) {
+	var allOutputs [][]map[string]interface{}
+	maxLength := 0
+	// var allLengths []int
+	storeLen := len(sc.store)
+	if storeLen > 0 {
+		// allLengths = append(allLengths, len(sc.store))
+		maxLength = len(sc.store)
+	}
+	for _, stream := range sc.streams {
+		output, err := stream.Read()
+		if !errors.Is(err, io.EOF) {
+			return output, err
+		}
+		thisLen := len(output)
+		if thisLen == 0 {
+			continue
+		}
+		allOutputs = append(allOutputs, output)
+		// allLengths = append(allLengths, thisLen)
+		if thisLen > maxLength {
+			maxLength = thisLen
+		}
+	}
+	if maxLength == 0 {
+		return nil, io.EOF
+	}
+	// lcm := maths.LcmMultiple(allLengths...)
+	rv := maths.CartesianProduct(allOutputs...)
+	return rv, io.EOF
+}

--- a/pkg/maths/common_maths.go
+++ b/pkg/maths/common_maths.go
@@ -1,0 +1,55 @@
+package maths
+
+// Pretty much transcribed from https://stackoverflow.com/a/147539
+// LcmMultiple returns the greatest common multiple of a and b...
+
+func Gcd(a, b int) int {
+	// Return greatest common divisor using Euclid's Algorithm.
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func Lcm(a, b int) int {
+	// Return lowest common multiple.
+	return a * b / Gcd(a, b)
+}
+
+func LcmMultiple(args ...int) int {
+	// """Return lcm of args."""
+	if len(args) == 0 {
+		return 1
+	}
+	rv := args[0]
+	for i := 1; i < len(args); i++ {
+		rv = Lcm(rv, args[i])
+	}
+	return rv
+}
+
+func CartesianProduct(args ...[]map[string]interface{}) []map[string]interface{} {
+	// """Return the Cartesian product of args."""
+	if len(args) == 0 {
+		return []map[string]interface{}{}
+	}
+	rv := []map[string]interface{}{}
+	rv = append(rv, args[0]...)
+	for i := 1; i < len(args); i++ {
+		newRV := []map[string]interface{}{}
+		for _, row := range args[i] {
+			for _, existingRow := range rv {
+				newRow := map[string]interface{}{}
+				for k, v := range existingRow {
+					newRow[k] = v
+				}
+				for k, v := range row {
+					newRow[k] = v
+				}
+				newRV = append(newRV, newRow)
+			}
+		}
+		rv = newRV
+	}
+	return rv
+}

--- a/test/mockserver/expectations/static-azure-expectations.json
+++ b/test/mockserver/expectations/static-azure-expectations.json
@@ -5,6 +5,982 @@
         "accept": [ "application/json" ]
       },
       "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/vaults/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"] 
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault",
+            "name": "stackql-testing-keyvault",
+            "type": "Microsoft.KeyVault/vaults",
+            "location": "eastus",
+            "tags": {},
+            "systemData": {
+              "createdBy": "joe.blow@stackql.com",
+              "createdByType": "User",
+              "createdAt": "2022-12-31T05:14:56.289Z",
+              "lastModifiedBy": "joe.blow@stackql.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-11T12:06:31.662Z"
+            },
+            "properties": {
+              "sku": {
+                "family": "A",
+                "name": "standard"
+              },
+              "tenantId": "000000-0000-0000-0000-000000000001",
+              "accessPolicies": [
+                {
+                  "tenantId": "000000-0000-0000-0000-000000000001",
+                  "objectId": "000000-0000-0000-0000-000000000002",
+                  "permissions": {
+                    "keys": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "Decrypt",
+                      "Encrypt",
+                      "UnwrapKey",
+                      "WrapKey",
+                      "Verify",
+                      "Sign",
+                      "Release",
+                      "Rotate",
+                      "GetRotationPolicy",
+                      "SetRotationPolicy"
+                    ],
+                    "secrets": [
+                      "Get",
+                      "List",
+                      "Set",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore"
+                    ],
+                    "certificates": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "ManageContacts",
+                      "ManageIssuers",
+                      "GetIssuers",
+                      "ListIssuers",
+                      "SetIssuers",
+                      "DeleteIssuers"
+                    ],
+                    "storage": [
+                      "all"
+                    ]
+                  }
+                },
+                {
+                  "tenantId": "000000-0000-0000-0000-000000000001",
+                  "objectId": "000000-0000-0000-0000-000000000003",
+                  "permissions": {
+                    "certificates": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "ManageContacts",
+                      "ManageIssuers",
+                      "GetIssuers",
+                      "ListIssuers",
+                      "SetIssuers",
+                      "DeleteIssuers",
+                      "Purge"
+                    ],
+                    "keys": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "GetRotationPolicy",
+                      "SetRotationPolicy",
+                      "Rotate",
+                      "Encrypt",
+                      "Decrypt",
+                      "UnwrapKey",
+                      "WrapKey",
+                      "Verify",
+                      "Sign",
+                      "Purge",
+                      "Release"
+                    ],
+                    "secrets": [
+                      "Get",
+                      "List",
+                      "Set",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "Purge"
+                    ]
+                  }
+                }
+              ],
+              "enabledForDeployment": false,
+              "enabledForDiskEncryption": false,
+              "enabledForTemplateDeployment": false,
+              "enableSoftDelete": true,
+              "softDeleteRetentionInDays": 90,
+              "vaultUri": "https://stackql-testing-keyvault.vault.azure.net/",
+              "provisioningState": "Succeeded",
+              "publicNetworkAccess": "Enabled"
+            }
+          },
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault",
+            "name": "stackql-alt-keyvault",
+            "type": "Microsoft.KeyVault/vaults",
+            "location": "eastus",
+            "tags": {},
+            "systemData": {
+              "createdBy": "joe.blow@stackql.com",
+              "createdByType": "User",
+              "createdAt": "2022-12-31T05:14:56.289Z",
+              "lastModifiedBy": "joe.blow@stackql.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-11T12:06:31.662Z"
+            },
+            "properties": {
+              "sku": {
+                "family": "A",
+                "name": "standard"
+              },
+              "tenantId": "000000-0000-0000-0000-000000000001",
+              "accessPolicies": [
+                {
+                  "tenantId": "000000-0000-0000-0000-000000000001",
+                  "objectId": "000000-0000-0000-0000-000000000002",
+                  "permissions": {
+                    "keys": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "Decrypt",
+                      "Encrypt",
+                      "UnwrapKey",
+                      "WrapKey",
+                      "Verify",
+                      "Sign",
+                      "Release",
+                      "Rotate",
+                      "GetRotationPolicy",
+                      "SetRotationPolicy"
+                    ],
+                    "secrets": [
+                      "Get",
+                      "List",
+                      "Set",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore"
+                    ],
+                    "certificates": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "ManageContacts",
+                      "ManageIssuers",
+                      "GetIssuers",
+                      "ListIssuers",
+                      "SetIssuers",
+                      "DeleteIssuers"
+                    ],
+                    "storage": [
+                      "all"
+                    ]
+                  }
+                },
+                {
+                  "tenantId": "000000-0000-0000-0000-000000000001",
+                  "objectId": "000000-0000-0000-0000-000000000003",
+                  "permissions": {
+                    "certificates": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "ManageContacts",
+                      "ManageIssuers",
+                      "GetIssuers",
+                      "ListIssuers",
+                      "SetIssuers",
+                      "DeleteIssuers",
+                      "Purge"
+                    ],
+                    "keys": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "GetRotationPolicy",
+                      "SetRotationPolicy",
+                      "Rotate",
+                      "Encrypt",
+                      "Decrypt",
+                      "UnwrapKey",
+                      "WrapKey",
+                      "Verify",
+                      "Sign",
+                      "Purge",
+                      "Release"
+                    ],
+                    "secrets": [
+                      "Get",
+                      "List",
+                      "Set",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "Purge"
+                    ]
+                  }
+                }
+              ],
+              "enabledForDeployment": false,
+              "enabledForDiskEncryption": false,
+              "enabledForTemplateDeployment": false,
+              "enableSoftDelete": true,
+              "softDeleteRetentionInDays": 90,
+              "vaultUri": "https://stackql-testing-keyvault.vault.azure.net/",
+              "provisioningState": "Succeeded",
+              "publicNetworkAccess": "Enabled"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/000000-0000-0000-0000-000000000022/providers/Microsoft.KeyVault/vaults/?api-version=2023-07-01&$skiptoken=0011"
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-01",
+            "name": "dummy-key-01",
+            "type": "Microsoft.KeyVault/vaults/keys",
+            "location": "eastus",
+            "tags": {},
+            "properties": {
+              "attributes": {
+                "enabled": true,
+                "created": 1720150115,
+                "updated": 1720150115,
+                "recoveryLevel": "Recoverable+Purgeable",
+                "exportable": false
+              },
+              "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01"
+            }
+          },
+
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-02",
+            "name": "dummy-key-02",
+            "type": "Microsoft.KeyVault/vaults/keys",
+            "location": "eastus",
+            "tags": {},
+            "properties": {
+              "attributes": {
+                "enabled": true,
+                "created": 1720150115,
+                "updated": 1720150115,
+                "recoveryLevel": "Recoverable+Purgeable",
+                "exportable": false
+              },
+              "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault/keys/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault/keys/alt-dummy-key-01",
+            "name": "alt-dummy-key-01",
+            "type": "Microsoft.KeyVault/vaults/keys",
+            "location": "eastus",
+            "tags": {},
+            "properties": {
+              "attributes": {
+                "enabled": true,
+                "created": 1720150115,
+                "updated": 1720150115,
+                "recoveryLevel": "Recoverable+Purgeable",
+                "exportable": false
+              },
+              "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01"
+            }
+          },
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault/keys/alt-dummy-key-02",
+            "name": "alt-dummy-key-02",
+            "type": "Microsoft.KeyVault/vaults/keys",
+            "location": "eastus",
+            "tags": {},
+            "properties": {
+              "attributes": {
+                "enabled": true,
+                "created": 1720150115,
+                "updated": 1720150115,
+                "recoveryLevel": "Recoverable+Purgeable",
+                "exportable": false
+              },
+              "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-01/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-01",
+        "name": "dummy-key-01",
+        "type": "Microsoft.KeyVault/vaults/keys",
+        "location": "eastus",
+        "tags": {},
+        "properties": {
+          "attributes": {
+            "enabled": true,
+            "created": 1720150115,
+            "updated": 1720150115,
+            "recoveryLevel": "Recoverable+Purgeable",
+            "exportable": false
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ]
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01",
+          "keyUriWithVersion": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01/aaaaaaaaa00000001"
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-02/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-02",
+        "name": "dummy-key-02",
+        "type": "Microsoft.KeyVault/vaults/keys",
+        "location": "eastus",
+        "tags": {},
+        "properties": {
+          "attributes": {
+            "enabled": true,
+            "created": 1720150115,
+            "updated": 1720150115,
+            "recoveryLevel": "Recoverable+Purgeable",
+            "exportable": false
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ]
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-02",
+          "keyUriWithVersion": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-02/aaaaaaaaa00000001"
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/alt-dummy-key-02/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-02",
+        "name": "dummy-key-02",
+        "type": "Microsoft.KeyVault/vaults/keys",
+        "location": "eastus",
+        "tags": {},
+        "properties": {
+          "attributes": {
+            "enabled": true,
+            "created": 1720150115,
+            "updated": 1720150115,
+            "recoveryLevel": "Recoverable+Purgeable",
+            "exportable": false
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ]
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-02",
+          "keyUriWithVersion": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-02/aaaaaaaaa00000001"
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault/keys/alt-dummy-key-01/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault/keys/alt-dummy-key-01",
+        "name": "dummy-key-01",
+        "type": "Microsoft.KeyVault/vaults/keys",
+        "location": "eastus",
+        "tags": {},
+        "properties": {
+          "attributes": {
+            "enabled": true,
+            "created": 1720150115,
+            "updated": 1720150115,
+            "recoveryLevel": "Recoverable+Purgeable",
+            "exportable": false
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ]
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://stackql-alt-keyvault.vault.azure.net/keys/alt-dummy-key-01",
+          "keyUriWithVersion": "https://stackql-alt-keyvault.vault.azure.net/keys/alt-dummy-key-01/aaaaaaaaa00000001"
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault/keys/alt-dummy-key-02/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-alt-keyvault/keys/alt-dummy-key-02",
+        "name": "dummy-key-02",
+        "type": "Microsoft.KeyVault/vaults/keys",
+        "location": "eastus",
+        "tags": {},
+        "properties": {
+          "attributes": {
+            "enabled": true,
+            "created": 1720150115,
+            "updated": 1720150115,
+            "recoveryLevel": "Recoverable+Purgeable",
+            "exportable": false
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ]
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://stackql-alt-keyvault.vault.azure.net/keys/dummy-key-02",
+          "keyUriWithVersion": "https://stackql-alt-keyvault.vault.azure.net/keys/dummy-key-02/aaaaaaaaa00000001"
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/vaults/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000011"] 
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000011/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault",
+            "name": "stackql-testing-keyvault",
+            "type": "Microsoft.KeyVault/vaults",
+            "location": "eastus",
+            "tags": {},
+            "systemData": {
+              "createdBy": "joe.blow@stackql.com",
+              "createdByType": "User",
+              "createdAt": "2022-12-31T05:14:56.289Z",
+              "lastModifiedBy": "joe.blow@stackql.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-11T12:06:31.662Z"
+            },
+            "properties": {
+              "sku": {
+                "family": "A",
+                "name": "standard"
+              },
+              "tenantId": "000000-0000-0000-0000-000000000001",
+              "accessPolicies": [
+                {
+                  "tenantId": "000000-0000-0000-0000-000000000001",
+                  "objectId": "000000-0000-0000-0000-000000000002",
+                  "permissions": {
+                    "keys": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "Decrypt",
+                      "Encrypt",
+                      "UnwrapKey",
+                      "WrapKey",
+                      "Verify",
+                      "Sign",
+                      "Release",
+                      "Rotate",
+                      "GetRotationPolicy",
+                      "SetRotationPolicy"
+                    ],
+                    "secrets": [
+                      "Get",
+                      "List",
+                      "Set",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore"
+                    ],
+                    "certificates": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "ManageContacts",
+                      "ManageIssuers",
+                      "GetIssuers",
+                      "ListIssuers",
+                      "SetIssuers",
+                      "DeleteIssuers"
+                    ],
+                    "storage": [
+                      "all"
+                    ]
+                  }
+                },
+                {
+                  "tenantId": "000000-0000-0000-0000-000000000001",
+                  "objectId": "000000-0000-0000-0000-000000000003",
+                  "permissions": {
+                    "certificates": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "ManageContacts",
+                      "ManageIssuers",
+                      "GetIssuers",
+                      "ListIssuers",
+                      "SetIssuers",
+                      "DeleteIssuers",
+                      "Purge"
+                    ],
+                    "keys": [
+                      "Get",
+                      "List",
+                      "Update",
+                      "Create",
+                      "Import",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "GetRotationPolicy",
+                      "SetRotationPolicy",
+                      "Rotate",
+                      "Encrypt",
+                      "Decrypt",
+                      "UnwrapKey",
+                      "WrapKey",
+                      "Verify",
+                      "Sign",
+                      "Purge",
+                      "Release"
+                    ],
+                    "secrets": [
+                      "Get",
+                      "List",
+                      "Set",
+                      "Delete",
+                      "Recover",
+                      "Backup",
+                      "Restore",
+                      "Purge"
+                    ]
+                  }
+                }
+              ],
+              "enabledForDeployment": false,
+              "enabledForDiskEncryption": false,
+              "enabledForTemplateDeployment": false,
+              "enableSoftDelete": true,
+              "softDeleteRetentionInDays": 90,
+              "vaultUri": "https://stackql-testing-keyvault.vault.azure.net/",
+              "provisioningState": "Succeeded",
+              "publicNetworkAccess": "Enabled"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/000000-0000-0000-0000-000000000011/providers/Microsoft.KeyVault/vaults/?api-version=2023-07-01&$skiptoken=0011"
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000011"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000011/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-01",
+            "name": "dummy-key-01",
+            "type": "Microsoft.KeyVault/vaults/keys",
+            "location": "eastus",
+            "tags": {},
+            "properties": {
+              "attributes": {
+                "enabled": true,
+                "created": 1720150115,
+                "updated": 1720150115,
+                "recoveryLevel": "Recoverable+Purgeable",
+                "exportable": false
+              },
+              "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-01/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000011"],
+        "resourceGroupName": ["[A-Za-z0-9-]+"]  
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2023-07-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "id": "/subscriptions/000000-0000-0000-0000-000000000011/resourceGroups/go-on-azure/providers/Microsoft.KeyVault/vaults/stackql-testing-keyvault/keys/dummy-key-01",
+        "name": "dummy-key-01",
+        "type": "Microsoft.KeyVault/vaults/keys",
+        "location": "eastus",
+        "tags": {},
+        "properties": {
+          "attributes": {
+            "enabled": true,
+            "created": 1720150115,
+            "updated": 1720150115,
+            "recoveryLevel": "Recoverable+Purgeable",
+            "exportable": false
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ]
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01",
+          "keyUriWithVersion": "https://stackql-testing-keyvault.vault.azure.net/keys/dummy-key-01/aaaaaaaaa00000001"
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
       "path": "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/sshPublicKeys/",
       "pathParameters": {
         "subscriptionId": ["[A-Za-z0-9-]+"] 

--- a/test/registry/src/azure/v0.1.0/services/key_vault.yaml
+++ b/test/registry/src/azure/v0.1.0/services/key_vault.yaml
@@ -1,0 +1,5415 @@
+openapi: 3.0.0
+servers:
+  - url: 'https://management.azure.com/'
+info:
+  title: Azure Key Vault
+  description: 'Use Key Vault to safeguard and manage cryptographic keys, certificates and secrets used by cloud applications and services.'
+  contact:
+    name: StackQL Studios
+    url: 'https://stackql.io/'
+    email: info@stackql.io
+  version: 2024-01-25-stackql-generated
+security:
+  - azure_auth:
+      - user_impersonation
+components:
+  securitySchemes:
+    azure_auth:
+      description: Azure Active Directory OAuth2 Flow.
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'https://login.microsoftonline.com/common/oauth2/authorize'
+          scopes:
+            user_impersonation: impersonate your user account
+  parameters:
+    SubscriptionIdParameter:
+      name: subscriptionId
+      in: path
+      description: Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.
+      required: true
+      schema:
+        type: string
+    ApiVersionParameter:
+      name: api-version
+      in: query
+      description: Client Api Version.
+      required: true
+      schema:
+        type: string
+    ResourceGroupNameParameter:
+      name: resourceGroupName
+      in: path
+      description: The name of the resource group. The name is case insensitive.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        minLength: 1
+        maxLength: 90
+        type: string
+    OperationIdParameter:
+      name: operationId
+      in: path
+      description: The ID of an ongoing async operation.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        minLength: 1
+        type: string
+    LocationParameter:
+      name: location
+      in: path
+      description: The name of Azure region.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        minLength: 1
+        type: string
+    ManagedHSMName:
+      name: name
+      in: path
+      description: The name of the Managed HSM Pool within the specified resource group.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        pattern: '^[A-Za-z]([A-Za-z0-9]|\-[A-Za-z0-9])+$'
+        maxLength: 24
+        minLength: 3
+        type: string
+    ManagedHSMKeyName:
+      name: keyName
+      in: path
+      description: The name of the key to be created. The value you provide may be copied globally for the purpose of running the service. The value provided should not include personally identifiable or sensitive information.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        pattern: '^[a-zA-Z0-9-]{1,127}$'
+        type: string
+    ManagedHSMKeyVersion:
+      name: keyVersion
+      in: path
+      description: The version of the key to be retrieved.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        pattern: '^[a-fA-F0-9]{32}$'
+        type: string
+    ResourceGroupName:
+      name: resourceGroupName
+      in: path
+      description: Name of the resource group that contains the key vault.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        type: string
+    VaultName:
+      name: vaultName
+      in: path
+      description: The name of the key vault.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        pattern: '^[a-zA-Z0-9-]{3,24}$'
+        type: string
+    PrivateEndpointConnectionName:
+      name: privateEndpointConnectionName
+      in: path
+      description: Name of the private endpoint connection associated with the key vault.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        type: string
+    ManagedHsmResourceGroupName:
+      name: resourceGroupName
+      in: path
+      description: Name of the resource group that contains the managed HSM pool.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        type: string
+    MHSMPrivateEndpointConnectionName:
+      name: privateEndpointConnectionName
+      in: path
+      description: Name of the private endpoint connection associated with the managed hsm pool.
+      required: true
+      x-ms-parameter-location: method
+      schema:
+        type: string
+  schemas:
+    Resource:
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+      description: Key Vault resource
+      x-ms-azure-resource: true
+      type: object
+    AzureEntityResource:
+      x-ms-client-name: AzureEntityResource
+      title: Entity Resource
+      description: The resource model definition for an Azure Resource Manager resource with an etag.
+      properties:
+        etag:
+          type: string
+          readOnly: true
+          description: Resource Etag.
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+      type: object
+    TrackedResource:
+      title: Tracked Resource
+      description: The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'
+      required:
+        - location
+      properties:
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+      type: object
+    ProxyResource:
+      title: Proxy Resource
+      description: The resource model definition for a Azure Resource Manager proxy resource. It will not have tags and a location
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+      type: object
+    ResourceModelWithAllowedPropertySet:
+      description: 'The resource model definition containing the full set of allowed properties for a resource. Except properties bag, there cannot be a top level property outside of this set.'
+      x-ms-azure-resource: true
+      properties:
+        managedBy:
+          type: string
+          x-ms-mutability:
+            - read
+            - create
+            - update
+          description: 'The fully qualified resource ID of the resource that manages this resource. Indicates if this resource is managed by another Azure resource. If this is present, complete mode deployment will not delete the resource if it is removed from the template since it is managed by another resource.'
+        kind:
+          type: string
+          x-ms-mutability:
+            - read
+            - create
+          description: 'Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type; e.g. ApiApps are a kind of Microsoft.Web/sites type.  If supported, the resource provider must validate and persist this value.'
+          pattern: '^[-\w\._,\(\)]+$'
+        etag:
+          readOnly: true
+          type: string
+          description: 'The etag field is *not* required. If it is provided in the response body, it must also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields. '
+        identity:
+          allOf:
+            - $ref: '#/components/schemas/Identity'
+        sku:
+          allOf:
+            - $ref: '#/components/schemas/Sku'
+        plan:
+          allOf:
+            - $ref: '#/components/schemas/Plan'
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          x-ms-mutability:
+            - read
+            - create
+            - update
+          description: Resource tags.
+        location:
+          type: string
+          x-ms-mutability:
+            - read
+            - create
+          description: The geo-location where the resource lives
+      type: object
+    SkuTier:
+      type: string
+      enum:
+        - Free
+        - Basic
+        - Standard
+        - Premium
+      x-ms-enum:
+        name: SkuTier
+        modelAsString: false
+      description: 'This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.'
+    Sku:
+      properties:
+        family:
+          type: string
+          description: SKU family name
+          enum:
+            - A
+          x-ms-client-default: A
+          x-ms-enum:
+            name: SkuFamily
+            modelAsString: true
+        name:
+          type: string
+          description: SKU name to specify whether the key vault is a standard vault or a premium vault.
+          enum:
+            - standard
+            - premium
+          x-ms-enum:
+            name: SkuName
+            modelAsString: false
+      description: SKU details
+      required:
+        - name
+        - family
+      type: object
+    Identity:
+      description: Identity for the resource.
+      type: object
+      properties:
+        principalId:
+          readOnly: true
+          type: string
+          description: The principal ID of resource identity.
+        tenantId:
+          readOnly: true
+          type: string
+          description: The tenant ID of resource.
+        type:
+          type: string
+          description: The identity type.
+          enum:
+            - SystemAssigned
+          x-ms-enum:
+            name: ResourceIdentityType
+            modelAsString: false
+    Plan:
+      type: object
+      properties:
+        name:
+          type: string
+          description: A user defined name of the 3rd Party Artifact that is being procured.
+        publisher:
+          type: string
+          description: The publisher of the 3rd Party Artifact that is being bought. E.g. NewRelic
+        product:
+          type: string
+          description: 'The 3rd Party artifact that is being procured. E.g. NewRelic. Product maps to the OfferID specified for the artifact at the time of Data Market onboarding. '
+        promotionCode:
+          type: string
+          description: A publisher provided promotion code as provisioned in Data Market for the said product/artifact.
+        version:
+          type: string
+          description: The version of the desired product/artifact.
+      description: Plan for the resource.
+      required:
+        - name
+        - publisher
+        - product
+    ErrorDetail:
+      description: The error detail.
+      type: object
+      properties:
+        code:
+          readOnly: true
+          type: string
+          description: The error code.
+        message:
+          readOnly: true
+          type: string
+          description: The error message.
+        target:
+          readOnly: true
+          type: string
+          description: The error target.
+        details:
+          readOnly: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorDetail'
+          x-ms-identifiers:
+            - message
+            - target
+          description: The error details.
+        additionalInfo:
+          readOnly: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorAdditionalInfo'
+          x-ms-identifiers: []
+          description: The error additional info.
+    ErrorResponse:
+      title: Error response
+      description: Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).
+      type: object
+      properties:
+        error:
+          description: The error object.
+          $ref: '#/components/schemas/ErrorDetail'
+    ErrorAdditionalInfo:
+      type: object
+      properties:
+        type:
+          readOnly: true
+          type: string
+          description: The additional info type.
+        info:
+          readOnly: true
+          type: object
+          description: The additional info.
+      description: The resource management error additional info.
+    Operation:
+      description: Key Vault REST API operation definition.
+      properties:
+        name:
+          description: 'Operation name: {provider}/{resource}/{operation}'
+          type: string
+        display:
+          description: Display metadata associated with the operation.
+          properties:
+            provider:
+              description: 'Service provider: Microsoft Key Vault.'
+              type: string
+            resource:
+              description: Resource on which the operation is performed etc.
+              type: string
+            operation:
+              description: 'Type of operation: get, read, delete, etc.'
+              type: string
+            description:
+              description: Description of operation.
+              type: string
+        origin:
+          type: string
+          description: The origin of operations.
+        properties:
+          description: 'Properties of operation, include metric specifications.'
+          x-ms-client-flatten: true
+          x-ms-client-name: OperationProperties
+          $ref: '#/components/schemas/OperationProperties'
+        isDataAction:
+          type: boolean
+          description: Property to specify whether the action is a data action.
+      type: object
+    OperationListResult:
+      description: Result of the request to list Storage operations. It contains a list of operations and a URL link to get the next set of results.
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
+          x-ms-identifiers: []
+          description: List of Storage operations supported by the Storage resource provider.
+        nextLink:
+          type: string
+          description: The URL to get the next set of operations.
+      type: object
+    OperationStatusResult:
+      description: The current status of an async operation.
+      type: object
+      required:
+        - status
+      properties:
+        id:
+          description: Fully qualified ID for the async operation.
+          type: string
+        name:
+          description: Name of the async operation.
+          type: string
+        status:
+          description: Operation status.
+          type: string
+        percentComplete:
+          description: Percent of the operation that is complete.
+          type: number
+          minimum: 0
+          maximum: 100
+        startTime:
+          description: The start time of the operation.
+          type: string
+          format: date-time
+        endTime:
+          description: The end time of the operation.
+          type: string
+          format: date-time
+        operations:
+          description: The operations list.
+          type: array
+          items:
+            $ref: '#/components/schemas/OperationStatusResult'
+        error:
+          description: 'If present, details of the operation error.'
+          $ref: '#/components/schemas/ErrorDetail'
+    locationData:
+      description: Metadata pertaining to the geographic location of the resource.
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          description: A canonical name for the geographic or physical location.
+        city:
+          type: string
+          description: The city or locality where the resource is located.
+        district:
+          type: string
+          description: 'The district, state, or province where the resource is located.'
+        countryOrRegion:
+          type: string
+          description: The country or region where the resource is located
+      required:
+        - name
+    systemData:
+      description: Metadata pertaining to creation and last modification of the resource.
+      type: object
+      readOnly: true
+      properties:
+        createdBy:
+          type: string
+          description: The identity that created the resource.
+        createdByType:
+          type: string
+          description: The type of identity that created the resource.
+          enum:
+            - User
+            - Application
+            - ManagedIdentity
+            - Key
+          x-ms-enum:
+            name: createdByType
+            modelAsString: true
+        createdAt:
+          type: string
+          format: date-time
+          description: The timestamp of resource creation (UTC).
+        lastModifiedBy:
+          type: string
+          description: The identity that last modified the resource.
+        lastModifiedByType:
+          type: string
+          description: The type of identity that last modified the resource.
+          enum:
+            - User
+            - Application
+            - ManagedIdentity
+            - Key
+          x-ms-enum:
+            name: createdByType
+            modelAsString: true
+        lastModifiedAt:
+          type: string
+          format: date-time
+          description: The timestamp of resource last modification (UTC)
+    encryptionProperties:
+      description: Configuration of key for data encryption
+      type: object
+      properties:
+        status:
+          description: Indicates whether or not the encryption is enabled for container registry.
+          enum:
+            - enabled
+            - disabled
+          type: string
+          x-ms-enum:
+            name: EncryptionStatus
+            modelAsString: true
+        keyVaultProperties:
+          $ref: '#/components/schemas/KeyVaultProperties'
+          description: Key vault properties.
+    KeyVaultProperties:
+      type: object
+      properties:
+        keyIdentifier:
+          description: Key vault uri to access the encryption key.
+          type: string
+        identity:
+          description: The client ID of the identity which will be used to access key vault.
+          type: string
+    CheckNameAvailabilityRequest:
+      description: The check availability request body.
+      type: object
+      properties:
+        name:
+          description: The name of the resource for which availability needs to be checked.
+          type: string
+        type:
+          description: The resource type.
+          type: string
+    CheckNameAvailabilityResponse:
+      description: The check availability result.
+      type: object
+      properties:
+        nameAvailable:
+          description: Indicates if the resource name is available.
+          type: boolean
+        reason:
+          description: The reason why the given name is not available.
+          type: string
+          enum:
+            - Invalid
+            - AlreadyExists
+          x-ms-enum:
+            name: CheckNameAvailabilityReason
+            modelAsString: true
+        message:
+          description: Detailed reason why the given name is available.
+          type: string
+    KeyProperties:
+      properties:
+        attributes:
+          $ref: '#/components/schemas/KeyAttributes'
+          description: The attributes of the key.
+        kty:
+          type: string
+          minLength: 1
+          description: 'The type of the key. For valid values, see JsonWebKeyType.'
+          enum:
+            - EC
+            - EC-HSM
+            - RSA
+            - RSA-HSM
+          x-ms-enum:
+            name: JsonWebKeyType
+            modelAsString: true
+        keyOps:
+          type: array
+          items:
+            type: string
+            description: 'The permitted JSON web key operations of the key. For more information, see JsonWebKeyOperation.'
+            enum:
+              - encrypt
+              - decrypt
+              - sign
+              - verify
+              - wrapKey
+              - unwrapKey
+              - import
+              - release
+            x-ms-enum:
+              name: JsonWebKeyOperation
+              modelAsString: true
+        keySize:
+          type: integer
+          format: int32
+          description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
+        curveName:
+          type: string
+          description: 'The elliptic curve name. For valid values, see JsonWebKeyCurveName.'
+          enum:
+            - P-256
+            - P-384
+            - P-521
+            - P-256K
+          x-ms-enum:
+            name: JsonWebKeyCurveName
+            modelAsString: true
+        keyUri:
+          type: string
+          description: The URI to retrieve the current version of the key.
+          readOnly: true
+        keyUriWithVersion:
+          type: string
+          description: The URI to retrieve the specific version of the key.
+          readOnly: true
+        rotationPolicy:
+          $ref: '#/components/schemas/RotationPolicy'
+          description: Key rotation policy in response. It will be used for both output and input. Omitted if empty
+        release_policy:
+          $ref: '#/components/schemas/KeyReleasePolicy'
+          description: Key release policy in response. It will be used for both output and input. Omitted if empty
+      description: The properties of the key.
+      type: object
+    KeyAttributes:
+      properties:
+        enabled:
+          type: boolean
+          description: Determines whether or not the object is enabled.
+        nbf:
+          x-ms-client-name: NotBefore
+          type: integer
+          format: int64
+          description: 'Not before date in seconds since 1970-01-01T00:00:00Z.'
+        exp:
+          x-ms-client-name: Expires
+          type: integer
+          format: int64
+          description: 'Expiry date in seconds since 1970-01-01T00:00:00Z.'
+        created:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Creation time in seconds since 1970-01-01T00:00:00Z.'
+        updated:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Last updated time in seconds since 1970-01-01T00:00:00Z.'
+        recoveryLevel:
+          type: string
+          description: 'The deletion recovery level currently in effect for the object. If it contains ''Purgeable'', then the object can be permanently deleted by a privileged user; otherwise, only the system can purge the object at the end of the retention interval.'
+          enum:
+            - Purgeable
+            - Recoverable+Purgeable
+            - Recoverable
+            - Recoverable+ProtectedSubscription
+          x-ms-enum:
+            name: DeletionRecoveryLevel
+            modelAsString: true
+          readOnly: true
+          nullable: false
+        exportable:
+          type: boolean
+          description: Indicates if the private key can be exported.
+          default: false
+      description: The object attributes managed by the Azure Key Vault service.
+      type: object
+    KeyCreateParameters:
+      description: The parameters used to create a key.
+      required:
+        - properties
+      x-ms-azure-resource: true
+      properties:
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: The tags that will be assigned to the key.
+        properties:
+          $ref: '#/components/schemas/KeyProperties'
+          description: The properties of the key to be created.
+      type: object
+    Key:
+      required:
+        - properties
+      description: The key resource.
+      properties:
+        properties:
+          x-ms-client-flatten: true
+          $ref: '#/components/schemas/KeyProperties'
+          description: The properties of the key.
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+      type: object
+    KeyListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Key'
+          description: The key resources.
+        nextLink:
+          type: string
+          description: The URL to get the next page of keys.
+      description: The page of keys.
+      type: object
+    RotationPolicy:
+      properties:
+        attributes:
+          $ref: '#/components/schemas/KeyRotationPolicyAttributes'
+          description: The attributes of key rotation policy.
+        lifetimeActions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LifetimeAction'
+          x-ms-identifiers: []
+          description: The lifetimeActions for key rotation action.
+      type: object
+    KeyRotationPolicyAttributes:
+      properties:
+        created:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Creation time in seconds since 1970-01-01T00:00:00Z.'
+        updated:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Last updated time in seconds since 1970-01-01T00:00:00Z.'
+        expiryTime:
+          type: string
+          description: 'The expiration time for the new key version. It should be in ISO8601 format. Eg: ''P90D'', ''P1Y''.'
+      type: object
+    LifetimeAction:
+      properties:
+        trigger:
+          $ref: '#/components/schemas/Trigger'
+          description: The trigger of key rotation policy lifetimeAction.
+        action:
+          $ref: '#/components/schemas/Action'
+          description: The action of key rotation policy lifetimeAction.
+      type: object
+    Trigger:
+      properties:
+        timeAfterCreate:
+          type: string
+          description: 'The time duration after key creation to rotate the key. It only applies to rotate. It will be in ISO 8601 duration format. Eg: ''P90D'', ''P1Y''.'
+        timeBeforeExpiry:
+          type: string
+          description: 'The time duration before key expiring to rotate or notify. It will be in ISO 8601 duration format. Eg: ''P90D'', ''P1Y''.'
+      type: object
+    Action:
+      properties:
+        type:
+          type: string
+          description: The type of action.
+          enum:
+            - rotate
+            - notify
+          x-ms-enum:
+            name: KeyRotationPolicyActionType
+            modelAsString: false
+      type: object
+    KeyReleasePolicy:
+      properties:
+        contentType:
+          description: Content type and version of key release policy
+          type: string
+          default: application/json; charset=utf-8
+        data:
+          description: Blob encoding the policy rules under which the key can be released.
+          type: string
+          format: base64url
+      type: object
+    ManagedHsmKeyProperties:
+      properties:
+        attributes:
+          $ref: '#/components/schemas/ManagedHsmKeyAttributes'
+          description: The attributes of the key.
+        kty:
+          type: string
+          minLength: 1
+          description: 'The type of the key. For valid values, see JsonWebKeyType.'
+          enum:
+            - EC
+            - EC-HSM
+            - RSA
+            - RSA-HSM
+          x-ms-enum:
+            name: JsonWebKeyType
+            modelAsString: true
+        keyOps:
+          type: array
+          items:
+            type: string
+            description: 'The permitted JSON web key operations of the key. For more information, see JsonWebKeyOperation.'
+            enum:
+              - encrypt
+              - decrypt
+              - sign
+              - verify
+              - wrapKey
+              - unwrapKey
+              - import
+              - release
+            x-ms-enum:
+              name: JsonWebKeyOperation
+              modelAsString: true
+        keySize:
+          type: integer
+          format: int32
+          description: 'The key size in bits. For example: 2048, 3072, or 4096 for RSA.'
+        curveName:
+          type: string
+          description: 'The elliptic curve name. For valid values, see JsonWebKeyCurveName.'
+          enum:
+            - P-256
+            - P-384
+            - P-521
+            - P-256K
+          x-ms-enum:
+            name: JsonWebKeyCurveName
+            modelAsString: true
+        keyUri:
+          type: string
+          description: The URI to retrieve the current version of the key.
+          readOnly: true
+        keyUriWithVersion:
+          type: string
+          description: The URI to retrieve the specific version of the key.
+          readOnly: true
+        rotationPolicy:
+          $ref: '#/components/schemas/ManagedHsmRotationPolicy'
+          description: Key rotation policy in response. It will be used for both output and input. Omitted if empty
+        release_policy:
+          $ref: '#/components/schemas/ManagedHsmKeyReleasePolicy'
+          description: Key release policy in response. It will be used for both output and input. Omitted if empty
+      description: The properties of the key.
+      type: object
+    ManagedHsmKeyAttributes:
+      properties:
+        enabled:
+          type: boolean
+          description: Determines whether or not the object is enabled.
+        nbf:
+          x-ms-client-name: NotBefore
+          type: integer
+          format: int64
+          description: 'Not before date in seconds since 1970-01-01T00:00:00Z.'
+        exp:
+          x-ms-client-name: Expires
+          type: integer
+          format: int64
+          description: 'Expiry date in seconds since 1970-01-01T00:00:00Z.'
+        created:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Creation time in seconds since 1970-01-01T00:00:00Z.'
+        updated:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Last updated time in seconds since 1970-01-01T00:00:00Z.'
+        recoveryLevel:
+          type: string
+          description: 'The deletion recovery level currently in effect for the object. If it contains ''Purgeable'', then the object can be permanently deleted by a privileged user; otherwise, only the system can purge the object at the end of the retention interval.'
+          enum:
+            - Purgeable
+            - Recoverable+Purgeable
+            - Recoverable
+            - Recoverable+ProtectedSubscription
+          x-ms-enum:
+            name: DeletionRecoveryLevel
+            modelAsString: true
+          readOnly: true
+          nullable: false
+        exportable:
+          type: boolean
+          description: Indicates if the private key can be exported.
+      description: The object attributes managed by the Azure Key Vault service.
+      type: object
+    ManagedHsmKeyCreateParameters:
+      description: The parameters used to create a key.
+      required:
+        - properties
+      x-ms-azure-resource: true
+      properties:
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: The tags that will be assigned to the key.
+        properties:
+          $ref: '#/components/schemas/ManagedHsmKeyProperties'
+          description: The properties of the key to be created.
+      type: object
+    ManagedHsmKey:
+      required:
+        - properties
+      description: The key resource.
+      properties:
+        properties:
+          x-ms-client-flatten: true
+          $ref: '#/components/schemas/ManagedHsmKeyProperties'
+          description: The properties of the key.
+        id:
+          readOnly: true
+          type: string
+          description: 'Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
+        name:
+          readOnly: true
+          type: string
+          description: The name of the resource
+        type:
+          readOnly: true
+          type: string
+          description: The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          x-ms-mutability:
+            - read
+            - create
+            - update
+          description: Resource tags.
+      type: object
+    ManagedHsmKeyListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ManagedHsmKey'
+          description: The key resources.
+        nextLink:
+          type: string
+          description: The URL to get the next page of keys.
+      description: The page of keys.
+      type: object
+    ManagedHsmRotationPolicy:
+      properties:
+        attributes:
+          $ref: '#/components/schemas/ManagedHsmKeyRotationPolicyAttributes'
+          description: The attributes of key rotation policy.
+        lifetimeActions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ManagedHsmLifetimeAction'
+          x-ms-identifiers: []
+          description: The lifetimeActions for key rotation action.
+      type: object
+    ManagedHsmKeyRotationPolicyAttributes:
+      properties:
+        created:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Creation time in seconds since 1970-01-01T00:00:00Z.'
+        updated:
+          type: integer
+          format: int64
+          readOnly: true
+          description: 'Last updated time in seconds since 1970-01-01T00:00:00Z.'
+        expiryTime:
+          type: string
+          description: 'The expiration time for the new key version. It should be in ISO8601 format. Eg: ''P90D'', ''P1Y''.'
+      type: object
+    ManagedHsmLifetimeAction:
+      properties:
+        trigger:
+          $ref: '#/components/schemas/ManagedHsmTrigger'
+          description: The trigger of key rotation policy lifetimeAction.
+        action:
+          $ref: '#/components/schemas/ManagedHsmAction'
+          description: The action of key rotation policy lifetimeAction.
+      type: object
+    ManagedHsmTrigger:
+      properties:
+        timeAfterCreate:
+          type: string
+          description: 'The time duration after key creation to rotate the key. It only applies to rotate. It will be in ISO 8601 duration format. Eg: ''P90D'', ''P1Y''.'
+        timeBeforeExpiry:
+          type: string
+          description: 'The time duration before key expiring to rotate or notify. It will be in ISO 8601 duration format. Eg: ''P90D'', ''P1Y''.'
+      type: object
+    ManagedHsmAction:
+      properties:
+        type:
+          type: string
+          description: The type of action.
+          enum:
+            - rotate
+            - notify
+          x-ms-enum:
+            name: KeyRotationPolicyActionType
+            modelAsString: false
+      type: object
+    ManagedHsmKeyReleasePolicy:
+      properties:
+        contentType:
+          description: Content type and version of key release policy
+          type: string
+          default: application/json; charset=utf-8
+        data:
+          description: Blob encoding the policy rules under which the key can be released.
+          type: string
+          format: base64url
+      type: object
+    ProxyResourceWithoutSystemData:
+      title: Resource
+      description: Common fields that are returned in the response for all Azure Resource Manager resources
+      type: object
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: 'Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}'
+        name:
+          readOnly: true
+          type: string
+          description: The name of the resource
+        type:
+          readOnly: true
+          type: string
+          description: The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          x-ms-mutability:
+            - read
+            - create
+            - update
+          description: Resource tags.
+      x-ms-azure-resource: true
+    OperationProperties:
+      description: 'Properties of operation, include metric specifications.'
+      properties:
+        serviceSpecification:
+          $ref: '#/components/schemas/ServiceSpecification'
+          description: 'One property of operation, include metric specifications.'
+      type: object
+    ServiceSpecification:
+      description: 'One property of operation, include log specifications.'
+      properties:
+        logSpecifications:
+          description: Log specifications of operation.
+          type: array
+          items:
+            $ref: '#/components/schemas/LogSpecification'
+          x-ms-identifiers:
+            - name
+        metricSpecifications:
+          description: Metric specifications of operation.
+          type: array
+          items:
+            $ref: '#/components/schemas/MetricSpecification'
+          x-ms-identifiers:
+            - name
+      type: object
+    LogSpecification:
+      description: Log specification of operation.
+      properties:
+        name:
+          type: string
+          description: Name of log specification.
+        displayName:
+          type: string
+          description: Display name of log specification.
+        blobDuration:
+          type: string
+          description: Blob duration of specification.
+      type: object
+    MetricSpecification:
+      description: Metric specification of operation.
+      properties:
+        name:
+          type: string
+          description: Name of metric specification.
+        displayName:
+          type: string
+          description: Display name of metric specification.
+        displayDescription:
+          type: string
+          description: Display description of metric specification.
+        unit:
+          type: string
+          description: 'The metric unit. Possible values include: ''Bytes'', ''Count'', ''Milliseconds''.'
+        aggregationType:
+          type: string
+          description: 'The metric aggregation type. Possible values include: ''Average'', ''Count'', ''Total''.'
+        supportedAggregationTypes:
+          type: array
+          description: The supported aggregation types for the metrics.
+          items:
+            type: string
+        supportedTimeGrainTypes:
+          type: array
+          description: The supported time grain types for the metrics.
+          items:
+            type: string
+        lockAggregationType:
+          type: string
+          description: The metric lock aggregation type.
+        dimensions:
+          type: array
+          description: The dimensions of metric
+          items:
+            $ref: '#/components/schemas/DimensionProperties'
+          x-ms-identifiers:
+            - name
+        fillGapWithZero:
+          type: boolean
+          description: Property to specify whether to fill gap with zero.
+        internalMetricName:
+          type: string
+          description: The internal metric name.
+      type: object
+    DimensionProperties:
+      description: 'Type of operation: get, read, delete, etc.'
+      properties:
+        name:
+          type: string
+          description: Name of dimension.
+        displayName:
+          type: string
+          description: Display name of dimension.
+        toBeExportedForShoebox:
+          type: boolean
+          description: Property to specify whether the dimension should be exported for Shoebox.
+      type: object
+    Attributes:
+      properties:
+        enabled:
+          type: boolean
+          description: Determines whether the object is enabled.
+        nbf:
+          x-ms-client-name: NotBefore
+          type: integer
+          format: unixtime
+          description: 'Not before date in seconds since 1970-01-01T00:00:00Z.'
+        exp:
+          x-ms-client-name: Expires
+          type: integer
+          format: unixtime
+          description: 'Expiry date in seconds since 1970-01-01T00:00:00Z.'
+        created:
+          type: integer
+          format: unixtime
+          readOnly: true
+          description: 'Creation time in seconds since 1970-01-01T00:00:00Z.'
+        updated:
+          type: integer
+          format: unixtime
+          readOnly: true
+          description: 'Last updated time in seconds since 1970-01-01T00:00:00Z.'
+      description: The object attributes managed by the KeyVault service.
+      type: object
+    SecretProperties:
+      properties:
+        value:
+          type: string
+          description: 'The value of the secret. NOTE: ''value'' will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets.'
+        contentType:
+          type: string
+          description: The content type of the secret.
+        attributes:
+          $ref: '#/components/schemas/SecretAttributes'
+          description: The attributes of the secret.
+        secretUri:
+          type: string
+          description: The URI to retrieve the current version of the secret.
+          readOnly: true
+        secretUriWithVersion:
+          type: string
+          description: The URI to retrieve the specific version of the secret.
+          readOnly: true
+      description: Properties of the secret
+      type: object
+    SecretPatchProperties:
+      properties:
+        value:
+          type: string
+          description: The value of the secret.
+        contentType:
+          type: string
+          description: The content type of the secret.
+        attributes:
+          $ref: '#/components/schemas/SecretAttributes'
+          description: The attributes of the secret.
+      description: Properties of the secret
+      type: object
+    SecretAttributes:
+      description: The secret management attributes.
+      properties:
+        enabled:
+          type: boolean
+          description: Determines whether the object is enabled.
+        nbf:
+          x-ms-client-name: NotBefore
+          type: integer
+          format: unixtime
+          description: 'Not before date in seconds since 1970-01-01T00:00:00Z.'
+        exp:
+          x-ms-client-name: Expires
+          type: integer
+          format: unixtime
+          description: 'Expiry date in seconds since 1970-01-01T00:00:00Z.'
+        created:
+          type: integer
+          format: unixtime
+          readOnly: true
+          description: 'Creation time in seconds since 1970-01-01T00:00:00Z.'
+        updated:
+          type: integer
+          format: unixtime
+          readOnly: true
+          description: 'Last updated time in seconds since 1970-01-01T00:00:00Z.'
+      type: object
+    SecretCreateOrUpdateParameters:
+      description: Parameters for creating or updating a secret
+      required:
+        - properties
+      x-ms-azure-resource: true
+      properties:
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: 'The tags that will be assigned to the secret. '
+        properties:
+          $ref: '#/components/schemas/SecretProperties'
+          description: Properties of the secret
+      type: object
+    SecretPatchParameters:
+      description: Parameters for patching a secret
+      x-ms-azure-resource: true
+      properties:
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: 'The tags that will be assigned to the secret. '
+        properties:
+          $ref: '#/components/schemas/SecretPatchProperties'
+          description: Properties of the secret
+      type: object
+    Secret:
+      required:
+        - properties
+      description: Resource information with extended details.
+      properties:
+        properties:
+          $ref: '#/components/schemas/SecretProperties'
+          description: Properties of the secret
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+      type: object
+    SecretListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Secret'
+          description: The list of secrets.
+        nextLink:
+          type: string
+          description: The URL to get the next set of secrets.
+      description: List of secrets
+      type: object
+    CloudError:
+      description: An error response from Key Vault resource provider
+      properties:
+        error:
+          $ref: '#/components/schemas/CloudErrorBody'
+      x-ms-external: true
+      type: object
+    CloudErrorBody:
+      description: An error response from Key Vault resource provider
+      properties:
+        code:
+          type: string
+          description: Error code. This is a mnemonic that can be consumed programmatically.
+        message:
+          type: string
+          description: User friendly error message. The message is typically localized and may vary with service version.
+      x-ms-external: true
+      type: object
+    SystemData:
+      description: Metadata pertaining to creation and last modification of the key vault resource.
+      readOnly: true
+      properties:
+        createdBy:
+          type: string
+          description: The identity that created the key vault resource.
+        createdByType:
+          description: The type of identity that created the key vault resource.
+          $ref: '#/components/schemas/IdentityType'
+        createdAt:
+          type: string
+          format: date-time
+          description: The timestamp of the key vault resource creation (UTC).
+        lastModifiedBy:
+          type: string
+          description: The identity that last modified the key vault resource.
+        lastModifiedByType:
+          description: The type of identity that last modified the key vault resource.
+          $ref: '#/components/schemas/IdentityType'
+        lastModifiedAt:
+          type: string
+          format: date-time
+          description: The timestamp of the key vault resource last modification (UTC).
+      type: object
+    IdentityType:
+      type: string
+      description: The type of identity.
+      enum:
+        - User
+        - Application
+        - ManagedIdentity
+        - Key
+      x-ms-enum:
+        name: identityType
+        modelAsString: true
+    AccessPolicyEntry:
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+          description: The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.
+        objectId:
+          type: string
+          description: 'The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies.'
+        applicationId:
+          type: string
+          format: uuid
+          description: ' Application ID of the client making request on behalf of a principal'
+        permissions:
+          $ref: '#/components/schemas/Permissions'
+          description: 'Permissions the identity has for keys, secrets and certificates.'
+      description: An identity that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
+      required:
+        - tenantId
+        - objectId
+        - permissions
+      type: object
+    Permissions:
+      properties:
+        keys:
+          type: array
+          items:
+            type: string
+            enum:
+              - all
+              - encrypt
+              - decrypt
+              - wrapKey
+              - unwrapKey
+              - sign
+              - verify
+              - get
+              - list
+              - create
+              - update
+              - import
+              - delete
+              - backup
+              - restore
+              - recover
+              - purge
+              - release
+              - rotate
+              - getrotationpolicy
+              - setrotationpolicy
+            x-ms-enum:
+              name: KeyPermissions
+              modelAsString: true
+          description: Permissions to keys
+        secrets:
+          type: array
+          items:
+            type: string
+            enum:
+              - all
+              - get
+              - list
+              - set
+              - delete
+              - backup
+              - restore
+              - recover
+              - purge
+            x-ms-enum:
+              name: SecretPermissions
+              modelAsString: true
+          description: Permissions to secrets
+        certificates:
+          type: array
+          items:
+            type: string
+            enum:
+              - all
+              - get
+              - list
+              - delete
+              - create
+              - import
+              - update
+              - managecontacts
+              - getissuers
+              - listissuers
+              - setissuers
+              - deleteissuers
+              - manageissuers
+              - recover
+              - purge
+              - backup
+              - restore
+            x-ms-enum:
+              name: CertificatePermissions
+              modelAsString: true
+          description: Permissions to certificates
+        storage:
+          type: array
+          items:
+            type: string
+            enum:
+              - all
+              - get
+              - list
+              - delete
+              - set
+              - update
+              - regeneratekey
+              - recover
+              - purge
+              - backup
+              - restore
+              - setsas
+              - listsas
+              - getsas
+              - deletesas
+            x-ms-enum:
+              name: StoragePermissions
+              modelAsString: true
+          description: Permissions to storage accounts
+      description: 'Permissions the identity has for keys, secrets, certificates and storage.'
+      type: object
+    VaultProperties:
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+          description: The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.
+        sku:
+          $ref: '#/components/schemas/Sku'
+          description: SKU details
+        accessPolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessPolicyEntry'
+          x-ms-identifiers:
+            - tenantId
+            - objectId
+            - permissions
+          description: 'An array of 0 to 1024 identities that have access to the key vault. All identities in the array must use the same tenant ID as the key vault''s tenant ID. When `createMode` is set to `recover`, access policies are not required. Otherwise, access policies are required.'
+        vaultUri:
+          type: string
+          description: The URI of the vault for performing operations on keys and secrets.
+        hsmPoolResourceId:
+          type: string
+          description: The resource id of HSM Pool.
+          readOnly: true
+        enabledForDeployment:
+          type: boolean
+          description: Property to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault.
+        enabledForDiskEncryption:
+          type: boolean
+          description: Property to specify whether Azure Disk Encryption is permitted to retrieve secrets from the vault and unwrap keys.
+        enabledForTemplateDeployment:
+          type: boolean
+          description: Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault.
+        enableSoftDelete:
+          type: boolean
+          default: true
+          description: 'Property to specify whether the ''soft delete'' functionality is enabled for this key vault. If it''s not set to any value(true or false) when creating new key vault, it will be set to true by default. Once set to true, it cannot be reverted to false.'
+        softDeleteRetentionInDays:
+          type: integer
+          format: int32
+          default: 90
+          description: softDelete data retention days. It accepts >=7 and <=90.
+        enableRbacAuthorization:
+          type: boolean
+          default: false
+          description: 'Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored. When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. If null or not specified, the vault is created with the default value of false. Note that management actions are always authorized with RBAC.'
+        createMode:
+          type: string
+          description: The vault's create mode to indicate whether the vault need to be recovered or not.
+          enum:
+            - recover
+            - default
+          x-ms-enum:
+            name: CreateMode
+            modelAsString: false
+          x-ms-mutability:
+            - create
+            - update
+        enablePurgeProtection:
+          type: boolean
+          description: 'Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. The setting is effective only if soft delete is also enabled. Enabling this functionality is irreversible - that is, the property does not accept false as its value.'
+        networkAcls:
+          $ref: '#/components/schemas/NetworkRuleSet'
+          description: Rules governing the accessibility of the key vault from specific network locations.
+        provisioningState:
+          type: string
+          description: Provisioning state of the vault.
+          enum:
+            - Succeeded
+            - RegisteringDns
+          x-ms-enum:
+            name: VaultProvisioningState
+            modelAsString: true
+        privateEndpointConnections:
+          readOnly: true
+          type: array
+          items:
+            $ref: '#/components/schemas/PrivateEndpointConnectionItem'
+          description: List of private endpoint connections associated with the key vault.
+        publicNetworkAccess:
+          type: string
+          default: enabled
+          description: 'Property to specify whether the vault will accept traffic from public internet. If set to ''disabled'' all traffic except private endpoint traffic and that that originates from trusted services will be blocked. This will override the set firewall rules, meaning that even if the firewall rules are present we will not honor the rules.'
+      required:
+        - tenantId
+        - sku
+      description: Properties of the vault
+      type: object
+    VaultPatchProperties:
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+          description: The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.
+        sku:
+          $ref: '#/components/schemas/Sku'
+          description: SKU details
+        accessPolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessPolicyEntry'
+          x-ms-identifiers:
+            - tenantId
+            - objectId
+            - permissions
+          description: An array of 0 to 16 identities that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
+        enabledForDeployment:
+          type: boolean
+          description: Property to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault.
+        enabledForDiskEncryption:
+          type: boolean
+          description: Property to specify whether Azure Disk Encryption is permitted to retrieve secrets from the vault and unwrap keys.
+        enabledForTemplateDeployment:
+          type: boolean
+          description: Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault.
+        enableSoftDelete:
+          type: boolean
+          description: 'Property to specify whether the ''soft delete'' functionality is enabled for this key vault. Once set to true, it cannot be reverted to false.'
+        enableRbacAuthorization:
+          type: boolean
+          description: 'Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored. When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. If null or not specified, the value of this property will not change.'
+        softDeleteRetentionInDays:
+          type: integer
+          format: int32
+          description: softDelete data retention days. It accepts >=7 and <=90.
+        createMode:
+          type: string
+          description: The vault's create mode to indicate whether the vault need to be recovered or not.
+          enum:
+            - recover
+            - default
+          x-ms-enum:
+            name: CreateMode
+            modelAsString: false
+        enablePurgeProtection:
+          type: boolean
+          description: 'Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. The setting is effective only if soft delete is also enabled. Enabling this functionality is irreversible - that is, the property does not accept false as its value.'
+        networkAcls:
+          $ref: '#/components/schemas/NetworkRuleSet'
+          description: A collection of rules governing the accessibility of the vault from specific network locations.
+        publicNetworkAccess:
+          type: string
+          description: 'Property to specify whether the vault will accept traffic from public internet. If set to ''disabled'' all traffic except private endpoint traffic and that that originates from trusted services will be blocked. This will override the set firewall rules, meaning that even if the firewall rules are present we will not honor the rules.'
+      description: Properties of the vault
+      type: object
+    VaultAccessPolicyProperties:
+      properties:
+        accessPolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessPolicyEntry'
+          x-ms-identifiers:
+            - tenantId
+            - objectId
+            - permissions
+          description: An array of 0 to 16 identities that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID.
+      required:
+        - accessPolicies
+      description: Properties of the vault access policy
+      type: object
+    DeletedVaultProperties:
+      properties:
+        vaultId:
+          readOnly: true
+          type: string
+          description: The resource id of the original vault.
+        location:
+          readOnly: true
+          type: string
+          description: The location of the original vault.
+        deletionDate:
+          readOnly: true
+          type: string
+          format: date-time
+          description: The deleted date.
+        scheduledPurgeDate:
+          readOnly: true
+          type: string
+          format: date-time
+          description: The scheduled purged date.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags of the original vault.
+        purgeProtectionEnabled:
+          readOnly: true
+          type: boolean
+          description: Purge protection status of the original vault.
+      description: Properties of the deleted vault.
+      type: object
+    VaultCreateOrUpdateParameters:
+      description: Parameters for creating or updating a vault
+      required:
+        - location
+        - properties
+      x-ms-azure-resource: true
+      properties:
+        location:
+          type: string
+          description: The supported Azure location where the key vault should be created.
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: The tags that will be assigned to the key vault.
+        properties:
+          $ref: '#/components/schemas/VaultProperties'
+          description: Properties of the vault
+      type: object
+    VaultPatchParameters:
+      description: Parameters for creating or updating a vault
+      x-ms-azure-resource: true
+      properties:
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: 'The tags that will be assigned to the key vault. '
+        properties:
+          $ref: '#/components/schemas/VaultPatchProperties'
+          description: Properties of the vault
+      type: object
+    VaultAccessPolicyParameters:
+      description: Parameters for updating the access policy in a vault
+      required:
+        - properties
+      x-ms-azure-resource: true
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: The resource id of the access policy.
+        name:
+          readOnly: true
+          type: string
+          description: The resource name of the access policy.
+        type:
+          readOnly: true
+          type: string
+          description: The resource name of the access policy.
+        location:
+          readOnly: true
+          type: string
+          description: The resource type of the access policy.
+        properties:
+          $ref: '#/components/schemas/VaultAccessPolicyProperties'
+          description: Properties of the access policy
+      type: object
+    Vault:
+      required:
+        - properties
+      description: Resource information with extended details.
+      x-ms-azure-resource: true
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+        systemData:
+          description: System metadata for the key vault.
+          $ref: '#/components/schemas/SystemData'
+        properties:
+          $ref: '#/components/schemas/VaultProperties'
+          description: Properties of the vault
+      type: object
+    DeletedVault:
+      description: Deleted vault information with extended details.
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: The resource ID for the deleted key vault.
+        name:
+          readOnly: true
+          type: string
+          description: The name of the key vault.
+        type:
+          readOnly: true
+          type: string
+          description: The resource type of the key vault.
+        properties:
+          $ref: '#/components/schemas/DeletedVaultProperties'
+          description: Properties of the vault
+      type: object
+    VaultListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Vault'
+          description: The list of vaults.
+        nextLink:
+          type: string
+          description: The URL to get the next set of vaults.
+      description: List of vaults
+      type: object
+    DeletedVaultListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeletedVault'
+          description: The list of deleted vaults.
+        nextLink:
+          type: string
+          description: The URL to get the next set of deleted vaults.
+      description: List of vaults
+      type: object
+    ResourceListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Resource'
+          description: The list of vault resources.
+        nextLink:
+          type: string
+          description: The URL to get the next set of vault resources.
+      description: List of vault resources.
+      type: object
+    VaultCheckNameAvailabilityParameters:
+      properties:
+        name:
+          type: string
+          description: The vault name.
+        type:
+          type: string
+          enum:
+            - Microsoft.KeyVault/vaults
+          x-ms-enum:
+            name: Type
+            modelAsString: false
+          description: 'The type of resource, Microsoft.KeyVault/vaults'
+      required:
+        - name
+        - type
+      description: The parameters used to check the availability of the vault name.
+      type: object
+    CheckNameAvailabilityResult:
+      properties:
+        nameAvailable:
+          readOnly: true
+          type: boolean
+          description: 'A boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or is invalid and cannot be used.'
+        reason:
+          readOnly: true
+          type: string
+          description: The reason that a vault name could not be used. The Reason element is only returned if NameAvailable is false.
+          enum:
+            - AccountNameInvalid
+            - AlreadyExists
+          x-ms-enum:
+            name: Reason
+            modelAsString: false
+        message:
+          readOnly: true
+          type: string
+          description: An error message explaining the Reason value in more detail.
+      description: The CheckNameAvailability operation response.
+      type: object
+    NetworkRuleSet:
+      properties:
+        bypass:
+          type: string
+          description: Tells what traffic can bypass network rules. This can be 'AzureServices' or 'None'.  If not specified the default is 'AzureServices'.
+          enum:
+            - AzureServices
+            - None
+          x-ms-enum:
+            name: NetworkRuleBypassOptions
+            modelAsString: true
+        defaultAction:
+          type: string
+          description: The default action when no rule from ipRules and from virtualNetworkRules match. This is only used after the bypass property has been evaluated.
+          enum:
+            - Allow
+            - Deny
+          x-ms-enum:
+            name: NetworkRuleAction
+            modelAsString: true
+        ipRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/IPRule'
+          description: The list of IP address rules.
+        virtualNetworkRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/VirtualNetworkRule'
+          x-ms-identifiers:
+            - id
+          description: The list of virtual network rules.
+      description: A set of rules governing the network accessibility of a vault.
+      type: object
+    IPRule:
+      properties:
+        value:
+          type: string
+          description: 'An IPv4 address range in CIDR notation, such as ''124.56.78.91'' (simple IP address) or ''124.56.78.0/24'' (all addresses that start with 124.56.78).'
+      required:
+        - value
+      description: A rule governing the accessibility of a vault from a specific ip address or ip range.
+      type: object
+    VirtualNetworkRule:
+      properties:
+        id:
+          type: string
+          description: 'Full resource id of a vnet subnet, such as ''/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1''.'
+        ignoreMissingVnetServiceEndpoint:
+          type: boolean
+          description: Property to specify whether NRP will ignore the check if parent subnet has serviceEndpoints configured.
+      required:
+        - id
+      description: A rule governing the accessibility of a vault from a specific virtual network.
+      type: object
+    PrivateEndpointConnectionItem:
+      description: Private endpoint connection item.
+      properties:
+        id:
+          type: string
+          description: Id of private endpoint connection.
+        etag:
+          type: string
+          description: Modified whenever there is a change in the state of private endpoint connection.
+        properties:
+          $ref: '#/components/schemas/PrivateEndpointConnectionProperties'
+          x-ms-client-flatten: true
+          description: Private endpoint connection properties.
+      type: object
+    PrivateEndpointConnection:
+      description: Private endpoint connection resource.
+      x-ms-azure-resource: true
+      properties:
+        properties:
+          $ref: '#/components/schemas/PrivateEndpointConnectionProperties'
+          x-ms-client-flatten: true
+          description: Resource properties.
+        etag:
+          type: string
+          description: Modified whenever there is a change in the state of private endpoint connection.
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+      type: object
+    PrivateEndpointConnectionListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/PrivateEndpointConnection'
+          description: The list of private endpoint connections.
+        nextLink:
+          type: string
+          description: The URL to get the next set of private endpoint connections.
+      description: List of private endpoint connections.
+      type: object
+    PrivateEndpointConnectionProperties:
+      properties:
+        privateEndpoint:
+          $ref: '#/components/schemas/PrivateEndpoint'
+          description: Properties of the private endpoint object.
+        privateLinkServiceConnectionState:
+          $ref: '#/components/schemas/PrivateLinkServiceConnectionState'
+          description: Approval state of the private link connection.
+        provisioningState:
+          $ref: '#/components/schemas/PrivateEndpointConnectionProvisioningState'
+          description: Provisioning state of the private endpoint connection.
+      description: Properties of the private endpoint connection resource.
+      type: object
+    PrivateEndpoint:
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: Full identifier of the private endpoint resource.
+      description: Private endpoint object properties.
+      type: object
+    PrivateLinkServiceConnectionState:
+      properties:
+        status:
+          $ref: '#/components/schemas/PrivateEndpointServiceConnectionStatus'
+          description: 'Indicates whether the connection has been approved, rejected or removed by the key vault owner.'
+        description:
+          type: string
+          description: The reason for approval or rejection.
+        actionsRequired:
+          type: string
+          description: A message indicating if changes on the service provider require any updates on the consumer.
+          enum:
+            - None
+          x-ms-enum:
+            name: ActionsRequired
+            modelAsString: true
+      description: An object that represents the approval state of the private link connection.
+      type: object
+    PrivateEndpointServiceConnectionStatus:
+      type: string
+      description: The private endpoint connection status.
+      enum:
+        - Pending
+        - Approved
+        - Rejected
+        - Disconnected
+      x-ms-enum:
+        name: PrivateEndpointServiceConnectionStatus
+        modelAsString: true
+    PrivateEndpointConnectionProvisioningState:
+      type: string
+      readOnly: true
+      description: The current provisioning state.
+      enum:
+        - Succeeded
+        - Creating
+        - Updating
+        - Deleting
+        - Failed
+        - Disconnected
+      x-ms-enum:
+        name: PrivateEndpointConnectionProvisioningState
+        modelAsString: true
+    PrivateLinkResourceListResult:
+      properties:
+        value:
+          type: array
+          description: Array of private link resources
+          items:
+            $ref: '#/components/schemas/PrivateLinkResource'
+      description: A list of private link resources
+      type: object
+    PrivateLinkResource:
+      description: A private link resource
+      properties:
+        properties:
+          $ref: '#/components/schemas/PrivateLinkResourceProperties'
+          description: Resource properties.
+          x-ms-client-flatten: true
+        id:
+          readOnly: true
+          type: string
+          description: Fully qualified identifier of the key vault resource.
+        name:
+          readOnly: true
+          type: string
+          description: Name of the key vault resource.
+        type:
+          readOnly: true
+          type: string
+          description: Resource type of the key vault resource.
+        location:
+          readOnly: true
+          type: string
+          description: Azure location of the key vault resource.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags assigned to the key vault resource.
+      type: object
+    PrivateLinkResourceProperties:
+      properties:
+        groupId:
+          description: Group identifier of private link resource.
+          type: string
+          readOnly: true
+        requiredMembers:
+          description: Required member names of private link resource.
+          type: array
+          items:
+            type: string
+          readOnly: true
+        requiredZoneNames:
+          type: array
+          items:
+            type: string
+          description: Required DNS zone names of the the private link resource.
+      description: Properties of a private link resource.
+      type: object
+    ManagedHsmSku:
+      properties:
+        family:
+          type: string
+          description: SKU Family of the managed HSM Pool
+          enum:
+            - B
+          x-ms-client-default: B
+          x-ms-enum:
+            name: ManagedHsmSkuFamily
+            modelAsString: true
+        name:
+          type: string
+          description: SKU of the managed HSM Pool
+          enum:
+            - Standard_B1
+            - Custom_B32
+            - Custom_B6
+          x-ms-enum:
+            name: ManagedHsmSkuName
+            modelAsString: false
+      description: SKU details
+      required:
+        - name
+        - family
+      type: object
+    ManagedHsmProperties:
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+          description: The Azure Active Directory tenant ID that should be used for authenticating requests to the managed HSM pool.
+        initialAdminObjectIds:
+          type: array
+          items:
+            type: string
+          description: Array of initial administrators object ids for this managed hsm pool.
+        hsmUri:
+          type: string
+          readOnly: true
+          description: The URI of the managed hsm pool for performing operations on keys.
+        enableSoftDelete:
+          type: boolean
+          default: true
+          description: Property to specify whether the 'soft delete' functionality is enabled for this managed HSM pool. Soft delete is enabled by default for all managed HSMs and is immutable.
+        softDeleteRetentionInDays:
+          type: integer
+          format: int32
+          default: 90
+          description: 'Soft deleted data retention days. When you delete an HSM or a key, it will remain recoverable for the configured retention period or for a default period of 90 days. It accepts values between 7 and 90.'
+        enablePurgeProtection:
+          type: boolean
+          default: true
+          description: 'Property specifying whether protection against purge is enabled for this managed HSM pool. Setting this property to true activates protection against purge for this managed HSM pool and its content - only the Managed HSM service may initiate a hard, irrecoverable deletion. Enabling this functionality is irreversible.'
+        createMode:
+          type: string
+          description: The create mode to indicate whether the resource is being created or is being recovered from a deleted resource.
+          enum:
+            - recover
+            - default
+          x-ms-enum:
+            name: CreateMode
+            modelAsString: false
+            values:
+              - value: recover
+                description: Recover the managed HSM pool from a soft-deleted resource.
+              - value: default
+                description: Create a new managed HSM pool. This is the default option.
+          x-ms-mutability:
+            - create
+            - update
+        statusMessage:
+          readOnly: true
+          type: string
+          description: Resource Status Message.
+        provisioningState:
+          readOnly: true
+          type: string
+          description: Provisioning state.
+          enum:
+            - Succeeded
+            - Provisioning
+            - Failed
+            - Updating
+            - Deleting
+            - Activated
+            - SecurityDomainRestore
+            - Restoring
+          x-ms-enum:
+            name: ProvisioningState
+            modelAsString: true
+            values:
+              - value: Succeeded
+                description: The managed HSM Pool has been full provisioned.
+              - value: Provisioning
+                description: The managed HSM Pool is currently being provisioned.
+              - value: Failed
+                description: Provisioning of the managed HSM Pool has failed.
+              - value: Updating
+                description: The managed HSM Pool is currently being updated.
+              - value: Deleting
+                description: The managed HSM Pool is currently being deleted.
+              - value: Activated
+                description: The managed HSM pool is ready for normal use.
+              - value: SecurityDomainRestore
+                description: The managed HSM pool is waiting for a security domain restore action.
+              - value: Restoring
+                description: The managed HSM pool is being restored from full HSM backup.
+        networkAcls:
+          $ref: '#/components/schemas/MHSMNetworkRuleSet'
+          description: Rules governing the accessibility of the key vault from specific network locations.
+        regions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MHSMGeoReplicatedRegion'
+          x-ms-identifiers:
+            - name
+          description: List of all regions associated with the managed hsm pool.
+        privateEndpointConnections:
+          readOnly: true
+          type: array
+          items:
+            $ref: '#/components/schemas/MHSMPrivateEndpointConnectionItem'
+          description: List of private endpoint connections associated with the managed hsm pool.
+        publicNetworkAccess:
+          description: Control permission to the managed HSM from public networks.
+          enum:
+            - Enabled
+            - Disabled
+          default: Enabled
+          type: string
+          x-ms-enum:
+            name: PublicNetworkAccess
+            modelAsString: true
+        scheduledPurgeDate:
+          readOnly: true
+          type: string
+          format: date-time
+          description: The scheduled purge date in UTC.
+        securityDomainProperties:
+          readOnly: true
+          $ref: '#/components/schemas/ManagedHSMSecurityDomainProperties'
+          description: Managed HSM security domain properties.
+      description: Properties of the managed HSM Pool
+      type: object
+    ManagedHsm:
+      description: Resource information with extended details.
+      properties:
+        properties:
+          $ref: '#/components/schemas/ManagedHsmProperties'
+          description: Properties of the managed HSM
+        id:
+          readOnly: true
+          type: string
+          description: The Azure Resource Manager resource ID for the managed HSM Pool.
+        name:
+          readOnly: true
+          type: string
+          description: The name of the managed HSM Pool.
+        type:
+          readOnly: true
+          type: string
+          description: The resource type of the managed HSM Pool.
+        location:
+          type: string
+          description: The supported Azure location where the managed HSM Pool should be created.
+          x-ms-mutability:
+            - create
+            - read
+        sku:
+          $ref: '#/components/schemas/ManagedHsmSku'
+          description: SKU details
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: Resource tags
+        systemData:
+          $ref: '#/components/schemas/SystemData'
+        identity:
+          $ref: '#/components/schemas/ManagedServiceIdentity'
+      type: object
+    ManagedHsmResource:
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: The Azure Resource Manager resource ID for the managed HSM Pool.
+        name:
+          readOnly: true
+          type: string
+          description: The name of the managed HSM Pool.
+        type:
+          readOnly: true
+          type: string
+          description: The resource type of the managed HSM Pool.
+        location:
+          type: string
+          description: The supported Azure location where the managed HSM Pool should be created.
+          x-ms-mutability:
+            - create
+            - read
+        sku:
+          $ref: '#/components/schemas/ManagedHsmSku'
+          description: SKU details
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: Resource tags
+        systemData:
+          $ref: '#/components/schemas/SystemData'
+        identity:
+          $ref: '#/components/schemas/ManagedServiceIdentity'
+      description: Managed HSM resource
+      x-ms-azure-resource: true
+      type: object
+    ManagedHsmListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ManagedHsm'
+          description: The list of managed HSM Pools.
+        nextLink:
+          type: string
+          description: The URL to get the next set of managed HSM Pools.
+      description: List of managed HSM Pools
+      type: object
+    MHSMPrivateEndpointConnectionsListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/MHSMPrivateEndpointConnection'
+          description: The private endpoint connection associated with a managed HSM Pools.
+        nextLink:
+          type: string
+          description: The URL to get the next set of managed HSM Pools.
+      description: List of private endpoint connections associated with a managed HSM Pools
+      type: object
+    MHSMRegionsListResult:
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/MHSMGeoReplicatedRegion'
+          x-ms-identifiers:
+            - name
+          description: The region associated with a managed HSM Pools.
+        nextLink:
+          type: string
+          description: The URL to get the next set of managed HSM Pools.
+      description: List of regions associated with a managed HSM Pools
+    ManagedHsmError:
+      properties:
+        error:
+          readOnly: true
+          description: The server error.
+          $ref: '#/components/schemas/Error'
+      description: The error exception.
+      type: object
+    Error:
+      properties:
+        code:
+          type: string
+          readOnly: true
+          description: The error code.
+        message:
+          type: string
+          readOnly: true
+          description: The error message.
+        innererror:
+          x-ms-client-name: innerError
+          readOnly: true
+          description: 'The inner error, contains a more specific error code.'
+          $ref: '#/components/schemas/Error'
+      description: The server error.
+      type: object
+    DeletedManagedHsm:
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: The Azure Resource Manager resource ID for the deleted managed HSM Pool.
+        name:
+          readOnly: true
+          type: string
+          description: The name of the managed HSM Pool.
+        type:
+          readOnly: true
+          type: string
+          description: The resource type of the managed HSM Pool.
+        properties:
+          $ref: '#/components/schemas/DeletedManagedHsmProperties'
+          description: Properties of the deleted managed HSM
+      type: object
+    DeletedManagedHsmProperties:
+      properties:
+        mhsmId:
+          readOnly: true
+          type: string
+          description: The resource id of the original managed HSM.
+        location:
+          readOnly: true
+          type: string
+          description: The location of the original managed HSM.
+        deletionDate:
+          readOnly: true
+          type: string
+          format: date-time
+          description: The deleted date.
+        scheduledPurgeDate:
+          readOnly: true
+          type: string
+          format: date-time
+          description: The scheduled purged date.
+        purgeProtectionEnabled:
+          readOnly: true
+          type: boolean
+          description: Purge protection status of the original managed HSM.
+        tags:
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+          description: Tags of the original managed HSM.
+      description: Properties of the deleted managed HSM.
+      type: object
+    DeletedManagedHsmListResult:
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeletedManagedHsm'
+          description: The list of deleted managed HSM Pools.
+        nextLink:
+          type: string
+          description: The URL to get the next set of deleted managed HSM Pools.
+      description: List of deleted managed HSM Pools
+      type: object
+    MHSMGeoReplicatedRegion:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the geo replicated region.
+        provisioningState:
+          $ref: '#/components/schemas/MHSMGeoReplicationRegionProvisioningState'
+          description: Provisioning state of the geo replicated region.
+        isPrimary:
+          type: boolean
+          description: A boolean value that indicates whether the region is the primary region or a secondary region.
+      description: A region that this managed HSM Pool has been extended to.
+    MHSMNetworkRuleSet:
+      properties:
+        bypass:
+          type: string
+          description: Tells what traffic can bypass network rules. This can be 'AzureServices' or 'None'.  If not specified the default is 'AzureServices'.
+          enum:
+            - AzureServices
+            - None
+          x-ms-enum:
+            name: NetworkRuleBypassOptions
+            modelAsString: true
+        defaultAction:
+          type: string
+          description: The default action when no rule from ipRules and from virtualNetworkRules match. This is only used after the bypass property has been evaluated.
+          enum:
+            - Allow
+            - Deny
+          x-ms-enum:
+            name: NetworkRuleAction
+            modelAsString: true
+        ipRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/MHSMIPRule'
+          x-ms-identifiers:
+            - value
+          description: The list of IP address rules.
+        virtualNetworkRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/MHSMVirtualNetworkRule'
+          description: The list of virtual network rules.
+      description: A set of rules governing the network accessibility of a managed hsm pool.
+      type: object
+    MHSMIPRule:
+      properties:
+        value:
+          type: string
+          description: 'An IPv4 address range in CIDR notation, such as ''124.56.78.91'' (simple IP address) or ''124.56.78.0/24'' (all addresses that start with 124.56.78).'
+      required:
+        - value
+      description: A rule governing the accessibility of a managed HSM pool from a specific IP address or IP range.
+      type: object
+    MHSMVirtualNetworkRule:
+      properties:
+        id:
+          type: string
+          description: 'Full resource id of a vnet subnet, such as ''/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1''.'
+      required:
+        - id
+      description: A rule governing the accessibility of a managed hsm pool from a specific virtual network.
+      type: object
+    MHSMPrivateEndpointConnectionItem:
+      description: Private endpoint connection item.
+      properties:
+        id:
+          type: string
+          description: Id of private endpoint connection.
+        etag:
+          type: string
+          description: Modified whenever there is a change in the state of private endpoint connection.
+        properties:
+          $ref: '#/components/schemas/MHSMPrivateEndpointConnectionProperties'
+          x-ms-client-flatten: true
+          description: Private endpoint connection properties.
+      type: object
+    MHSMPrivateEndpointConnection:
+      description: Private endpoint connection resource.
+      x-ms-azure-resource: true
+      properties:
+        properties:
+          $ref: '#/components/schemas/MHSMPrivateEndpointConnectionProperties'
+          x-ms-client-flatten: true
+          description: Resource properties.
+        etag:
+          type: string
+          description: Modified whenever there is a change in the state of private endpoint connection.
+        id:
+          readOnly: true
+          type: string
+          description: The Azure Resource Manager resource ID for the managed HSM Pool.
+        name:
+          readOnly: true
+          type: string
+          description: The name of the managed HSM Pool.
+        type:
+          readOnly: true
+          type: string
+          description: The resource type of the managed HSM Pool.
+        location:
+          type: string
+          description: The supported Azure location where the managed HSM Pool should be created.
+          x-ms-mutability:
+            - create
+            - read
+        sku:
+          $ref: '#/components/schemas/ManagedHsmSku'
+          description: SKU details
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: Resource tags
+        systemData:
+          $ref: '#/components/schemas/SystemData'
+        identity:
+          $ref: '#/components/schemas/ManagedServiceIdentity'
+      type: object
+    MHSMPrivateEndpointConnectionProperties:
+      properties:
+        privateEndpoint:
+          $ref: '#/components/schemas/MHSMPrivateEndpoint'
+          description: Properties of the private endpoint object.
+        privateLinkServiceConnectionState:
+          $ref: '#/components/schemas/MHSMPrivateLinkServiceConnectionState'
+          description: Approval state of the private link connection.
+        provisioningState:
+          $ref: '#/components/schemas/MHSMPrivateEndpointConnectionProvisioningState'
+          description: Provisioning state of the private endpoint connection.
+      description: Properties of the private endpoint connection resource.
+      type: object
+    MHSMPrivateEndpoint:
+      properties:
+        id:
+          readOnly: true
+          type: string
+          description: Full identifier of the private endpoint resource.
+      description: Private endpoint object properties.
+      type: object
+    MHSMPrivateLinkServiceConnectionState:
+      properties:
+        status:
+          $ref: '#/components/schemas/MHSMPrivateEndpointServiceConnectionStatus'
+          description: 'Indicates whether the connection has been approved, rejected or removed by the key vault owner.'
+        description:
+          type: string
+          description: The reason for approval or rejection.
+        actionsRequired:
+          type: string
+          description: A message indicating if changes on the service provider require any updates on the consumer.
+          enum:
+            - None
+          x-ms-enum:
+            name: ActionsRequired
+            modelAsString: true
+      description: An object that represents the approval state of the private link connection.
+      type: object
+    MHSMPrivateEndpointServiceConnectionStatus:
+      type: string
+      description: The private endpoint connection status.
+      enum:
+        - Pending
+        - Approved
+        - Rejected
+        - Disconnected
+      x-ms-enum:
+        name: PrivateEndpointServiceConnectionStatus
+        modelAsString: true
+    MHSMPrivateEndpointConnectionProvisioningState:
+      type: string
+      readOnly: true
+      description: The current provisioning state.
+      enum:
+        - Succeeded
+        - Creating
+        - Updating
+        - Deleting
+        - Failed
+        - Disconnected
+      x-ms-enum:
+        name: PrivateEndpointConnectionProvisioningState
+        modelAsString: true
+    MHSMPrivateLinkResourceListResult:
+      properties:
+        value:
+          type: array
+          description: Array of private link resources
+          items:
+            $ref: '#/components/schemas/MHSMPrivateLinkResource'
+      description: A list of private link resources
+      type: object
+    MHSMPrivateLinkResource:
+      description: A private link resource
+      properties:
+        properties:
+          $ref: '#/components/schemas/MHSMPrivateLinkResourceProperties'
+          description: Resource properties.
+          x-ms-client-flatten: true
+        id:
+          readOnly: true
+          type: string
+          description: The Azure Resource Manager resource ID for the managed HSM Pool.
+        name:
+          readOnly: true
+          type: string
+          description: The name of the managed HSM Pool.
+        type:
+          readOnly: true
+          type: string
+          description: The resource type of the managed HSM Pool.
+        location:
+          type: string
+          description: The supported Azure location where the managed HSM Pool should be created.
+          x-ms-mutability:
+            - create
+            - read
+        sku:
+          $ref: '#/components/schemas/ManagedHsmSku'
+          description: SKU details
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: Resource tags
+        systemData:
+          $ref: '#/components/schemas/SystemData'
+        identity:
+          $ref: '#/components/schemas/ManagedServiceIdentity'
+      type: object
+    MHSMPrivateLinkResourceProperties:
+      properties:
+        groupId:
+          description: Group identifier of private link resource.
+          type: string
+          readOnly: true
+        requiredMembers:
+          description: Required member names of private link resource.
+          type: array
+          items:
+            type: string
+          readOnly: true
+        requiredZoneNames:
+          type: array
+          items:
+            type: string
+          description: Required DNS zone names of the the private link resource.
+      description: Properties of a private link resource.
+      type: object
+    MHSMGeoReplicationRegionProvisioningState:
+      type: string
+      readOnly: true
+      description: The current provisioning state.
+      enum:
+        - Preprovisioning
+        - Provisioning
+        - Succeeded
+        - Failed
+        - Deleting
+        - Cleanup
+      x-ms-enum:
+        name: GeoReplicationRegionProvisioningState
+        modelAsString: true
+    CheckMhsmNameAvailabilityParameters:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The managed hsm name.
+      required:
+        - name
+      description: The parameters used to check the availability of the managed hsm name.
+    CheckMhsmNameAvailabilityResult:
+      type: object
+      properties:
+        nameAvailable:
+          readOnly: true
+          type: boolean
+          description: 'A boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or is invalid and cannot be used.'
+        reason:
+          readOnly: true
+          type: string
+          description: The reason that a managed hsm name could not be used. The reason element is only returned if NameAvailable is false.
+          enum:
+            - AccountNameInvalid
+            - AlreadyExists
+          x-ms-enum:
+            name: Reason
+            modelAsString: true
+        message:
+          readOnly: true
+          type: string
+          description: An error message explaining the Reason value in more detail.
+      description: The CheckMhsmNameAvailability operation response.
+    ManagedHSMSecurityDomainProperties:
+      type: object
+      properties:
+        activationStatus:
+          readOnly: true
+          type: string
+          description: Activation Status
+          enum:
+            - Active
+            - NotActivated
+            - Unknown
+            - Failed
+          x-ms-enum:
+            name: ActivationStatus
+            modelAsString: true
+            values:
+              - value: Active
+                description: The managed HSM Pool is active.
+              - value: NotActivated
+                description: The managed HSM Pool is not yet activated.
+              - value: Unknown
+                description: An unknown error occurred while activating managed hsm.
+              - value: Failed
+                description: Failed to activate managed hsm.
+        activationStatusMessage:
+          readOnly: true
+          type: string
+          description: Activation Status Message.
+      description: The security domain properties of the managed hsm.
+    UserAssignedIdentities:
+      title: User-Assigned Identities
+      description: 'The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: ''/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.'
+      additionalProperties:
+        $ref: '#/components/schemas/UserAssignedIdentity'
+        nullable: true
+        x-nullable: true
+      properties: {}
+      type: object
+    UserAssignedIdentity:
+      type: object
+      description: User assigned identity properties
+      properties:
+        principalId:
+          description: The principal ID of the assigned identity.
+          format: uuid
+          type: string
+          readOnly: true
+        clientId:
+          description: The client ID of the assigned identity.
+          format: uuid
+          type: string
+          readOnly: true
+    ManagedServiceIdentityType:
+      description: Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
+      enum:
+        - None
+        - SystemAssigned
+        - UserAssigned
+        - 'SystemAssigned,UserAssigned'
+      type: string
+      x-ms-enum:
+        name: ManagedServiceIdentityType
+        modelAsString: true
+    ManagedServiceIdentity:
+      description: Managed service identity (system assigned and/or user assigned identities)
+      type: object
+      properties:
+        principalId:
+          readOnly: true
+          format: uuid
+          type: string
+          description: The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.
+        tenantId:
+          readOnly: true
+          format: uuid
+          type: string
+          description: The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.
+        type:
+          $ref: '#/components/schemas/ManagedServiceIdentityType'
+        userAssignedIdentities:
+          $ref: '#/components/schemas/UserAssignedIdentities'
+      required:
+        - type
+    SystemAssignedServiceIdentityType:
+      description: 'Type of managed service identity (either system assigned, or none).'
+      enum:
+        - None
+        - SystemAssigned
+      type: string
+      x-ms-enum:
+        name: SystemAssignedServiceIdentityType
+        modelAsString: true
+    SystemAssignedServiceIdentity:
+      description: 'Managed service identity (either system assigned, or none)'
+      type: object
+      properties:
+        principalId:
+          readOnly: true
+          format: uuid
+          type: string
+          description: The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.
+        tenantId:
+          readOnly: true
+          format: uuid
+          type: string
+          description: The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.
+        type:
+          $ref: '#/components/schemas/SystemAssignedServiceIdentityType'
+      required:
+        - type
+  x-stackQL-resources:
+    keys:
+      id: azure.key_vault.keys
+      name: keys
+      title: Keys
+      methods:
+        create_if_not_exist:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1keys~1{keyName}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1keys~1{keyName}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1keys~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1keys~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/keys/methods/get'
+          - $ref: '#/components/x-stackQL-resources/keys/methods/list'
+        insert: []
+        update: []
+        delete: []
+    keys_version:
+      id: azure.key_vault.keys_version
+      name: keys_version
+      title: Keys Version
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1keys~1{keyName}~1versions~1{keyVersion}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/keys_version/methods/get'
+        insert: []
+        update: []
+        delete: []
+    keys_versions:
+      id: azure.key_vault.keys_versions
+      name: keys_versions
+      title: Keys Versions
+      methods:
+        list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1keys~1{keyName}~1versions~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1keys~1{keyName}~1versions~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/keys_versions/methods/list'
+        insert: []
+        update: []
+        delete: []
+    managed_hsm_keys:
+      id: azure.key_vault.managed_hsm_keys
+      name: managed_hsm_keys
+      title: Managed Hsm Keys
+      methods:
+        create_if_not_exist:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1keys~1{keyName}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1keys~1{keyName}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1keys~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1keys~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/managed_hsm_keys/methods/get'
+          - $ref: '#/components/x-stackQL-resources/managed_hsm_keys/methods/list'
+        insert: []
+        update: []
+        delete: []
+    managed_hsm_keys_version:
+      id: azure.key_vault.managed_hsm_keys_version
+      name: managed_hsm_keys_version
+      title: Managed Hsm Keys Version
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1keys~1{keyName}~1versions~1{keyVersion}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/managed_hsm_keys_version/methods/get'
+        insert: []
+        update: []
+        delete: []
+    managed_hsm_keys_versions:
+      id: azure.key_vault.managed_hsm_keys_versions
+      name: managed_hsm_keys_versions
+      title: Managed Hsm Keys Versions
+      methods:
+        list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1keys~1{keyName}~1versions~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1keys~1{keyName}~1versions~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/managed_hsm_keys_versions/methods/list'
+        insert: []
+        update: []
+        delete: []
+    operations:
+      id: azure.key_vault.operations
+      name: operations
+      title: Operations
+      methods:
+        list:
+          operation:
+            $ref: '#/paths/~1providers~1Microsoft.KeyVault~1operations~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1providers~1Microsoft.KeyVault~1operations~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/operations/methods/list'
+        insert: []
+        update: []
+        delete: []
+    secrets:
+      id: azure.key_vault.secrets
+      name: secrets
+      title: Secrets
+      methods:
+        create_or_update:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1secrets~1{secretName}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        update:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1secrets~1{secretName}~1?api-version=2023-07-01/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1secrets~1{secretName}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1secrets~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1secrets~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/secrets/methods/get'
+          - $ref: '#/components/x-stackQL-resources/secrets/methods/list'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/secrets/methods/create_or_update'
+        update: []
+        delete: []
+    vaults:
+      id: azure.key_vault.vaults
+      name: vaults
+      title: Vaults
+      methods:
+        create_or_update:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        update:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1?api-version=2023-07-01/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        delete:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1?api-version=2023-07-01/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list_by_resource_group:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_resource_group:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list_by_subscription:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1vaults~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_subscription:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1vaults~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        purge_deleted:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1locations~1{location}~1deletedVaults~1{vaultName}~1purge~1?api-version=2023-07-01/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        exec_list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resources~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _exec_list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resources~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        check_name_availability:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1checkNameAvailability~1?api-version=2023-07-01/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/vaults/methods/get'
+          - $ref: '#/components/x-stackQL-resources/vaults/methods/list_by_resource_group'
+          - $ref: '#/components/x-stackQL-resources/vaults/methods/list_by_subscription'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/vaults/methods/create_or_update'
+        update: []
+        delete:
+          - $ref: '#/components/x-stackQL-resources/vaults/methods/delete'
+    vaults_access_policy:
+      id: azure.key_vault.vaults_access_policy
+      name: vaults_access_policy
+      title: Vaults Access Policy
+      methods:
+        update:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1accessPolicies~1{operationKind}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select: []
+        insert: []
+        update: []
+        delete: []
+    vaults_deleted:
+      id: azure.key_vault.vaults_deleted
+      name: vaults_deleted
+      title: Vaults Deleted
+      methods:
+        list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1deletedVaults~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1deletedVaults~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1locations~1{location}~1deletedVaults~1{vaultName}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/vaults_deleted/methods/get'
+          - $ref: '#/components/x-stackQL-resources/vaults_deleted/methods/list'
+        insert: []
+        update: []
+        delete: []
+    private_endpoint_connections:
+      id: azure.key_vault.private_endpoint_connections
+      name: private_endpoint_connections
+      title: Private Endpoint Connections
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        put:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        delete:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-07-01/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list_by_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1privateEndpointConnections~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1privateEndpointConnections~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/private_endpoint_connections/methods/get'
+          - $ref: '#/components/x-stackQL-resources/private_endpoint_connections/methods/list_by_resource'
+        insert: []
+        update: []
+        delete:
+          - $ref: '#/components/x-stackQL-resources/private_endpoint_connections/methods/delete'
+    private_link_resources:
+      id: azure.key_vault.private_link_resources
+      name: private_link_resources
+      title: Private Link Resources
+      methods:
+        list_by_vault:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1privateLinkResources~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_vault:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1vaults~1{vaultName}~1privateLinkResources~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/private_link_resources/methods/list_by_vault'
+        insert: []
+        update: []
+        delete: []
+    managed_hsms:
+      id: azure.key_vault.managed_hsms
+      name: managed_hsms
+      title: Managed Hsms
+      methods:
+        create_or_update:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        update:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1?api-version=2023-07-01/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        delete:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1?api-version=2023-07-01/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list_by_resource_group:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_resource_group:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        list_by_subscription:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1managedHSMs~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_subscription:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1managedHSMs~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        purge_deleted:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1locations~1{location}~1deletedManagedHSMs~1{name}~1purge~1?api-version=2023-07-01/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '202'
+        check_mhsm_name_availability:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1checkMhsmNameAvailability~1?api-version=2023-07-01/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/managed_hsms/methods/get'
+          - $ref: '#/components/x-stackQL-resources/managed_hsms/methods/list_by_resource_group'
+          - $ref: '#/components/x-stackQL-resources/managed_hsms/methods/list_by_subscription'
+        insert:
+          - $ref: '#/components/x-stackQL-resources/managed_hsms/methods/create_or_update'
+        update: []
+        delete:
+          - $ref: '#/components/x-stackQL-resources/managed_hsms/methods/delete'
+    mhsm_private_endpoint_connections:
+      id: azure.key_vault.mhsm_private_endpoint_connections
+      name: mhsm_private_endpoint_connections
+      title: Mhsm Private Endpoint Connections
+      methods:
+        list_by_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1privateEndpointConnections~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1privateEndpointConnections~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        put:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-07-01/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        delete:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1privateEndpointConnections~1{privateEndpointConnectionName}~1?api-version=2023-07-01/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/mhsm_private_endpoint_connections/methods/get'
+          - $ref: '#/components/x-stackQL-resources/mhsm_private_endpoint_connections/methods/list_by_resource'
+        insert: []
+        update: []
+        delete:
+          - $ref: '#/components/x-stackQL-resources/mhsm_private_endpoint_connections/methods/delete'
+    managed_hsms_deleted:
+      id: azure.key_vault.managed_hsms_deleted
+      name: managed_hsms_deleted
+      title: Managed Hsms Deleted
+      methods:
+        list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1deletedManagedHSMs~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1deletedManagedHSMs~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        get:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.KeyVault~1locations~1{location}~1deletedManagedHSMs~1{name}~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/managed_hsms_deleted/methods/get'
+          - $ref: '#/components/x-stackQL-resources/managed_hsms_deleted/methods/list'
+        insert: []
+        update: []
+        delete: []
+    mhsm_private_link_resources:
+      id: azure.key_vault.mhsm_private_link_resources
+      name: mhsm_private_link_resources
+      title: Mhsm Private Link Resources
+      methods:
+        list_by_mhsm_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1privateLinkResources~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_mhsm_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1privateLinkResources~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/mhsm_private_link_resources/methods/list_by_mhsm_resource'
+        insert: []
+        update: []
+        delete: []
+    mhsm_regions:
+      id: azure.key_vault.mhsm_regions
+      name: mhsm_regions
+      title: Mhsm Regions
+      methods:
+        list_by_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1regions~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+            objectKey: $.value
+        _list_by_resource:
+          operation:
+            $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.KeyVault~1managedHSMs~1{name}~1regions~1?api-version=2023-07-01/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/mhsm_regions/methods/list_by_resource'
+        insert: []
+        update: []
+        delete: []
+paths:
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/keys/{keyName}/?api-version=2023-07-01':
+    put:
+      tags:
+        - Keys
+      operationId: Keys_CreateIfNotExist
+      description: 'Creates the first version of a new key if it does not exist. If it already exists, then the existing key is returned without any write operations being performed. This API does not create subsequent versions, and does not update existing keys.'
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - name: resourceGroupName
+          in: path
+          description: The name of the resource group which contains the specified key vault.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the key vault which contains the key to be created.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - name: keyName
+          in: path
+          description: The name of the key to be created. The value you provide may be copied globally for the purpose of running the service. The value provided should not include personally identifiable or sensitive information.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{1,127}$'
+            type: string
+      requestBody:
+        description: The parameters used to create the specified key.
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KeyCreateParameters'
+      responses:
+        '200':
+          description: The created key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: keys
+      x-stackQL-method: create_if_not_exist
+      x-stackQL-verb: exec
+    get:
+      tags:
+        - Keys
+      operationId: Keys_Get
+      description: Gets the current version of the specified key from the specified key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - name: resourceGroupName
+          in: path
+          description: The name of the resource group which contains the specified key vault.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault which contains the key to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - name: keyName
+          in: path
+          description: The name of the key to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{1,127}$'
+            type: string
+      responses:
+        '200':
+          description: The retrieved key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: keys
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/keys/?api-version=2023-07-01':
+    get:
+      tags:
+        - Keys
+      operationId: Keys_List
+      description: Lists the keys in the specified key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - name: resourceGroupName
+          in: path
+          description: The name of the resource group which contains the specified key vault.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault which contains the keys to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+      responses:
+        '200':
+          description: The retrieved page of keys.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: keys
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/keys/{keyName}/versions/{keyVersion}/?api-version=2023-07-01':
+    get:
+      tags:
+        - Keys
+      operationId: Keys_GetVersion
+      description: Gets the specified version of the specified key in the specified key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - name: resourceGroupName
+          in: path
+          description: The name of the resource group which contains the specified key vault.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault which contains the key version to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - name: keyName
+          in: path
+          description: The name of the key version to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{1,127}$'
+            type: string
+        - name: keyVersion
+          in: path
+          description: The version of the key to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-fA-F0-9]{32}$'
+            type: string
+      responses:
+        '200':
+          description: The retrieved key version.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: keys_version
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/keys/{keyName}/versions/?api-version=2023-07-01':
+    get:
+      tags:
+        - Keys
+      operationId: Keys_ListVersions
+      description: Lists the versions of the specified key in the specified key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - name: resourceGroupName
+          in: path
+          description: The name of the resource group which contains the specified key vault.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault which contains the key versions to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - name: keyName
+          in: path
+          description: The name of the key versions to be retrieved.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{1,127}$'
+            type: string
+      responses:
+        '200':
+          description: The retrieved page of key versions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: keys_versions
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/keys/{keyName}/?api-version=2023-07-01':
+    put:
+      tags:
+        - ManagedHsmKeys
+      operationId: ManagedHsmKeys_CreateIfNotExist
+      description: 'Creates the first version of a new key if it does not exist. If it already exists, then the existing key is returned without any write operations being performed. This API does not create subsequent versions, and does not update existing keys.'
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupNameParameter'
+        - $ref: '#/components/parameters/ManagedHSMName'
+        - $ref: '#/components/parameters/ManagedHSMKeyName'
+      requestBody:
+        description: The parameters used to create the specified key.
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagedHsmKeyCreateParameters'
+      responses:
+        '200':
+          description: The created key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmKey'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: managed_hsm_keys
+      x-stackQL-method: create_if_not_exist
+      x-stackQL-verb: exec
+    get:
+      tags:
+        - ManagedHsmKeys
+      operationId: ManagedHsmKeys_Get
+      description: Gets the current version of the specified key from the specified managed HSM.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupNameParameter'
+        - $ref: '#/components/parameters/ManagedHSMName'
+        - $ref: '#/components/parameters/ManagedHSMKeyName'
+      responses:
+        '200':
+          description: The retrieved key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmKey'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: managed_hsm_keys
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/keys/?api-version=2023-07-01':
+    get:
+      tags:
+        - ManagedHsmKeys
+      operationId: ManagedHsmKeys_List
+      description: Lists the keys in the specified managed HSM.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupNameParameter'
+        - $ref: '#/components/parameters/ManagedHSMName'
+      responses:
+        '200':
+          description: The retrieved page of keys.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmKeyListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: managed_hsm_keys
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/keys/{keyName}/versions/{keyVersion}/?api-version=2023-07-01':
+    get:
+      tags:
+        - ManagedHsmKeys
+      operationId: ManagedHsmKeys_GetVersion
+      description: Gets the specified version of the specified key in the specified managed HSM.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupNameParameter'
+        - $ref: '#/components/parameters/ManagedHSMName'
+        - $ref: '#/components/parameters/ManagedHSMKeyName'
+        - $ref: '#/components/parameters/ManagedHSMKeyVersion'
+      responses:
+        '200':
+          description: The retrieved key version.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmKey'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: managed_hsm_keys_version
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/keys/{keyName}/versions/?api-version=2023-07-01':
+    get:
+      tags:
+        - ManagedHsmKeys
+      operationId: ManagedHsmKeys_ListVersions
+      description: Lists the versions of the specified key in the specified managed HSM.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupNameParameter'
+        - $ref: '#/components/parameters/ManagedHSMName'
+        - $ref: '#/components/parameters/ManagedHSMKeyName'
+      responses:
+        '200':
+          description: The retrieved page of key versions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmKeyListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: managed_hsm_keys_versions
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  /providers/Microsoft.KeyVault/operations/?api-version=2023-07-01:
+    get:
+      tags:
+        - Operations
+      description: Lists all of the available Key Vault Rest API operations.
+      operationId: Operations_List
+      parameters: []
+      responses:
+        '200':
+          description: OK. The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: operations
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/secrets/{secretName}/?api-version=2023-07-01':
+    put:
+      tags:
+        - Secrets
+      operationId: Secrets_CreateOrUpdate
+      description: 'Create or update a secret in a key vault in the specified subscription.  NOTE: This API is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets.'
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: Name of the vault
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - name: secretName
+          in: path
+          description: Name of the secret. The value you provide may be copied globally for the purpose of running the service. The value provided should not include personally identifiable or sensitive information.
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{1,127}$'
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      requestBody:
+        description: Parameters to create or update the secret
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretCreateOrUpdateParameters'
+      responses:
+        '200':
+          description: Created or updated secret
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Secret'
+        '201':
+          description: Created or updated vault
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Secret'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: secrets
+      x-stackQL-method: create_or_update
+      x-stackQL-verb: insert
+    patch:
+      tags:
+        - Secrets
+      operationId: Secrets_Update
+      description: 'Update a secret in the specified subscription.  NOTE: This API is intended for internal use in ARM deployments.  Users should use the data-plane REST service for interaction with vault secrets.'
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: Name of the vault
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - name: secretName
+          in: path
+          description: Name of the secret
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{1,127}$'
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      requestBody:
+        description: Parameters to patch the secret
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretPatchParameters'
+      responses:
+        '200':
+          description: Patched secret
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Secret'
+        '201':
+          description: Patched secret
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Secret'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: secrets
+      x-stackQL-method: update
+      x-stackQL-verb: exec
+    get:
+      tags:
+        - Secrets
+      operationId: Secrets_Get
+      description: 'Gets the specified secret.  NOTE: This API is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets.'
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault.
+          required: true
+          schema:
+            type: string
+        - name: secretName
+          in: path
+          description: The name of the secret.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Retrieved secret
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Secret'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: secrets
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/secrets/?api-version=2023-07-01':
+    get:
+      tags:
+        - Secrets
+      operationId: Secrets_List
+      description: 'The List operation gets information about the secrets in a vault.  NOTE: This API is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets.'
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault.
+          required: true
+          schema:
+            type: string
+        - name: $top
+          in: query
+          description: Maximum number of results to return.
+          schema:
+            format: int32
+            type: integer
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Get information about secrets in the specified vault.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: secrets
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/?api-version=2023-07-01':
+    put:
+      tags:
+        - Vaults
+      operationId: Vaults_CreateOrUpdate
+      x-ms-long-running-operation: true
+      description: Create or update a key vault in the specified subscription.
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the server belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: Name of the vault
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      requestBody:
+        description: Parameters to create or update the vault
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VaultCreateOrUpdateParameters'
+      responses:
+        '200':
+          description: Created or updated vault
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+        '201':
+          description: Created or updated vault
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults
+      x-stackQL-method: create_or_update
+      x-stackQL-verb: insert
+    patch:
+      tags:
+        - Vaults
+      operationId: Vaults_Update
+      description: Update a key vault in the specified subscription.
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the server belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: Name of the vault
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      requestBody:
+        description: Parameters to patch the vault
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VaultPatchParameters'
+      responses:
+        '200':
+          description: Patched vault
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+        '201':
+          description: Patched vault
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults
+      x-stackQL-method: update
+      x-stackQL-verb: exec
+    delete:
+      tags:
+        - Vaults
+      operationId: Vaults_Delete
+      description: Deletes the specified Azure key vault.
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault to delete
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: OK Response.
+        '204':
+          description: No Content.
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults
+      x-stackQL-method: delete
+      x-stackQL-verb: delete
+    get:
+      tags:
+        - Vaults
+      operationId: Vaults_Get
+      description: Gets the specified Azure key vault.
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: The name of the vault.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Retrieved vault
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/accessPolicies/{operationKind}/?api-version=2023-07-01':
+    put:
+      tags:
+        - Vaults
+      operationId: Vaults_UpdateAccessPolicy
+      description: Update access policies in a key vault in the specified subscription.
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: vaultName
+          in: path
+          description: Name of the vault
+          required: true
+          schema:
+            pattern: '^[a-zA-Z0-9-]{3,24}$'
+            type: string
+        - name: operationKind
+          in: path
+          description: Name of the operation
+          required: true
+          schema:
+            enum:
+              - add
+              - replace
+              - remove
+            x-ms-enum:
+              name: AccessPolicyUpdateKind
+              modelAsString: false
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      requestBody:
+        description: Access policy to merge into the vault
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VaultAccessPolicyParameters'
+      responses:
+        '200':
+          description: The updated access policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultAccessPolicyParameters'
+        '201':
+          description: The updated access policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultAccessPolicyParameters'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults_access_policy
+      x-stackQL-method: update
+      x-stackQL-verb: exec
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/?api-version=2023-07-01':
+    get:
+      tags:
+        - Vaults
+      operationId: Vaults_ListByResourceGroup
+      description: The List operation gets information about the vaults associated with the subscription and within the specified resource group.
+      parameters:
+        - name: resourceGroupName
+          in: path
+          description: The name of the Resource Group to which the vault belongs.
+          required: true
+          schema:
+            type: string
+        - name: $top
+          in: query
+          description: Maximum number of results to return.
+          schema:
+            format: int32
+            type: integer
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Get information about all key vaults in the specified resource group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: vaults
+      x-stackQL-method: list_by_resource_group
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/vaults/?api-version=2023-07-01':
+    get:
+      tags:
+        - Vaults
+      operationId: Vaults_ListBySubscription
+      description: The List operation gets information about the vaults associated with the subscription.
+      parameters:
+        - name: $top
+          in: query
+          description: Maximum number of results to return.
+          schema:
+            format: int32
+            type: integer
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Get information about all key vaults in the specified subscription.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: vaults
+      x-stackQL-method: list_by_subscription
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/deletedVaults/?api-version=2023-07-01':
+    get:
+      tags:
+        - Vaults
+      operationId: Vaults_ListDeleted
+      description: Gets information about the deleted vaults in a subscription.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Retrieved information about all deleted key vaults in a subscription.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedVaultListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: vaults_deleted
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}/?api-version=2023-07-01':
+    get:
+      tags:
+        - Vaults
+      operationId: Vaults_GetDeleted
+      description: Gets the deleted Azure key vault.
+      parameters:
+        - name: vaultName
+          in: path
+          description: The name of the vault.
+          required: true
+          schema:
+            type: string
+        - name: location
+          in: path
+          description: The location of the deleted vault.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Retrieved information about the deleted vault.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedVault'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults_deleted
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}/purge/?api-version=2023-07-01':
+    post:
+      tags:
+        - Vaults
+      operationId: Vaults_PurgeDeleted
+      x-ms-long-running-operation: true
+      description: Permanently deletes the specified vault. aka Purges the deleted Azure key vault.
+      parameters:
+        - name: vaultName
+          in: path
+          description: The name of the soft-deleted vault.
+          required: true
+          schema:
+            type: string
+        - name: location
+          in: path
+          description: The location of the soft-deleted vault.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: The vault is purged.
+        '202':
+          description: Vault is being purged.
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults
+      x-stackQL-method: purge_deleted
+      x-stackQL-verb: exec
+  '/subscriptions/{subscriptionId}/resources/?api-version=2023-07-01':
+    get:
+      tags:
+        - Vaults
+      operationId: Vaults_List
+      description: The List operation gets information about the vaults associated with the subscription.
+      parameters:
+        - name: $filter
+          in: query
+          description: The filter to apply on the operation.
+          required: true
+          schema:
+            enum:
+              - resourceType eq 'Microsoft.KeyVault/vaults'
+            x-ms-enum:
+              name: VaultListFilterTypes
+              modelAsString: false
+            type: string
+        - name: $top
+          in: query
+          description: Maximum number of results to return.
+          schema:
+            format: int32
+            type: integer
+        - name: api-version
+          in: query
+          description: Azure Resource Manager Api Version.
+          required: true
+          x-ms-api-version: false
+          schema:
+            enum:
+              - '2015-11-01'
+            x-ms-enum:
+              name: ResourceManagerApiVersions
+              modelAsString: false
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Get information about all key vaults in the subscription.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: vaults
+      x-stackQL-method: exec_list
+      x-stackQL-verb: exec
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/checkNameAvailability/?api-version=2023-07-01':
+    post:
+      tags:
+        - Vaults
+      operationId: Vaults_CheckNameAvailability
+      description: Checks that the vault name is valid and is not already in use.
+      requestBody:
+        description: The name of the vault.
+        required: true
+        x-ms-requestBody-name: vaultName
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VaultCheckNameAvailabilityParameters'
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: OK -- Operation to check the vault name availability was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckNameAvailabilityResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: vaults
+      x-stackQL-method: check_name_availability
+      x-stackQL-verb: exec
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}/?api-version=2023-07-01':
+    get:
+      tags:
+        - PrivateEndpointConnections
+      operationId: PrivateEndpointConnections_Get
+      description: Gets the specified private endpoint connection associated with the key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupName'
+        - $ref: '#/components/parameters/VaultName'
+        - $ref: '#/components/parameters/PrivateEndpointConnectionName'
+      responses:
+        '200':
+          description: Private endpoint connection successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateEndpointConnection'
+        '204':
+          description: The private endpoint connection does not exist.
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: private_endpoint_connections
+      x-stackQL-method: get
+      x-stackQL-verb: select
+    put:
+      tags:
+        - PrivateEndpointConnections
+      operationId: PrivateEndpointConnections_Put
+      description: Updates the specified private endpoint connection associated with the key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupName'
+        - $ref: '#/components/parameters/VaultName'
+        - $ref: '#/components/parameters/PrivateEndpointConnectionName'
+      requestBody:
+        description: The intended state of private endpoint connection.
+        required: true
+        x-ms-requestBody-name: properties
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrivateEndpointConnection'
+      responses:
+        '200':
+          description: The state of private endpoint connection was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateEndpointConnection'
+          headers:
+            Retry-After:
+              schema:
+                format: int32
+                type: integer
+              description: (specified only if operation does not finish synchronously) The recommended number of seconds to wait before calling the URI specified in Azure-AsyncOperation.
+            Azure-AsyncOperation:
+              schema:
+                type: string
+              description: (specified only if operation does not finish synchronously) The URI to poll for completion status. The response of this URI may be synchronous or asynchronous.
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: private_endpoint_connections
+      x-stackQL-method: put
+      x-stackQL-verb: exec
+    delete:
+      tags:
+        - PrivateEndpointConnections
+      operationId: PrivateEndpointConnections_Delete
+      description: Deletes the specified private endpoint connection associated with the key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupName'
+        - $ref: '#/components/parameters/VaultName'
+        - $ref: '#/components/parameters/PrivateEndpointConnectionName'
+      responses:
+        '200':
+          description: The private endpoint connection was successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateEndpointConnection'
+        '202':
+          description: The private endpoint connection is being deleted.
+          headers:
+            Retry-After:
+              schema:
+                format: int32
+                type: integer
+              description: The recommended number of seconds to wait before calling the URI specified in the location header.
+            Location:
+              schema:
+                type: string
+              description: The URI to poll for completion status.
+        '204':
+          description: The private endpoint connection does not exist.
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-long-running-operation: true
+      x-stackQL-resource: private_endpoint_connections
+      x-stackQL-method: delete
+      x-stackQL-verb: delete
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/privateEndpointConnections/?api-version=2023-07-01':
+    get:
+      tags:
+        - PrivateEndpointConnections
+      operationId: PrivateEndpointConnections_ListByResource
+      description: The List operation gets information about the private endpoint connections associated with the vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupName'
+        - $ref: '#/components/parameters/VaultName'
+      responses:
+        '200':
+          description: Get information about all private endpoint connections in the specified resource group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateEndpointConnectionListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: private_endpoint_connections
+      x-stackQL-method: list_by_resource
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/privateLinkResources/?api-version=2023-07-01':
+    get:
+      tags:
+        - PrivateLinkResources
+      operationId: PrivateLinkResources_ListByVault
+      description: Gets the private link resources supported for the key vault.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ResourceGroupName'
+        - $ref: '#/components/parameters/VaultName'
+      responses:
+        '200':
+          description: Successfully retrieved private link resources.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrivateLinkResourceListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: private_link_resources
+      x-stackQL-method: list_by_vault
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/?api-version=2023-07-01':
+    put:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_CreateOrUpdate
+      x-ms-long-running-operation: true
+      description: Create or update a managed HSM Pool in the specified subscription.
+      parameters:
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      requestBody:
+        description: Parameters to create or update the managed HSM Pool
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagedHsm'
+      responses:
+        '200':
+          description: Created or updated managed HSM Pool
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsm'
+        '202':
+          description: Accepted and the operation will complete asynchronously.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsm'
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The URI to poll for completion status.
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: create_or_update
+      x-stackQL-verb: insert
+    patch:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_Update
+      x-ms-long-running-operation: true
+      description: Update a managed HSM Pool in the specified subscription.
+      parameters:
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      requestBody:
+        description: Parameters to patch the managed HSM Pool
+        required: true
+        x-ms-requestBody-name: parameters
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagedHsm'
+      responses:
+        '200':
+          description: Patched managed HSM Pool
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsm'
+        '202':
+          description: Accepted and the operation will complete asynchronously.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsm'
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The URI to poll for completion status.
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: update
+      x-stackQL-verb: exec
+    delete:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_Delete
+      x-ms-long-running-operation: true
+      description: Deletes the specified managed HSM Pool.
+      parameters:
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: The name of the managed HSM Pool to delete
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Delete successful.
+        '202':
+          description: Accepted and the operation will complete asynchronously.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The URI to poll for completion status.
+        '204':
+          description: Request successful. Resource does not exist.
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: delete
+      x-stackQL-verb: delete
+    get:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_Get
+      description: Gets the specified managed HSM Pool.
+      parameters:
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: The name of the managed HSM Pool.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Retrieved managed HSM Pool
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsm'
+        '204':
+          description: Request successful. Resource does not exist.
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/?api-version=2023-07-01':
+    get:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_ListByResourceGroup
+      description: The List operation gets information about the managed HSM Pools associated with the subscription and within the specified resource group.
+      parameters:
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: $top
+          in: query
+          description: Maximum number of results to return.
+          schema:
+            format: int32
+            type: integer
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Get information about all managed HSM Pools in the specified resource group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmListResult'
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: list_by_resource_group
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/managedHSMs/?api-version=2023-07-01':
+    get:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_ListBySubscription
+      description: The List operation gets information about the managed HSM Pools associated with the subscription.
+      parameters:
+        - name: $top
+          in: query
+          description: Maximum number of results to return.
+          schema:
+            format: int32
+            type: integer
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Get information about all managed HSM Pools in the specified subscription.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmListResult'
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: list_by_subscription
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/privateEndpointConnections/?api-version=2023-07-01':
+    get:
+      tags:
+        - MHSMListPrivateEndpointConnections
+      operationId: MHSMPrivateEndpointConnections_ListByResource
+      description: The List operation gets information about the private endpoint connections associated with the managed HSM Pool.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Get information about all managed HSM Pools in the specified subscription.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MHSMPrivateEndpointConnectionsListResult'
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: mhsm_private_endpoint_connections
+      x-stackQL-method: list_by_resource
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/deletedManagedHSMs/?api-version=2023-07-01':
+    get:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_ListDeleted
+      description: The List operation gets information about the deleted managed HSMs associated with the subscription.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Retrieved information about all managed HSMs in the specified subscription.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedManagedHsmListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: managed_hsms_deleted
+      x-stackQL-method: list
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedManagedHSMs/{name}/?api-version=2023-07-01':
+    get:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_GetDeleted
+      description: Gets the specified deleted managed HSM.
+      parameters:
+        - name: name
+          in: path
+          description: The name of the deleted managed HSM.
+          required: true
+          schema:
+            type: string
+        - name: location
+          in: path
+          description: The location of the deleted managed HSM.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: Retrieved information about the specified deleted managed HSM.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletedManagedHsm'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-stackQL-resource: managed_hsms_deleted
+      x-stackQL-method: get
+      x-stackQL-verb: select
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedManagedHSMs/{name}/purge/?api-version=2023-07-01':
+    post:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_PurgeDeleted
+      x-ms-long-running-operation: true
+      description: Permanently deletes the specified managed HSM.
+      parameters:
+        - name: name
+          in: path
+          description: The name of the soft-deleted managed HSM.
+          required: true
+          schema:
+            type: string
+        - name: location
+          in: path
+          description: The location of the soft-deleted managed HSM.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '202':
+          description: Accepted and the operation will complete asynchronously.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The URI to poll for completion status.
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: purge_deleted
+      x-stackQL-verb: exec
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/privateEndpointConnections/{privateEndpointConnectionName}/?api-version=2023-07-01':
+    get:
+      tags:
+        - MHSMPrivateEndpointConnections
+      operationId: MHSMPrivateEndpointConnections_Get
+      description: Gets the specified private endpoint connection associated with the managed HSM Pool.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/MHSMPrivateEndpointConnectionName'
+      responses:
+        '200':
+          description: Private endpoint connection successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MHSMPrivateEndpointConnection'
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-stackQL-resource: mhsm_private_endpoint_connections
+      x-stackQL-method: get
+      x-stackQL-verb: select
+    put:
+      tags:
+        - MHSMPrivateEndpointConnections
+      operationId: MHSMPrivateEndpointConnections_Put
+      description: Updates the specified private endpoint connection associated with the managed hsm pool.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/MHSMPrivateEndpointConnectionName'
+      requestBody:
+        description: The intended state of private endpoint connection.
+        required: true
+        x-ms-requestBody-name: properties
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MHSMPrivateEndpointConnection'
+      responses:
+        '200':
+          description: The state of private endpoint connection was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MHSMPrivateEndpointConnection'
+          headers:
+            Retry-After:
+              schema:
+                format: int32
+                type: integer
+              description: (specified only if operation does not finish synchronously) The recommended number of seconds to wait before calling the URI specified in Azure-AsyncOperation.
+            Azure-AsyncOperation:
+              schema:
+                type: string
+              description: (specified only if operation does not finish synchronously) The URI to poll for completion status. The response of this URI may be synchronous or asynchronous.
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: mhsm_private_endpoint_connections
+      x-stackQL-method: put
+      x-stackQL-verb: exec
+    delete:
+      tags:
+        - MHSMPrivateEndpointConnections
+      operationId: MHSMPrivateEndpointConnections_Delete
+      x-ms-long-running-operation: true
+      description: Deletes the specified private endpoint connection associated with the managed hsm pool.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/MHSMPrivateEndpointConnectionName'
+      responses:
+        '200':
+          description: The private endpoint connection was successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MHSMPrivateEndpointConnection'
+        '202':
+          description: The private endpoint connection is being deleted.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The URI to poll for completion status.
+        '204':
+          description: The private endpoint connection does not exist.
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: mhsm_private_endpoint_connections
+      x-stackQL-method: delete
+      x-stackQL-verb: delete
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/privateLinkResources/?api-version=2023-07-01':
+    get:
+      tags:
+        - MHSMPrivateLinkResources
+      operationId: MHSMPrivateLinkResources_ListByMHSMResource
+      description: Gets the private link resources supported for the managed hsm pool.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully retrieved private link resources.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MHSMPrivateLinkResourceListResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: mhsm_private_link_resources
+      x-stackQL-method: list_by_mhsm_resource
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/regions/?api-version=2023-07-01':
+    get:
+      tags:
+        - MHSMListRegions
+      operationId: MHSMRegions_ListByResource
+      description: The List operation gets information about the regions associated with the managed HSM Pool.
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+        - $ref: '#/components/parameters/ManagedHsmResourceGroupName'
+        - name: name
+          in: path
+          description: Name of the managed HSM Pool
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Get information about all managed HSM Pools in the specified subscription.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MHSMRegionsListResult'
+        default:
+          description: The error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedHsmError'
+      x-ms-pageable:
+        nextLinkName: nextLink
+      x-stackQL-resource: mhsm_regions
+      x-stackQL-method: list_by_resource
+      x-stackQL-verb: select
+      x-stackQL-objectKey: $.value
+  '/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/checkMhsmNameAvailability/?api-version=2023-07-01':
+    post:
+      tags:
+        - ManagedHsms
+      operationId: ManagedHsms_CheckMhsmNameAvailability
+      description: Checks that the managed hsm name is valid and is not already in use.
+      requestBody:
+        description: The name of the managed hsm.
+        required: true
+        x-ms-requestBody-name: mhsmName
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckMhsmNameAvailabilityParameters'
+      parameters:
+        - $ref: '#/components/parameters/SubscriptionIdParameter'
+      responses:
+        '200':
+          description: OK -- Operation to check the mhsm name availability was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckMhsmNameAvailabilityResult'
+        default:
+          description: Error response describing why the operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloudError'
+      x-stackQL-resource: managed_hsms
+      x-stackQL-method: check_mhsm_name_availability
+      x-stackQL-verb: exec

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -5989,3 +5989,215 @@ Aggregation of Doc Based View of Table Valued Function List And Detail Dataflow 
     ...    stderr=${CURDIR}/tmp/Aggregation-of-Doc-Based-View-of-Table-Valued-Function-List-And-Detail-Dataflow-Works-As-Exemplified-By-AWS-S3-Bucket-stderr.tmp
     ...    stackql_dataflow_permissive=True
 
+Multi Dependency List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details
+    ${sqliteInputStr} =    Catenate
+    ...    select 
+    ...    keyz.name as key_name, 
+    ...    keyz.tags as key_tags, 
+    ...    json_extract(detail.properties, '$.kty') as key_class, 
+    ...    json_extract(detail.properties, '$.keySize') as key_size, 
+    ...    json_extract(detail.properties, '$.keyOps') as key_ops, 
+    ...    keyz.type as key_type 
+    ...    from 
+    ...    azure.key_vault.vaults vaultz 
+    ...    inner join azure.key_vault.keys keyz 
+    ...    on keyz.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and keyz.subscriptionId = vaultz.subscriptionId 
+    ...    and keyz.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    inner join azure.key_vault.keys detail 
+    ...    on detail.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and detail.subscriptionId = '000000-0000-0000-0000-000000000011' 
+    ...    and detail.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    and detail.keyName = split_part(keyz.id, '/', -1) 
+    ...    where vaultz.subscriptionId = '000000-0000-0000-0000-000000000011' 
+    ...    ;
+    ${postgresInputStr} =    Catenate
+    ...    select 
+    ...    keyz.name as key_name, 
+    ...    keyz.tags as key_tags, 
+    ...    json_extract_path_text(detail.properties, 'kty') as key_class, 
+    ...    json_extract_path_text(detail.properties, 'keySize') as key_size, 
+    ...    json_extract_path_text(detail.properties, 'keyOps') as key_ops, 
+    ...    keyz.type as key_type 
+    ...    from 
+    ...    azure.key_vault.vaults vaultz 
+    ...    inner join azure.key_vault.keys keyz 
+    ...    on keyz.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and keyz.subscriptionId = vaultz.subscriptionId 
+    ...    and keyz.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    inner join azure.key_vault.keys detail 
+    ...    on detail.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and detail.subscriptionId = '000000-0000-0000-0000-000000000011' 
+    ...    and detail.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    and detail.keyName = split_part(keyz.id, '/', -1) 
+    ...    where vaultz.subscriptionId = '000000-0000-0000-0000-000000000011' 
+    ...    ;
+    ${inputStr} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${postgresInputStr}    ${sqliteInputStr}
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |--------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}key_name${SPACE}${SPACE}${SPACE}|${SPACE}key_tags${SPACE}|${SPACE}key_class${SPACE}|${SPACE}key_size${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_ops${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_type${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}dummy-key-01${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |--------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Multi-Dependency-List-And-Detail-Dataflow-Works-As-Exemplified-By-Azure-Vault-and-Keys-and-Key-Details.tmp
+    ...    stderr=${CURDIR}/tmp/Multi-Dependency-List-And-Detail-Dataflow-Works-As-Exemplified-By-Azure-Vault-and-Keys-and-Key-Details-stderr.tmp
+    ...    stackql_dataflow_permissive=True
+
+
+Multi Dependency Multiple List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details
+    ${sqliteInputStr} =    Catenate
+    ...    select
+    ...    keyz.name as key_name, 
+    ...    keyz.tags as key_tags, 
+    ...    json_extract(detail.properties, '$.kty') as key_class, 
+    ...    json_extract(detail.properties, '$.keySize') as key_size, 
+    ...    json_extract(detail.properties, '$.keyOps') as key_ops, 
+    ...    keyz.type as key_type 
+    ...    from azure.key_vault.vaults vaultz 
+    ...    inner join azure.key_vault.keys keyz 
+    ...    on keyz.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and keyz.subscriptionId = vaultz.subscriptionId 
+    ...    and keyz.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    inner join azure.key_vault.keys detail 
+    ...    on detail.vaultName = split_part(keyz.id, '/', 9) 
+    ...    and detail.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    and detail.resourceGroupName = split_part(keyz.id, '/', 5) 
+    ...    and detail.keyName = split_part(keyz.id, '/', -1) 
+    ...    where vaultz.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    order by key_name
+    ...    ;
+    ${postgresInputStr} =    Catenate
+    ...    select
+    ...    keyz.name as key_name, 
+    ...    keyz.tags as key_tags, 
+    ...    json_extract_path_text(detail.properties, 'kty') as key_class, 
+    ...    json_extract_path_text(detail.properties, 'keySize') as key_size, 
+    ...    json_extract_path_text(detail.properties, 'keyOps') as key_ops, 
+    ...    keyz.type as key_type 
+    ...    from azure.key_vault.vaults vaultz 
+    ...    inner join azure.key_vault.keys keyz 
+    ...    on keyz.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and keyz.subscriptionId = vaultz.subscriptionId 
+    ...    and keyz.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    inner join azure.key_vault.keys detail 
+    ...    on detail.vaultName = split_part(keyz.id, '/', 9) 
+    ...    and detail.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    and detail.resourceGroupName = split_part(keyz.id, '/', 5) 
+    ...    and detail.keyName = split_part(keyz.id, '/', -1) 
+    ...    where vaultz.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    order by key_name
+    ...    ;
+    ${inputStr} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${postgresInputStr}    ${sqliteInputStr}
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}key_tags${SPACE}|${SPACE}key_class${SPACE}|${SPACE}key_size${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_ops${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_type${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}alt-dummy-key-01${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}alt-dummy-key-02${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}dummy-key-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}dummy-key-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Multi-Dependency-Multiple-List-And-Detail-Dataflow-Works-As-Exemplified-By-Azure-Vault-and-Keys-and-Key-Details.tmp
+    ...    stderr=${CURDIR}/tmp/Multi-Dependency-Multiple-List-And-Detail-Dataflow-Works-As-Exemplified-By-Azure-Vault-and-Keys-and-Key-Details-stderr.tmp
+    ...    stackql_dataflow_permissive=True
+
+
+Multi Dependency Multi Dependent Multiple List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details
+    ${sqliteInputStr} =    Catenate
+    ...    select
+    ...    keyz.name as key_name, 
+    ...    keyz.tags as key_tags, 
+    ...    json_extract(detail.properties, '$.kty') as key_class, 
+    ...    json_extract(detail.properties, '$.keySize') as key_size, 
+    ...    json_extract(detail.properties, '$.keyOps') as key_ops, 
+    ...    keyz.type as key_type 
+    ...    from azure.key_vault.vaults vaultz 
+    ...    inner join azure.key_vault.keys keyz 
+    ...    on keyz.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and keyz.subscriptionId = vaultz.subscriptionId 
+    ...    and keyz.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    inner join azure.key_vault.keys detail 
+    ...    on detail.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and detail.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    and detail.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    and detail.keyName = split_part(keyz.id, '/', -1) 
+    ...    where vaultz.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    order by key_name
+    ...    ;
+    ${postgresInputStr} =    Catenate
+    ...    select
+    ...    keyz.name as key_name, 
+    ...    keyz.tags as key_tags, 
+    ...    json_extract_path_text(detail.properties, 'kty') as key_class, 
+    ...    json_extract_path_text(detail.properties, 'keySize') as key_size, 
+    ...    json_extract_path_text(detail.properties, 'keyOps') as key_ops, 
+    ...    keyz.type as key_type 
+    ...    from azure.key_vault.vaults vaultz 
+    ...    inner join azure.key_vault.keys keyz 
+    ...    on keyz.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and keyz.subscriptionId = vaultz.subscriptionId 
+    ...    and keyz.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    inner join azure.key_vault.keys detail 
+    ...    on detail.vaultName = split_part(vaultz.id, '/', -1) 
+    ...    and detail.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    and detail.resourceGroupName = split_part(vaultz.id, '/', 5) 
+    ...    and detail.keyName = split_part(keyz.id, '/', -1) 
+    ...    where vaultz.subscriptionId = '000000-0000-0000-0000-000000000022' 
+    ...    order by key_name
+    ...    ;
+    ${inputStr} =    Set Variable If    "${SQL_BACKEND}" == "postgres_tcp"     ${postgresInputStr}    ${sqliteInputStr}
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}key_tags${SPACE}|${SPACE}key_class${SPACE}|${SPACE}key_size${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_ops${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}key_type${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}alt-dummy-key-01${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}alt-dummy-key-02${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}dummy-key-01${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ...    |${SPACE}dummy-key-02${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}{}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}RSA${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}2048${SPACE}|${SPACE}\["sign","verify","wrapKey","unwrapKey","encrypt","decrypt"]${SPACE}|${SPACE}Microsoft.KeyVault/vaults/keys${SPACE}|
+    ...    |------------------|----------|-----------|----------|-------------------------------------------------------------|--------------------------------|
+    ${outputErrStr} =    Catenate    SEPARATOR=\n
+    ...    http response status code: 404, response body is nil
+    ...    http response status code: 404, response body is nil
+    ...    http response status code: 404, response body is nil
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${outputErrStr}
+    ...    stdout=${CURDIR}/tmp/Multi-Dependency-Multi-Dependent-Multiple-List-And-Detail-Dataflow-Works-As-Exemplified-By-Azure-Vault-and-Keys-and-Key-Details.tmp
+    ...    stderr=${CURDIR}/tmp/Multi-Dependency-Multi-Dependent-Multiple-List-And-Detail-Dataflow-Works-As-Exemplified-By-Azure-Vault-and-Keys-and-Key-Details-stderr.tmp
+    ...    stackql_dataflow_permissive=True


### PR DESCRIPTION
## Description

- Support for dataflow graphs with in degrees > 1 and out degreees > 1.
- Deduplicate dataflow graph node ordering.
- Split dataflow analysis passes.
- Number of builders corrected, in theory.
- Lifetime of tracking stores changed.
- Do not stop the world on streamed input generating 404s.
- Added robot test `Multi Dependency List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details`.
- Added robot test `Multi Dependency Multiple List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details`.
- Added robot test `Multi Dependency Multi Dependent Multiple List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Multi Dependency List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details`.
- Added robot test `Multi Dependency Multiple List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details`.
- Added robot test `Multi Dependency Multi Dependent Multiple List And Detail Dataflow Works As Exemplified By Azure Vault and Keys and Key Details`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
