### PR TITLE
add unit testing for sqlcontrol package

### DIFF
--- a/internal/stackql/sqlcontrol/sqlcontrol_test.go
+++ b/internal/stackql/sqlcontrol/sqlcontrol_test.go
@@ -1,0 +1,39 @@
+package sqlcontrol_test
+
+import (
+	"testing"
+
+	. "github.com/stackql/stackql/internal/stackql/sqlcontrol"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetControlAttributes tests the GetControlAttributes function.
+func TestGetControlAttributes(t *testing.T) {
+	t.Run("standard type", func(t *testing.T) {
+		attrType := "standard"
+		controlAttrs := GetControlAttributes(attrType)
+
+		assert.NotNil(t, controlAttrs, "Expected non-nil ControlAttributes for standard attrType")
+	})
+
+	t.Run("non-standard type", func(t *testing.T) {
+		attrType := "non-standard"
+		controlAttrs := GetControlAttributes(attrType)
+
+		assert.NotNil(t, controlAttrs, "Expected non-nil ControlAttributes for non-standard attrType")
+	})
+}
+
+// TestStandardControlAttributes tests the standardControlAttributes' methods.
+func TestStandardControlAttributes(t *testing.T) {
+	ca := GetControlAttributes("standard")
+
+	assert.Equal(t, "iql_generation_id", ca.GetControlGenIDColumnName(), "Expected iql_generation_id")
+	assert.Equal(t, "iql_session_id", ca.GetControlSsnIDColumnName(), "Expected iql_session_id")
+	assert.Equal(t, "iql_txn_id", ca.GetControlTxnIDColumnName(), "Expected iql_txn_id")
+	assert.Equal(t, "iql_insert_id", ca.GetControlInsIDColumnName(), "Expected iql_insert_id")
+	assert.Equal(t, "iql_insert_encoded", ca.GetControlInsertEncodedIDColumnName(), "Expected iql_insert_encoded")
+	assert.Equal(t, "iql_max_txn_id", ca.GetControlMaxTxnColumnName(), "Expected iql_max_txn_id")
+	assert.Equal(t, "iql_last_modified", ca.GetControlLatestUpdateColumnName(), "Expected iql_last_modified")
+	assert.Equal(t, "iql_gc_status", ca.GetControlGCStatusColumnName(), "Expected iql_gc_status")
+}


### PR DESCRIPTION
## Description

Added unit testing for internal/stackql/sqlcontrol pacakge

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  Unit test.

## Issues referenced.
Closes #265 

## Evidence
![image](https://github.com/user-attachments/assets/60d540be-0bc3-4279-ba51-0f648acb8067)


## Checklist:
- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

## Tech Debt