### PR TITLE
busted-gha-ubuntu-docker

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,7 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
     - ubuntu-latest-m
+    - ubuntu-22-04-m
     - arm-ubuntu-22-04-runner-one
     - macos-13 # should not be necessary
     - macos-14 # should not be necessary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
 
   linuxbuild:
     name: Linux Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
     steps:
 
@@ -1081,7 +1081,7 @@ jobs:
   ##
   dockerbuild:
     name: Docker Build
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-22-04-m
     timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
     strategy:
       fail-fast: false
@@ -1366,7 +1366,7 @@ jobs:
         python cicd/python/build.py --robot-test-integration --config='{ "variables":  { "EXECUTION_PLATFORM": "docker" } }'
 
   dockermerge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - dockerbuild
     steps:

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -17,7 +17,7 @@ Summary:
     - This pattern is only required because if tag pushes are done concurrently, then identical multi-architecture tags are clobbered in a reverse race condition. 
     - **NOTE**: The QEMU build for linux/arm64 is **very slow**.  On the order of 30 minutes.  This is currently unavoidable.
     - **TODO**: Migrate linux/arm64 docker build to native once GHA supports this platform as a first class citizen.
-    - ~~**DANGER**: New pattern depends entirely on [docker manifest](https://docs.docker.com/reference/cli/docker/manifest/), which is marked "experimental" by the vendor.  Per [this stackoverflow answer](https://stackoverflow.com/a/66337328), in spite of fundamental instability, this is still the best option.~~
+    - **NOTE**.  Be careful selecting from [the available github actions runners](https://github.com/actions/runner-images).  Some runnner instances may be incompatible with assumed toolchain.
 
 
 ## Secrets


### PR DESCRIPTION
## Description

- Short term fix to avoid defective github action runner.
- Non standard runnner version pin.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- All tests pass.
- Private repository build succeeds for docker `arm64` per below screen grab.


<img width="1622" alt="Screenshot 2025-01-25 at 10 46 51 am" src="https://github.com/user-attachments/assets/022f43de-69e9-4879-ab09-53d950cded18" />



<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

- This does not accrue technical debt.
- That said, 

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
