### PR TITLE
test-coverage-self-join-polymorphic

### DIFF
--- a/test/mockserver/expectations/static-azure-expectations.json
+++ b/test/mockserver/expectations/static-azure-expectations.json
@@ -1,4 +1,742 @@
-[  
+[ 
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["rg2"],
+        "gatewayName": ["gateway2"]
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2022-01-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "name": "gateway2",
+        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "location": "West US",
+        "type": "Microsoft.Network/vpnGateways",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "virtualHub": {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub1"
+          },
+          "connections": [
+            {
+              "name": "vpnConnection1",
+              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/vpnConnections/vpnConnection1",
+              "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "remoteVpnSite": {
+                  "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnSites/vpnSite1"
+                },
+                "enableInternetSecurity": false,
+                "ingressBytesTransferred": 0,
+                "egressBytesTransferred": 0,
+                "vpnLinkConnections": [
+                  {
+                    "name": "Connection-Link1",
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/vpnConnections/vpnConnection1/VpnSiteLinkConnections/Connection-Link1",
+                    "type": "Microsoft.Network/vpnGateways/vpnConnections/VpnSiteLinkConnections",
+                    "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "vpnSiteLink": {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnSites/vpnSite1/vpnSiteLinks/siteLink1"
+                      },
+                      "connectionBandwidth": 200,
+                      "ipsecPolicies": [],
+                      "vpnConnectionProtocolType": "IKEv2",
+                      "sharedKey": "key",
+                      "ingressBytesTransferred": 0,
+                      "egressBytesTransferred": 0,
+                      "enableBgp": false,
+                      "enableRateLimiting": false,
+                      "useLocalAzureIpAddress": false,
+                      "usePolicyBasedTrafficSelectors": false,
+                      "routingWeight": 0,
+                      "ingressNatRules": [
+                        {
+                          "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/natRules/nat03"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Connection-Link2",
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/vpnConnections/vpnConnection1/VpnSiteLinkConnections/Connection-Link2",
+                    "type": "Microsoft.Network/vpnGateways/vpnConnections/VpnSiteLinkConnections",
+                    "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "vpnSiteLink": {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnSites/vpnSite1/vpnSiteLinks/siteLink2"
+                      },
+                      "connectionBandwidth": 200,
+                      "ipsecPolicies": [],
+                      "vpnConnectionProtocolType": "IKEv2",
+                      "sharedKey": "key",
+                      "ingressBytesTransferred": 0,
+                      "egressBytesTransferred": 0,
+                      "enableBgp": false,
+                      "enableRateLimiting": false,
+                      "useLocalAzureIpAddress": false,
+                      "usePolicyBasedTrafficSelectors": false,
+                      "routingWeight": 0,
+                      "egressNatRules": [
+                        {
+                          "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/natRules/nat04"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "routingConfiguration": {
+                  "associatedRouteTable": {
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable1"
+                  },
+                  "propagatedRouteTables": {
+                    "labels": [
+                      "label1",
+                      "label2"
+                    ],
+                    "ids": [
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable1"
+                      },
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable2"
+                      },
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable3"
+                      }
+                    ]
+                  },
+                  "vnetRoutes": {
+                    "staticRoutes": []
+                  }
+                }
+              }
+            }
+          ],
+          "bgpSettings": {
+            "asn": 65514,
+            "bgpPeeringAddress": "10.0.1.60",
+            "peerWeight": 0,
+            "bgpPeeringAddresses": [
+              {
+                "ipconfigurationId": "Instance0",
+                "defaultBgpIpAddresses": [
+                  "10.30.0.4"
+                ],
+                "customBgpIpAddresses": [
+                  "169.254.21.5"
+                ],
+                "tunnelIpAddresses": [
+                  "104.208.48.178"
+                ]
+              },
+              {
+                "ipconfigurationId": "Instance1",
+                "defaultBgpIpAddresses": [
+                  "10.30.0.5"
+                ],
+                "customBgpIpAddresses": [
+                  "169.254.21.10"
+                ],
+                "tunnelIpAddresses": [
+                  "104.208.48.179"
+                ]
+              }
+            ]
+          },
+          "natRules": [
+            {
+              "name": "nat03",
+              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/natRules/nat03",
+              "properties": {
+                "type": "Dynamic",
+                "mode": "IgressSnat",
+                "internalMappings": [
+                  {
+                    "addressSpace": "0.0.0.0/26"
+                  }
+                ],
+                "externalMappings": [
+                  {
+                    "addressSpace": "192.168.0.0/26"
+                  }
+                ],
+                "ingressVpnSiteLinkConnections": [
+                  {
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/vpnConnections/vpnConnection1/vpnLinkConnections/Connection-Link1"
+                  }
+                ]
+              },
+              "type": "Microsoft.Network/vpnGateways/natRules"
+            },
+            {
+              "name": "nat04",
+              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/natRules/nat04",
+              "properties": {
+                "type": "Static",
+                "mode": "EgressSnat",
+                "internalMappings": [
+                  {
+                    "addressSpace": "0.0.0.0/26"
+                  }
+                ],
+                "externalMappings": [
+                  {
+                    "addressSpace": "192.168.0.0/26"
+                  }
+                ],
+                "egressVpnSiteLinkConnections": [
+                  {
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/vpnConnections/vpnConnection1/vpnLinkConnections/Connection-Link2"
+                  }
+                ]
+              },
+              "type": "Microsoft.Network/vpnGateways/natRules"
+            }
+          ],
+          "isRoutingPreferenceInternet": false,
+          "enableBgpRouteTranslationForNat": false
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"],
+        "resourceGroupName": ["rg1"],
+        "gatewayName": ["gateway1"]
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2022-01-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "name": "gateway1",
+        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "location": "West US",
+        "type": "Microsoft.Network/vpnGateways",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "virtualHub": {
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1"
+          },
+          "connections": [
+            {
+              "name": "vpnConnection1",
+              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1",
+              "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "remoteVpnSite": {
+                  "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnSites/vpnSite1"
+                },
+                "enableInternetSecurity": false,
+                "ingressBytesTransferred": 0,
+                "egressBytesTransferred": 0,
+                "vpnLinkConnections": [
+                  {
+                    "name": "Connection-Link1",
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/VpnSiteLinkConnections/Connection-Link1",
+                    "type": "Microsoft.Network/vpnGateways/vpnConnections/VpnSiteLinkConnections",
+                    "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "vpnSiteLink": {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnSites/vpnSite1/vpnSiteLinks/siteLink1"
+                      },
+                      "connectionBandwidth": 200,
+                      "ipsecPolicies": [],
+                      "vpnConnectionProtocolType": "IKEv2",
+                      "sharedKey": "key",
+                      "ingressBytesTransferred": 0,
+                      "egressBytesTransferred": 0,
+                      "enableBgp": false,
+                      "enableRateLimiting": false,
+                      "useLocalAzureIpAddress": false,
+                      "usePolicyBasedTrafficSelectors": false,
+                      "routingWeight": 0,
+                      "ingressNatRules": [
+                        {
+                          "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat03"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Connection-Link2",
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/VpnSiteLinkConnections/Connection-Link2",
+                    "type": "Microsoft.Network/vpnGateways/vpnConnections/VpnSiteLinkConnections",
+                    "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "vpnSiteLink": {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnSites/vpnSite1/vpnSiteLinks/siteLink2"
+                      },
+                      "connectionBandwidth": 200,
+                      "ipsecPolicies": [],
+                      "vpnConnectionProtocolType": "IKEv2",
+                      "sharedKey": "key",
+                      "ingressBytesTransferred": 0,
+                      "egressBytesTransferred": 0,
+                      "enableBgp": false,
+                      "enableRateLimiting": false,
+                      "useLocalAzureIpAddress": false,
+                      "usePolicyBasedTrafficSelectors": false,
+                      "routingWeight": 0,
+                      "egressNatRules": [
+                        {
+                          "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat04"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "routingConfiguration": {
+                  "associatedRouteTable": {
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable1"
+                  },
+                  "propagatedRouteTables": {
+                    "labels": [
+                      "label1",
+                      "label2"
+                    ],
+                    "ids": [
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable1"
+                      },
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable2"
+                      },
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable3"
+                      }
+                    ]
+                  },
+                  "vnetRoutes": {
+                    "staticRoutes": []
+                  }
+                }
+              }
+            }
+          ],
+          "bgpSettings": {
+            "asn": 65514,
+            "bgpPeeringAddress": "10.0.1.30",
+            "peerWeight": 0,
+            "bgpPeeringAddresses": [
+              {
+                "ipconfigurationId": "Instance0",
+                "defaultBgpIpAddresses": [
+                  "10.30.0.4"
+                ],
+                "customBgpIpAddresses": [
+                  "169.254.21.5"
+                ],
+                "tunnelIpAddresses": [
+                  "104.208.48.178"
+                ]
+              },
+              {
+                "ipconfigurationId": "Instance1",
+                "defaultBgpIpAddresses": [
+                  "10.30.0.5"
+                ],
+                "customBgpIpAddresses": [
+                  "169.254.21.10"
+                ],
+                "tunnelIpAddresses": [
+                  "104.208.48.179"
+                ]
+              }
+            ]
+          },
+          "natRules": [
+            {
+              "name": "nat03",
+              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat03",
+              "properties": {
+                "type": "Dynamic",
+                "mode": "IgressSnat",
+                "internalMappings": [
+                  {
+                    "addressSpace": "0.0.0.0/26"
+                  }
+                ],
+                "externalMappings": [
+                  {
+                    "addressSpace": "192.168.0.0/26"
+                  }
+                ],
+                "ingressVpnSiteLinkConnections": [
+                  {
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/vpnLinkConnections/Connection-Link1"
+                  }
+                ]
+              },
+              "type": "Microsoft.Network/vpnGateways/natRules"
+            },
+            {
+              "name": "nat04",
+              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat04",
+              "properties": {
+                "type": "Static",
+                "mode": "EgressSnat",
+                "internalMappings": [
+                  {
+                    "addressSpace": "0.0.0.0/26"
+                  }
+                ],
+                "externalMappings": [
+                  {
+                    "addressSpace": "192.168.0.0/26"
+                  }
+                ],
+                "egressVpnSiteLinkConnections": [
+                  {
+                    "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/vpnLinkConnections/Connection-Link2"
+                  }
+                ]
+              },
+              "type": "Microsoft.Network/vpnGateways/natRules"
+            }
+          ],
+          "isRoutingPreferenceInternet": false,
+          "enableBgpRouteTranslationForNat": false
+        }
+      }
+    }
+  },
+  {
+    "httpRequest": {
+      "headers": {
+        "accept": [ "application/json" ]
+      },
+      "method": "GET",
+      "path": "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnGateways/",
+      "pathParameters": {
+        "subscriptionId": ["000000-0000-0000-0000-000000000022"] 
+      },
+      "queryStringParameters" : {
+        "api-version" : [ "2022-01-01" ]
+      }
+    },
+    "httpResponse": {
+      "body": {
+        "value": [
+          {
+            "name": "gateway1",
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1",
+            "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+            "location": "West US",
+            "type": "Microsoft.Network/vpnGateways",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "virtualHub": {
+                "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1"
+              },
+              "connections": [
+                {
+                  "name": "vpnConnection1",
+                  "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1",
+                  "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "remoteVpnSite": {
+                      "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnSites/vpnSite1"
+                    },
+                    "enableInternetSecurity": false,
+                    "ingressBytesTransferred": 0,
+                    "egressBytesTransferred": 0,
+                    "vpnLinkConnections": [
+                      {
+                        "name": "Connection-Link1",
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/VpnSiteLinkConnections/Connection-Link1",
+                        "type": "Microsoft.Network/vpnGateways/vpnConnections/VpnSiteLinkConnections",
+                        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                        "properties": {
+                          "provisioningState": "Succeeded",
+                          "vpnSiteLink": {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnSites/vpnSite1/vpnSiteLinks/siteLink1"
+                          },
+                          "connectionBandwidth": 200,
+                          "ipsecPolicies": [],
+                          "vpnConnectionProtocolType": "IKEv2",
+                          "sharedKey": "key",
+                          "ingressBytesTransferred": 0,
+                          "egressBytesTransferred": 0,
+                          "enableBgp": false,
+                          "enableRateLimiting": false,
+                          "useLocalAzureIpAddress": false,
+                          "usePolicyBasedTrafficSelectors": false,
+                          "routingWeight": 0,
+                          "ingressNatRules": [
+                            {
+                              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat03"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "name": "Connection-Link2",
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/VpnSiteLinkConnections/Connection-Link2",
+                        "type": "Microsoft.Network/vpnGateways/vpnConnections/VpnSiteLinkConnections",
+                        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                        "properties": {
+                          "provisioningState": "Succeeded",
+                          "vpnSiteLink": {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnSites/vpnSite1/vpnSiteLinks/siteLink2"
+                          },
+                          "connectionBandwidth": 200,
+                          "ipsecPolicies": [],
+                          "vpnConnectionProtocolType": "IKEv2",
+                          "sharedKey": "key",
+                          "ingressBytesTransferred": 0,
+                          "egressBytesTransferred": 0,
+                          "enableBgp": false,
+                          "enableRateLimiting": false,
+                          "useLocalAzureIpAddress": false,
+                          "usePolicyBasedTrafficSelectors": false,
+                          "routingWeight": 0,
+                          "egressNatRules": [
+                            {
+                              "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat04"
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "routingConfiguration": {
+                      "associatedRouteTable": {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable1"
+                      },
+                      "propagatedRouteTables": {
+                        "labels": [
+                          "label1",
+                          "label2"
+                        ],
+                        "ids": [
+                          {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable1"
+                          },
+                          {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable2"
+                          },
+                          {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubRouteTables/hubRouteTable3"
+                          }
+                        ]
+                      },
+                      "vnetRoutes": {
+                        "staticRoutes": []
+                      }
+                    }
+                  }
+                }
+              ],
+              "bgpSettings": {
+                "asn": 65514,
+                "bgpPeeringAddress": "10.0.1.30",
+                "peerWeight": 0,
+                "bgpPeeringAddresses": [
+                  {
+                    "ipconfigurationId": "Instance0",
+                    "defaultBgpIpAddresses": [
+                      "10.30.0.4"
+                    ],
+                    "customBgpIpAddresses": [
+                      "169.254.21.5"
+                    ],
+                    "tunnelIpAddresses": [
+                      "104.208.48.178"
+                    ]
+                  },
+                  {
+                    "ipconfigurationId": "Instance1",
+                    "defaultBgpIpAddresses": [
+                      "10.30.0.5"
+                    ],
+                    "customBgpIpAddresses": [
+                      "169.254.21.10"
+                    ],
+                    "tunnelIpAddresses": [
+                      "104.208.48.179"
+                    ]
+                  }
+                ]
+              },
+              "natRules": [
+                {
+                  "name": "nat03",
+                  "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat03",
+                  "properties": {
+                    "type": "Dynamic",
+                    "mode": "IgressSnat",
+                    "internalMappings": [
+                      {
+                        "addressSpace": "0.0.0.0/26"
+                      }
+                    ],
+                    "externalMappings": [
+                      {
+                        "addressSpace": "192.168.0.0/26"
+                      }
+                    ],
+                    "ingressVpnSiteLinkConnections": [
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/vpnLinkConnections/Connection-Link1"
+                      }
+                    ]
+                  },
+                  "type": "Microsoft.Network/vpnGateways/natRules"
+                },
+                {
+                  "name": "nat04",
+                  "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/natRules/nat04",
+                  "properties": {
+                    "type": "Static",
+                    "mode": "EgressSnat",
+                    "internalMappings": [
+                      {
+                        "addressSpace": "0.0.0.0/26"
+                      }
+                    ],
+                    "externalMappings": [
+                      {
+                        "addressSpace": "192.168.0.0/26"
+                      }
+                    ],
+                    "egressVpnSiteLinkConnections": [
+                      {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg1/providers/Microsoft.Network/vpnGateways/gateway1/vpnConnections/vpnConnection1/vpnLinkConnections/Connection-Link2"
+                      }
+                    ]
+                  },
+                  "type": "Microsoft.Network/vpnGateways/natRules"
+                }
+              ],
+              "isRoutingPreferenceInternet": false,
+              "enableBgpRouteTranslationForNat": false
+            }
+          },
+          {
+            "name": "gateway2",
+            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2",
+            "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+            "location": "West US",
+            "type": "Microsoft.Network/vpnGateways",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "virtualHub": {
+                "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub2"
+              },
+              "connections": [
+                {
+                  "name": "vpnConnection1",
+                  "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnGateways/gateway2/vpnConnections/vpnConnection2",
+                  "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "remoteVpnSite": {
+                      "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/vpnSites/vpnSite2"
+                    },
+                    "connectionStatus": "Connected",
+                    "ingressBytesTransferred": 0,
+                    "egressBytesTransferred": 0,
+                    "routingWeight": 0,
+                    "connectionBandwidth": 100,
+                    "sharedKey": "key",
+                    "enableBgp": false,
+                    "useLocalAzureIpAddress": false,
+                    "ipsecPolicies": [],
+                    "routingConfiguration": {
+                      "associatedRouteTable": {
+                        "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub2/hubRouteTables/hubRouteTable1"
+                      },
+                      "propagatedRouteTables": {
+                        "labels": [
+                          "label1",
+                          "label2"
+                        ],
+                        "ids": [
+                          {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub2/hubRouteTables/hubRouteTable1"
+                          },
+                          {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub2/hubRouteTables/hubRouteTable2"
+                          },
+                          {
+                            "id": "/subscriptions/000000-0000-0000-0000-000000000022/resourceGroups/rg2/providers/Microsoft.Network/virtualHubs/virtualHub2/hubRouteTables/hubRouteTable3"
+                          }
+                        ]
+                      },
+                      "vnetRoutes": {
+                        "staticRoutes": []
+                      }
+                    }
+                  }
+                }
+              ],
+              "bgpSettings": {
+                "asn": 65514,
+                "bgpPeeringAddress": "10.0.1.60",
+                "peerWeight": 0,
+                "bgpPeeringAddresses": [
+                  {
+                    "ipconfigurationId": "Instance0",
+                    "defaultBgpIpAddresses": [
+                      "10.30.0.4"
+                    ],
+                    "customBgpIpAddresses": [
+                      "169.254.21.5"
+                    ],
+                    "tunnelIpAddresses": [
+                      "104.208.48.178"
+                    ]
+                  },
+                  {
+                    "ipconfigurationId": "Instance1",
+                    "defaultBgpIpAddresses": [
+                      "10.30.0.5"
+                    ],
+                    "customBgpIpAddresses": [
+                      "169.254.21.10"
+                    ],
+                    "tunnelIpAddresses": [
+                      "104.208.48.179"
+                    ]
+                  }
+                ]
+              },
+              "natRules": [],
+              "isRoutingPreferenceInternet": false,
+              "enableBgpRouteTranslationForNat": false
+            }
+          }
+        ]
+      }
+  }
+  }, 
   {
     "httpRequest": {
       "headers": {

--- a/test/registry/src/azure/v0.1.0/services/network.yaml
+++ b/test/registry/src/azure/v0.1.0/services/network.yaml
@@ -26360,7 +26360,6 @@ components:
           response:
             mediaType: application/json
             openAPIDocKey: '200'
-            objectKey: $.value
         VpnGateways_CreateOrUpdate:
           operation:
             $ref: '#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Network~1vpnGateways~1{gatewayName}~1?api-version=2022-01-01/put'
@@ -26413,6 +26412,7 @@ components:
             objectKey: $.value
       sqlVerbs:
         select:
+          - $ref: '#/components/x-stackQL-resources/vpn_gateways/methods/VpnGateways_Get'
           - $ref: '#/components/x-stackQL-resources/vpn_gateways/methods/VpnGateways_ListByResourceGroup'
           - $ref: '#/components/x-stackQL-resources/vpn_gateways/methods/VpnGateways_List'
         insert:
@@ -40804,11 +40804,15 @@ paths:
             type: string
       responses:
         '200':
-          description: Request successful. Returns the details of the virtual wan vpn gateway retrieved.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VpnGateway'
+                type: object
+                properties:
+                  name:
+                    type: string
+                  properties:
+                    $ref: '#/components/schemas/VpnGateway'
         default:
           description: Error response describing why the operation failed.
           content:


### PR DESCRIPTION
## Description

- Support for polymorhpic self join.  this is highly useful for analytics.
- Added robot test `Self Join Polymorphic Works As Exemplified By Azure VPN List and Details`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Explanation**: .

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Self Join Polymorphic Works As Exemplified By Azure VPN List and Details`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
