### PR TITLE
k8s-provider-automation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,5 @@ self-hosted-runner:
   labels:
     - ubuntu-latest-m
     - arm-ubuntu-22-04-runner-one
+    - macos-13 # should not be necessary
+    - macos-14 # should not be necessary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
     - name: Output from mocked functional tests
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml || echo "no functional test output present"
+        cat ./test/robot/reports/output.xml || echo "no functional test output present"
     
     - name: Run robot integration tests
       if: env.AZURE_CLIENT_SECRET != '' && startsWith(env.STATE_SOURCE_TAG, 'build-release')
@@ -381,7 +381,7 @@ jobs:
     - name: Output from mocked functional tests
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
 
     - name: Run robot mocked functional tests with aggressive concurrency
       if: success()
@@ -391,7 +391,7 @@ jobs:
     - name: Output from mocked functional tests with aggressive concurrency
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
     
     - name: Run robot integration tests
       if: env.AZURE_CLIENT_SECRET != '' && startsWith(env.STATE_SOURCE_TAG, 'build-release')
@@ -452,7 +452,7 @@ jobs:
     - name: Output from mocked deb package functional tests
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
 
     - name: Upload deb Artifact
       uses: actions/upload-artifact@v4.3.1
@@ -637,7 +637,7 @@ jobs:
     - name: Output from mocked functional tests
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
 
     - name: Run robot mocked functional tests with aggressive concurrency
       if: success()
@@ -647,7 +647,7 @@ jobs:
     - name: Output from mocked functional tests with aggressive concurrency
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
     
     - name: Run robot integration tests
       if: env.AZURE_CLIENT_SECRET != '' && startsWith(env.STATE_SOURCE_TAG, 'build-release')
@@ -735,7 +735,7 @@ jobs:
     - name: Output from mocked deb package functional tests
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
 
     - name: Upload deb Artifact
       uses: actions/upload-artifact@v4.3.1
@@ -833,7 +833,7 @@ jobs:
       name: Output from mocked functional tests
       if: always()
       run: |
-          cat ./test/robot/functional/output.xml
+          cat ./test/robot/reports/output.xml
     
     - shell: wsl-bash {0}
       name: Run robot integration tests
@@ -863,11 +863,14 @@ jobs:
 
   macosbuild:
     name: MacOS Build
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4.1.1
+
+    - name: Set env # awful hack to get java 8 and support the abomnible mock server template grammar
+      run: echo "JAVA_HOME=${JAVA_HOME_8_X64}" >> "$GITHUB_ENV"
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v5.0.0
@@ -892,8 +895,9 @@ jobs:
             echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}"
           } >> "${GITHUB_STATE}"
 
-    - name: Install Python dependencies
+    - name: Install Various dependencies
       run: |
+        brew install postgresql
         pip3 install -r cicd/requirements.txt
     
     - name: Generate rewritten registry for simulations
@@ -971,7 +975,7 @@ jobs:
     - name: Output from mocked functional tests
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
     
     - name: Run robot integration tests
       if: env.AZURE_CLIENT_SECRET != '' && startsWith(env.STATE_SOURCE_TAG, 'build-release')
@@ -1002,7 +1006,7 @@ jobs:
 
   macosarmbuild:
     name: MacOS ARM Build
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
     steps:
 
@@ -1258,7 +1262,7 @@ jobs:
     - name: Output from mocked functional tests
       if: always()
       run: |
-        cat ./test/robot/functional/output.xml
+        cat ./test/robot/reports/output.xml
 
     - name: Run robot integration tests
       if: env.AZURE_CLIENT_SECRET != '' && startsWith(env.STATE_SOURCE_TAG, 'build-release')

--- a/cicd/python/build.py
+++ b/cicd/python/build.py
@@ -43,7 +43,7 @@ def run_robot_mocked_functional_tests_stackql(*args, **kwargs) -> int:
     return subprocess.call(
         'robot '
         f'{variables} ' 
-        '-d test/robot/functional '
+        '-d test/robot/reports '
         'test/robot/functional',
         shell=True
     )

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -7,6 +7,7 @@ Summary:
 - At present, PR checks, build and test are all performed through [.github/workflows/go.yml](/.github/workflows/go.yml).
 - Releasing over various channels (website, homebrew, chocolatey...) is performed manually.
 - The strategic state is to split the functions: PR checks, build and test; into separate files, and migrate to use [goreleaser](https://goreleaser.com/).
+- Should take the hint from docker to [speed up multi-platform builds using multiple runners](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners).
 
 
 ## Secrets
@@ -15,3 +16,7 @@ In lieu of a full implementation of [github actions best practices](https://secu
 - Pull request checks use [the pull_request event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), as per [best practices](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
 - Integration test steps, which require secrets, leverage [the github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to avoid running where secrets are absent.
     - Therefore, external fork PRs, which are the community contribution model, do not run integration tests.  Strategically, we may funnel community contribution though a staging branch and/or adopt release branches.  This is not an urgent consideration, and we shall decide after some reflection.
+
+## API mocking
+
+According to [this swagger-codegen example](https://github.com/swagger-api/swagger-codegen/blob/master/bin/python-flask-petstore.sh), it is not overly difficult to generate python mocks from openapi docs.  This can then be used for credible regression testing against new provider docs and certainly the relationship of endpoints to stackql resources.  Know weakness: will not detect defective transform from source (eg: MS-graph, AWS) to openapi.

--- a/test/robot/functional/__init__.robot
+++ b/test/robot/functional/__init__.robot
@@ -1,5 +1,5 @@
 *** Settings ***
 Resource          ${CURDIR}/stackql.resource
 Suite Setup       Prepare StackQL Environment
-Suite Teardown    Terminate All Processes
+Suite Teardown    Terminate All Processes    kill=True
 

--- a/test/robot/lib/stackql_context.py
+++ b/test/robot/lib/stackql_context.py
@@ -857,7 +857,7 @@ def get_select_k8s_nodes_asc(execution_env :str) -> str:
   k8s_host = '127.0.0.1'
   if execution_env == 'docker':
     k8s_host = 'host.docker.internal'
-  return f"select name, uid, creationTimestamp from k8s.core_v1.node where cluster_addr = '{k8s_host}:{MOCKSERVER_PORT_K8S}' order by name asc;"
+  return f"select json_extract(metadata, '$.name') as name, json_extract(metadata, '$.uid') as uid, json_extract(metadata, '$.creationTimestamp') as creationTimestamp from k8s.core_v1.nodes where cluster_addr = '{k8s_host}:{MOCKSERVER_PORT_K8S}' order by name asc;"
 
 def get_registry_mock_url(execution_env :str) -> str:
   host = 'localhost'

--- a/test/robot/reports/.gitignore
+++ b/test/robot/reports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Description

- Prelude to mega robust product.
- New `k8s.core_v1` release candidate.
- Amended query supporting robot test `K8S Nodes Select Leveraging` JSON Path for updated `k8s.core_v1 interface.
- Send kill signal to destroy al web servers in CI.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Amended query supporting robot test `K8S Nodes Select Leveraging` JSON Path for updated `k8s.core_v1 interface.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is here introduced, however:

- It has been found that future versions of the `mockserver` `jar` file are incompatible with the `VELOCITY` template bodies currently in use with versioon `5.12.0`.  Even a migration to `5.13.0` is breaking.  Have created [this ticket](https://github.com/stackql/stackql/issues/478) to deal with the issue.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
