### PR TITLE
Added unit testing for astformat

### DIFF
--- a/internal/stackql/astformat/ast_format_test.go
+++ b/internal/stackql/astformat/ast_format_test.go
@@ -1,0 +1,88 @@
+package astformat
+
+import (
+	"testing"
+
+	"github.com/stackql/stackql/internal/stackql/parser"
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// sqlNodes are used for both
+var selectNode, dropNode sqlparser.Statement
+func TestMain(m *testing.M){
+  p, _ := parser.NewParser()
+  selectNode, _ = p.ParseQuery("select 1+2*3 from a WHERE a.v1 = 3")
+  dropNode, _ = p.ParseQuery("DROP TABLE tab");
+  m.Run()
+}
+
+
+func TestPostgresSelectExprsFormatter (t *testing.T){
+  // only covers SELECT and DROP Statements
+  // Doesn't cover most actual SQL Nodes 
+  // no constructor for ColName, ColIdent, ...
+  tests := []struct {
+    name string
+    node sqlparser.SQLNode
+    expected string
+  }{
+    {
+      "PostgresSelectExprsFormatter: select",
+      selectNode.(sqlparser.SQLNode),
+      "select 1 + 2 * 3 from \"a\" where \"a\".v1 = 3",
+    },
+    {
+      "PostgresSelectExprsFormatter: drop",
+      dropNode.(sqlparser.SQLNode),
+      "drop table \"tab\"",
+    },
+  }
+  for _, tt := range tests{
+    t.Run(tt.name, func(t *testing.T){
+      buf := sqlparser.NewTrackedBuffer(nil)
+
+      PostgresSelectExprsFormatter(buf, tt.node)
+      
+      //assert.Equal(t, fmt.Sprintf("TYPE: %T\n",tt.node), "")
+      switch tt.node.(type){
+      case *sqlparser.GroupConcatExpr:
+          assert.Equal(t,true,false)
+          break
+      }
+      assert.Equal(t, tt.expected, buf.String())
+    })
+  }
+}
+
+
+
+func TestString(t *testing.T){
+
+  tests := []struct {
+    name  string
+    node sqlparser.SQLNode
+    expected string
+  }{
+    {
+      "string: select query",
+      selectNode.(sqlparser.SQLNode),
+      "select 1 + 2 * 3 from \"a\" where \"a\".\"v1\" = 3",
+    },
+    {
+      "string: drop query",
+      dropNode.(sqlparser.SQLNode),
+      "drop table \"tab\"",
+    },
+  }
+  var formatter sqlparser.NodeFormatter = PostgresSelectExprsFormatter
+  for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T){
+      got := String(tt.node, formatter)
+      assert.Equal(t, tt.expected, got) 
+    })
+  }
+}
+
+

