### PR TITLE
percent-render

### DIFF
--- a/internal/stackql/presentation/presentation.go
+++ b/internal/stackql/presentation/presentation.go
@@ -8,6 +8,7 @@ import (
 
 type Driver interface {
 	Sprintf(format string, args ...interface{}) string
+	Print(s string) string
 }
 
 type prezzoDriver struct {
@@ -23,4 +24,8 @@ func NewPresentationDriver(runtimeCtx dto.RuntimeCtx) Driver {
 
 func (prezzoDriver *prezzoDriver) Sprintf(format string, args ...interface{}) string {
 	return fmt.Sprintf(format, args...)
+}
+
+func (prezzoDriver *prezzoDriver) Print(s string) string {
+	return fmt.Sprint(s)
 }

--- a/internal/stackql/writer/writer.go
+++ b/internal/stackql/writer/writer.go
@@ -41,7 +41,7 @@ type StdStreamWriter struct {
 }
 
 func (ssw *StdStreamWriter) render(p []byte) []byte {
-	return []byte(ssw.prezzoDriver.Sprintf(string(p)))
+	return []byte(ssw.prezzoDriver.Print(string(p)))
 }
 
 func (ssw *StdStreamWriter) enclose(p []byte) []byte {


### PR DESCRIPTION
## Description

- Bugfix for shell display of `%` user input.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

This is lacking; we do not have a test harness for shell display.

Anecdotally, this is the errant behaviour for shell input `show services in google like '%';`, the display shows:

```
show services in google like '%!'(MISSING);
```

...and this is the fix:

```
show services in google like '%';
```

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

- Evidence is lacking; we do not have a test harness for shell display.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

- This change does not *introduce* technical debt, however we should add a test harness for shell display.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
