### PR TITLE
docker-ownership-debt-reduction

### DIFF
--- a/docker-compose-persist-postgres.yml
+++ b/docker-compose-persist-postgres.yml
@@ -3,6 +3,7 @@ version: "3.9"
 services:
   stackqlsrv:
     image: "${STACKQL_IMAGE_NAME:-stackql/stackql}"
+    user: "${UID}:${GID}"
     build:
       context: .
       cache_from: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
    
 services:
   stackqlsrv:
+    user: "${UID}:${GID}"
     image: "${STACKQL_IMAGE_NAME:-stackql/stackql}"
     build:
       context: .

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -7325,7 +7325,7 @@ Busted Auth Throws Error Then Set Statement Update Auth Scenario Working
     ...    stderr=${CURDIR}/tmp/Busted-Auth-Throws-Error-Then-Set-Statement-Update-Auth-Scenario-Working-Working-stderr.tmp
 
 Alternate App Root Persists All Temp Materials in Alotted Directory
-    # [Teardown]    Remove Directory    ${TEST_TMP_EXEC_APP_ROOT_NATIVE}    recursive=True
+    [Teardown]    Remove Directory    ${TEST_TMP_EXEC_APP_ROOT_NATIVE}    recursive=True
     ${inputStr} =    Catenate
     ...    registry pull google v0.1.2;
     ...    show providers;


### PR DESCRIPTION
## Description

- Empower host-side deletion for `stackql` docker container mounted directories by running these containers as the host user.
- `postgres` server container user not addressed at this time.
- Teadown now active and working for robot test `Alternate App Root Persists All Temp Materials in Alotted Directory`.
- Remaining robot tests continue to work post changes.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Teadown now active and working for robot test `Alternate App Root Persists All Temp Materials in Alotted Directory`.
- Remaining robot tests continue to work post changes.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