--- a/internal/stackql/astformat/ast_format_test.go
+++ b/internal/stackql/astformat/ast_format_test.go
@@ -1,88 +1,97 @@
-package astformat
+package astformat //nolint:testpackage // don't use an underscore in package name
 
 import (
 	"testing"
 
-	"github.com/stackql/stackql/internal/stackql/parser"
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/parser"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// sqlNodes are used for both
-var selectNode, dropNode sqlparser.Statement
-func TestMain(m *testing.M){
-  p, _ := parser.NewParser()
-  selectNode, _ = p.ParseQuery("select 1+2*3 from a WHERE a.v1 = 3")
-  dropNode, _ = p.ParseQuery("DROP TABLE tab");
-  m.Run()
+// sqlNodes are used for both.
+//
+//nolint:gochecknoglobals // allows test functions to share test cases, only used by ast_format_test, unique names
+var astFormatTestselectNode, astFormatTestdropNode sqlparser.Statement
+
+func TestMain(m *testing.M) {
+	p, _ := parser.NewParser()
+	astFormatTestselectNode, _ = p.ParseQuery("select 1+2*3 from a WHERE a.v1 = 3")
+	astFormatTestdropNode, _ = p.ParseQuery("DROP TABLE tab")
+	m.Run()
 }
 
+func TestPostgresSelectExprsFormatter(t *testing.T) {
+	// only covers SELECT and DROP Statements.
+	// Doesn't cover most actual SQL Nodes.
+	// no constructor for ColName, ColIdent, ...
+	selNode, ok1 := astFormatTestselectNode.(sqlparser.SQLNode)
+	droNode, ok2 := astFormatTestdropNode.(sqlparser.SQLNode)
+	if !ok1 || !ok2 {
+		t.Errorf("selectNode and/or dropNode are not of type sqlparser.SQLNode")
+		return
+	}
+	tests := []struct {
+		name     string
+		node     sqlparser.SQLNode
+		expected string
+	}{
+		{
+			"PostgresSelectExprsFormatter: select",
+			selNode,
+			"select 1 + 2 * 3 from \"a\" where \"a\".v1 = 3",
+		},
+		{
+			"PostgresSelectExprsFormatter: drop",
+			droNode,
+			"drop table \"tab\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := sqlparser.NewTrackedBuffer(nil)
 
-func TestPostgresSelectExprsFormatter (t *testing.T){
-  // only covers SELECT and DROP Statements
-  // Doesn't cover most actual SQL Nodes 
-  // no constructor for ColName, ColIdent, ...
-  tests := []struct {
-    name string
-    node sqlparser.SQLNode
-    expected string
-  }{
-    {
-      "PostgresSelectExprsFormatter: select",
-      selectNode.(sqlparser.SQLNode),
-      "select 1 + 2 * 3 from \"a\" where \"a\".v1 = 3",
-    },
-    {
-      "PostgresSelectExprsFormatter: drop",
-      dropNode.(sqlparser.SQLNode),
-      "drop table \"tab\"",
-    },
-  }
-  for _, tt := range tests{
-    t.Run(tt.name, func(t *testing.T){
-      buf := sqlparser.NewTrackedBuffer(nil)
+			PostgresSelectExprsFormatter(buf, tt.node)
 
-      PostgresSelectExprsFormatter(buf, tt.node)
-      
-      //assert.Equal(t, fmt.Sprintf("TYPE: %T\n",tt.node), "")
-      switch tt.node.(type){
-      case *sqlparser.GroupConcatExpr:
-          assert.Equal(t,true,false)
-          break
-      }
-      assert.Equal(t, tt.expected, buf.String())
-    })
-  }
+			// assert.Equal(t, fmt.Sprintf("TYPE: %T\n",tt.node), "").
+			switch tt.node.(type) { //nolint:gocritic // switch makes it easily extendable in case we want to add more test cases
+			case *sqlparser.GroupConcatExpr:
+				assert.Equal(t, true, false)
+			}
+			assert.Equal(t, tt.expected, buf.String())
+		})
+	}
 }
 
+func TestString(t *testing.T) {
+	selNode, ok1 := astFormatTestselectNode.(sqlparser.SQLNode)
+	droNode, ok2 := astFormatTestdropNode.(sqlparser.SQLNode)
+	if !ok1 || !ok2 {
+		t.Errorf("selectNode and/or dropNode are not of type sqlparser.SQLNode")
+		return
+	}
 
-
-func TestString(t *testing.T){
-
-  tests := []struct {
-    name  string
-    node sqlparser.SQLNode
-    expected string
-  }{
-    {
-      "string: select query",
-      selectNode.(sqlparser.SQLNode),
-      "select 1 + 2 * 3 from \"a\" where \"a\".\"v1\" = 3",
-    },
-    {
-      "string: drop query",
-      dropNode.(sqlparser.SQLNode),
-      "drop table \"tab\"",
-    },
-  }
-  var formatter sqlparser.NodeFormatter = PostgresSelectExprsFormatter
-  for _, tt := range tests {
-    t.Run(tt.name, func(t *testing.T){
-      got := String(tt.node, formatter)
-      assert.Equal(t, tt.expected, got) 
-    })
-  }
+	tests := []struct {
+		name     string
+		node     sqlparser.SQLNode
+		expected string
+	}{
+		{
+			"string: select query",
+			selNode,
+			"select 1 + 2 * 3 from \"a\" where \"a\".\"v1\" = 3",
+		},
+		{
+			"string: drop query",
+			droNode,
+			"drop table \"tab\"",
+		},
+	}
+	var formatter sqlparser.NodeFormatter = PostgresSelectExprsFormatter
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := String(tt.node, formatter)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
 }
-
-


### PR DESCRIPTION
…ring. Very sparse coverage for PostgresSelectExprsFormatting since I couldn't find a constructor for the ColIdent, ColName, and other SQLNode types.


## Description

Added sparse unit testing for astformat.PostgresSelectExprsFormatting and astformat.String. Very sparse coverage for PostgresSelectExprsFormatting since I couldn't find a constructor for the ColIdent, ColName, and other SQLNode types.

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [X] Other (eg: documentation change).  **Please explain**. Added testing

## Issues referenced.

Closes #285 

## Evidence

Added 2 test functions

## Checklist:

- [X] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [X] The changes are covered with functional and/or integration robot testing.
- [X] The changes work on all supported platforms.
- [X] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [X] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [X] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A

## Tech Debt

If parser.ParseQuery or the function's in astformat's signature or return changed significantly, these methods would most likely break.

If parser.ParseQuery functionality is even slightly modified, the asserts would fail, but this could be fixed very easily, since the assert compare the strings and have no logic to allow different case of ' vs "

## Other

Test has sparse coverage. If you have suggestions on how to improve this pr, or if it should be postponed until constructors for types of SQLNodes is implemented, that is ok with me.
