### PR TITLE
psql-and-env-vars

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -26,7 +26,7 @@ Then, each of these should be run from the repository root:
 For serious development, simulated integration tests are essential.  So, there are more dependencies:
 
 - Install the python dependencies (including `robot` framework).  Simplest way, system permitting, is `pip install -r cicd/requirements.txt`.
-- Install `psql`.  On some systems, this can be done as client only asnd/or with various package managers; fallback is to just [install postgres manually](https://www.postgresql.org/download/).
+- Install `psql`.  On some systems, this can be done as client only and/or with various package managers; fallback is to just [install postgres manually](https://www.postgresql.org/download/).
 - Install `java`.  Version `11` is what is currently used in CI but this ought not to be mandatory.
 - Install `mock-server`, either using a package manager (eg `maven`), or from source per [the mockserver docs](https://www.mock-server.com/mock_server/running_mock_server.html#build-and-run-from-source).
 

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -312,6 +312,52 @@ Acceptable Secure PSQL Connection to mTLS Server With Diagnostic Query Returns C
     ...    stderr=${CURDIR}/tmp/Acceptable-Secure-PSQL-Connection-to-mTLS-Server-With-Diagnostic-Query-Returns-Connection-Info-stderr.tmp
     Should Contain    ${result.stdout}    SSL connection (protocol: TLSv1.3
 
+Acceptable Password Only PSQL Connection Defined by Env Vars to Server With Diagnostic Query Returns Connection Info
+    Set Environment Variable    PGHOST           ${PSQL_CLIENT_HOST}
+    Set Environment Variable    PGPORT           ${PG_SRV_PORT_UNENCRYPTED}
+    Set Environment Variable    PGUSER           stackql
+    Set Environment Variable    PGPASSWORD       ${PSQL_PASSWORD} 
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}" -c "\\conninfo"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Acceptable-Password-Only-PSQL-Connection-Defined-by-Env-Vars-to-Server-With-Diagnostic-Query-Returns-Connection-Info.tmp
+    ...    stderr=${CURDIR}/tmp/Acceptable-Password-Only-PSQL-Connection-Defined-by-Env-Vars-to-Server-With-Diagnostic-Query-Returns-Connection-Info-stderr.tmp
+    Should Contain    ${result.stdout}    You are connected to database
+    [Teardown]  Run Keywords    Remove Environment Variable     PGHOST
+    ...         AND             Remove Environment Variable     PGPORT
+    ...         AND             Remove Environment Variable     PGUSER 
+    ...         AND             Remove Environment Variable     PGPASSWORD
+
+Acceptable Secure PSQL Connection Defined by Env Vars to mTLS Server With Diagnostic Query Returns Connection Info
+    Set Environment Variable    PGHOST           ${PSQL_CLIENT_HOST}
+    Set Environment Variable    PGPORT           ${PG_SRV_PORT_MTLS}
+    Set Environment Variable    PGSSLMODE        verify\-full 
+    Set Environment Variable    PGSSLCERT        ${STACKQL_PG_CLIENT_CERT_PATH} 
+    Set Environment Variable    PGSSLKEY         ${STACKQL_PG_CLIENT_KEY_PATH} 
+    Set Environment Variable    PGSSLROOTCERT    ${STACKQL_PG_SERVER_CERT_PATH} 
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}" -c "\\conninfo"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${result} =    Run Process
+    ...    ${shellExe}     \-c    ${input}
+    ...    stdout=${CURDIR}/tmp/Acceptable-Secure-PSQL-Connection-Defined-by-Env-Vars-to-mTLS-Server-With-Diagnostic-Query-Returns-Connection-Info.tmp
+    ...    stderr=${CURDIR}/tmp/Acceptable-Secure-PSQL-Connection-Defined-by-Env-Vars-to-mTLS-Server-With-Diagnostic-Query-Returns-Connection-Info-stderr.tmp
+    Should Contain    ${result.stdout}    SSL connection (protocol: TLSv1.3
+    [Teardown]  Run Keywords    Remove Environment Variable     PGHOST
+    ...         AND             Remove Environment Variable     PGPORT
+    ...         AND             Remove Environment Variable     PGSSLMODE 
+    ...         AND             Remove Environment Variable     PGSSLCERT 
+    ...         AND             Remove Environment Variable     PGSSLKEY
+    ...         AND             Remove Environment Variable     PGSSLROOTCERT
+
 Unacceptable Insecure PSQL Connection to mTLS Server Returns Error Message
     ${posixInput} =     Catenate
     ...    "${PSQL_EXE}"    -d    "${PSQL_MTLS_DISABLE_CONN_STR_UNIX}" -c "\\conninfo"

--- a/test/robot/lib/stackql_context.py
+++ b/test/robot/lib/stackql_context.py
@@ -570,6 +570,9 @@ CREATE_DISKS_VIEW_PRIMARY_ALIAS = "create view cross_cloud_disks_aliased as sele
 PSQL_MTLS_CONN_STR :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH} sslkey={STACKQL_PG_CLIENT_KEY_PATH} sslrootcert={STACKQL_PG_SERVER_CERT_PATH} dbname=mydatabase"
 PSQL_MTLS_CONN_STR_UNIX :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_UNIX} sslkey={STACKQL_PG_CLIENT_KEY_PATH_UNIX} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_UNIX} dbname=mydatabase"
 
