### PR TITLE
deb-arm64

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -673,6 +673,75 @@ jobs:
         name: stackql_linux_arm64
         path: build/stackql
 
+    - name: prepare deb boilerplate
+      env:
+        pkgCompressType: 'gzip'
+        pkgRoot: '.debpkg'
+        pkgName: 'stackql'
+        pkgVersion: ${{env.BUILDMAJORVERSION}}.${{env.BUILDMINORVERSION}}.${{env.BUILDPATCHVERSION}}
+        pkgArchitecture: 'arm64'
+        pkgMaintainer: 'stackql'
+        pkgDepends: ''
+        pkgHomepage: 'https://stackql.io'
+        pkgDescription: 'stackql treats the internet as a relational database'
+        pkgInstalledSize: ''
+        pkgOwner: '--root-owner-group'
+      run: |
+        mkdir -p "${pkgRoot}/usr/bin"
+        mkdir -p "${pkgRoot}/DEBIAN"
+        cp -p build/stackql "${pkgRoot}/usr/bin/"
+        if [ -z "$pkgInstalledSize" ]; then
+          pkgRootSizeBytes="$(du --bytes --summarize --exclude=DEBIAN "$pkgRoot"/ | awk '{print $1}')"
+          pkgInstalledSize="$(( (pkgRootSizeBytes + 1024 - 1) / 1024 ))"
+        fi
+        cat >"${pkgRoot}/DEBIAN/control" <<EOL
+        Package: ${pkgName}
+        Version: ${pkgVersion}
+        Installed-Size: ${pkgInstalledSize}
+        Architecture: ${pkgArchitecture}
+        Maintainer: ${pkgMaintainer}
+        ${pkgDepends}${pkgHomepage}${pkgDescription}
+        EOL
+        sudo apt-get update -yqq && \
+        sudo apt-get install -y \
+            devscripts \
+            build-essential \
+            cdbs
+        DEB_FILE="${pkgName}_${pkgVersion}_${pkgArchitecture}.deb"
+        dpkg-deb -Z"${pkgCompressType}" ${pkgOwner:+"$pkgOwner"} --build "$pkgRoot" "$DEB_FILE"     
+        ls ./*.deb
+        echo "file_name=$DEB_FILE"
+    
+    - name: install and test deb package
+      env:
+        pkgName: 'stackql'
+        pkgVersion: ${{env.BUILDMAJORVERSION}}.${{env.BUILDMINORVERSION}}.${{env.BUILDPATCHVERSION}}
+        pkgArchitecture: 'arm64'
+      run: |
+        mkdir -p deb_test
+        DEB_FILE="${pkgName}_${pkgVersion}_${pkgArchitecture}.deb"
+        cp "${DEB_FILE}" deb_test/
+        sudo dpkg -i "./deb_test/${DEB_FILE}"
+        sudo apt-get install -f
+        python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true", "CONCURRENCY_LIMIT": -1, "USE_STACKQL_PREINSTALLED": "true"  } }'
+        stackqlLocation="$(which stackql 2>&1 | head -n 1)"
+        stackqlVersion="$(stackql --version 2>&1 | head -n 1)"
+        echo "stackql location: ${stackqlLocation}"
+        echo "stackql version: ${stackqlVersion}"
+      
+    - name: Output from mocked deb package functional tests
+      if: always()
+      run: |
+        cat ./test/robot/functional/output.xml
+
+    - name: Upload deb Artifact
+      uses: actions/upload-artifact@v4.3.1
+      if: success()
+      with:
+        name: arm64-artifact-deb
+        path: |
+          ./*.deb
+
   wsltest:
     name: WSL Test
     runs-on: windows-latest


### PR DESCRIPTION
## Description

- Automate `deb` package build and retain.
- `robot` tests support preinstalled `stackql`.
- Incorporate robot testing for `deb` package.
- Add both `amd64` `deb` package.
- `deb`-installed `stackql` info `echo`ed post robot tests.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Full complement of robot tests against `arm64` `deb` package.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
