### PR TITLE
indirection-symbol-collision

### DIFF
--- a/internal/stackql/primitivegenerator/select.go
+++ b/internal/stackql/primitivegenerator/select.go
@@ -160,7 +160,8 @@ func (pb *standardPrimitiveGenerator) analyzeSelect(pbi planbuilderinput.PlanBui
 
 		for _, tbl := range tblz {
 			err := pb.expandTable(tbl)
-			if err != nil {
+			_, isIndirect := tbl.GetIndirect()
+			if err != nil && !isIndirect {
 				return err
 			}
 		}

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -6815,3 +6815,161 @@ Conditional Column on Table Valued Function in Materialized View Returns Expecte
     ...    ${outputErrStr}
     ...    stdout=${CURDIR}/tmp/Conditional-Column-on-Table-Valued-Function-in-Materialized-View-Returns-Expected-Results-as-Exemplified-by-Google-Firewalls.tmp
     ...    stderr=${CURDIR}/tmp/Conditional-Column-on-Table-Valued-Function-in-Materialized-View-Returns-Expected-Results-as-Exemplified-by-Google-Firewalls-stderr.tmp
+
+Unaliased Projection on Materialized View as Exemplified by Google Firewalls
+    ${inputStr} =    Catenate
+    ...    create or replace materialized view google_firewalls as 
+    ...    select 
+    ...    id, 
+    ...    name, 
+    ...    sourceRanges as source_ranges 
+    ...    from google.compute.firewalls 
+    ...    where project = 'testing-project'; 
+    ...    select 
+    ...    id,
+    ...    name 
+    ...    from 
+    ...    google_firewalls
+    ...    order by id asc, name asc
+    ...    ;
+    ...    drop materialized view google_firewalls;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}id${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}111111111111${SPACE}|${SPACE}allow-spark-ui${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}22222222222${SPACE}|${SPACE}default-allow-http${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}33333333${SPACE}|${SPACE}default-allow-https${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}4444444444444${SPACE}|${SPACE}default-allow-icmp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}5555555555555${SPACE}|${SPACE}default-allow-internal${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}6666666666${SPACE}|${SPACE}default-allow-rdp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}777777777777${SPACE}|${SPACE}default-allow-ssh${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}8888888888888${SPACE}|${SPACE}selected-allow-rdesk${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ${outputErrStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${outputErrStr}
+    ...    stdout=${CURDIR}/tmp/Unaliased-Projection-on-Materialized-View-as-Exemplified-by-Google-Firewalls.tmp
+    ...    stderr=${CURDIR}/tmp/Unaliased-Projection-on-Materialized-View-as-Exemplified-by-Google-Firewalls-stderr.tmp
+
+Unaliased Projection on View as Exemplified by Google Firewalls
+    ${inputStr} =    Catenate
+    ...    create or replace view google_firewalls_v as 
+    ...    select 
+    ...    id, 
+    ...    name, 
+    ...    sourceRanges as source_ranges 
+    ...    from google.compute.firewalls 
+    ...    where project = 'testing-project'; 
+    ...    select 
+    ...    id,
+    ...    name 
+    ...    from 
+    ...    google_firewalls_v
+    ...    order by id asc, name asc
+    ...    ;
+    ...    drop materialized view google_firewalls_v;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}id${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}111111111111${SPACE}|${SPACE}allow-spark-ui${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}22222222222${SPACE}|${SPACE}default-allow-http${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}33333333${SPACE}|${SPACE}default-allow-https${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}4444444444444${SPACE}|${SPACE}default-allow-icmp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}5555555555555${SPACE}|${SPACE}default-allow-internal${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}6666666666${SPACE}|${SPACE}default-allow-rdp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}777777777777${SPACE}|${SPACE}default-allow-ssh${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}8888888888888${SPACE}|${SPACE}selected-allow-rdesk${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ${outputErrStr} =    Catenate    SEPARATOR=\n
+    ...    DDL Execution Completed
+    ...    DDL Execution Completed
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${outputErrStr}
+    ...    stdout=${CURDIR}/tmp/Unaliased-Projection-on-View-as-Exemplified-by-Google-Firewalls.tmp
+    ...    stderr=${CURDIR}/tmp/Unaliased-Projection-on-View-as-Exemplified-by-Google-Firewalls-stderr.tmp
+
+Unaliased Projection on Subquery as Exemplified by Google Firewalls
+    ${inputStr} =    Catenate
+    ...    select 
+    ...    id, 
+    ...    name
+    ...    from
+    ...    (
+    ...    select 
+    ...    id, 
+    ...    name, 
+    ...    sourceRanges as source_ranges 
+    ...    from google.compute.firewalls 
+    ...    where project = 'testing-project'
+    ...    ) google_firewalls
+    ...    order by id asc, name asc
+    ...    ;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}id${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}111111111111${SPACE}|${SPACE}allow-spark-ui${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}22222222222${SPACE}|${SPACE}default-allow-http${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}33333333${SPACE}|${SPACE}default-allow-https${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}4444444444444${SPACE}|${SPACE}default-allow-icmp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}5555555555555${SPACE}|${SPACE}default-allow-internal${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}6666666666${SPACE}|${SPACE}default-allow-rdp${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}${SPACE}777777777777${SPACE}|${SPACE}default-allow-ssh${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    ...    |${SPACE}8888888888888${SPACE}|${SPACE}selected-allow-rdesk${SPACE}${SPACE}${SPACE}|
+    ...    |---------------|------------------------|
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/Unaliased-Projection-on-Subquery-as-Exemplified-by-Google-Firewalls.tmp
+    ...    stderr=${CURDIR}/tmp/Unaliased-Projection-on-Subquery-as-Exemplified-by-Google-Firewalls-stderr.tmp


### PR DESCRIPTION
## Description

- Support unaliased projection on views and subqueries.
- Added robot test `Unaliased Projection on Materialized View as Exemplified by Google Firewalls`.
- Added robot test `Unaliased Projection on View as Exemplified by Google Firewalls`.
- Added robot test `Unaliased Projection on Subquery as Exemplified by Google Firewalls`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Unaliased Projection on Materialized View as Exemplified by Google Firewalls`.
- Added robot test `Unaliased Projection on View as Exemplified by Google Firewalls`.
- Added robot test `Unaliased Projection on Subquery as Exemplified by Google Firewalls`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No new technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