+def generate_password() -> str:
+  return os.urandom(16).hex()
+
 PSQL_MTLS_CONN_STR_EXPORT_UNIX :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS_EXPORT} user=myuser sslmode=verify-full sslcert={STACKQL_PG_CLIENT_CERT_PATH_UNIX} sslkey={STACKQL_PG_CLIENT_KEY_PATH_UNIX} sslrootcert={STACKQL_PG_SERVER_CERT_PATH_UNIX} dbname=mydatabase".replace('\\', '/')
 
 PSQL_MTLS_DISABLE_CONN_STR :str = f"host={PSQL_CLIENT_HOST} port={PG_SRV_PORT_MTLS} user=myuser sslmode=disable sslcert={STACKQL_PG_CLIENT_CERT_PATH} sslkey={STACKQL_PG_CLIENT_KEY_PATH} sslrootcert={STACKQL_PG_SERVER_CERT_PATH} dbname=mydatabase"
@@ -937,6 +940,7 @@ def get_variables(execution_env :str, sql_backend_str :str, use_stackql_preinsta
     'PG_CLIENT_SETUP_QUERIES':                                                [ SHOW_TRANSACTION_ISOLATION_LEVEL, SELECT_HSTORE_DETAILS ],
     'PG_CLIENT_SETUP_QUERIES_JSON_EXPECTED':                                  SHOW_TRANSACTION_ISOLATION_LEVEL_JSON_EXPECTED + SELECT_HSTORE_DETAILS_JSON_EXPECTED,
     'PG_CLIENT_SETUP_QUERIES_TUPLES_EXPECTED':                                SHOW_TRANSACTION_ISOLATION_LEVEL_TUPLES_EXPECTED + SELECT_HSTORE_DETAILS_TUPLES_EXPECTED,
+    'PSQL_PASSWORD':                                                          generate_password(),
     'QUERY_PARSER_TEST_KEYWORD_QUOTING':                                      _QUERY_PARSER_TEST_KEYWORD_QUOTING,
     'QUERY_PARSER_TEST_POSTGRES_CASTING':                                     _QUERY_PARSER_TEST_POSTGRES_CASTING,
     'REGISTRY_GOOGLE_PROVIDER_LIST':                                          REGISTRY_GOOGLE_PROVIDER_LIST,


### PR DESCRIPTION


## Description

- `psql` connection driven by env vars.
- Added robot test `Acceptable Password Only PSQL Connection Defined by Env Vars to Server With Diagnostic Query Returns Connection Info`.
- Added robot test `Acceptable Secure PSQL Connection Defined by Env Vars to mTLS Server With Diagnostic Query Returns Connection Info`.






<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Please explain**: Test expansion to prevent regression.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Acceptable Password Only PSQL Connection Defined by Env Vars to Server With Diagnostic Query Returns Connection Info`.
- Added robot test `Acceptable Secure PSQL Connection Defined by Env Vars to mTLS Server With Diagnostic Query Returns Connection Info`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
