### PR TITLE
tcp-lb

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,6 +3,7 @@ self-hosted-runner:
   labels:
     - ubuntu-latest-m
     - ubuntu-22-04-m
+    - ubuntu-22-04-arm64-m
     - arm-ubuntu-22-04-runner-one
     - macos-13 # should not be necessary
     - macos-14 # should not be necessary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,58 +360,6 @@ jobs:
           exit 1
         fi
 
-    - name: Create certificates for robot tests
-      run: |
-        openssl req -x509 -keyout test/server/mtls/credentials/pg_server_key.pem -out test/server/mtls/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
-        openssl req -x509 -keyout test/server/mtls/credentials/pg_client_key.pem -out test/server/mtls/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
-        openssl req -x509 -keyout test/server/mtls/credentials/pg_rubbish_key.pem -out test/server/mtls/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365 
-
-    - name: Run robot mocked functional tests
-      if: success()
-      run: |
-        python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true" } }'
-
-    - name: Output from mocked functional tests
-      if: always()
-      run: |
-        cat ./test/robot/reports/output.xml
-
-    - name: Run robot mocked functional tests with aggressive concurrency
-      if: success()
-      run: |
-        echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
-        echo "## End ##"
-        python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true", "CONCURRENCY_LIMIT": -1  } }'
-
-    - name: Output from mocked functional tests with aggressive concurrency
-      if: always()
-      run: |
-        cat ./test/robot/reports/output.xml
-    
-    - name: Run robot integration tests
-      if: env.AZURE_CLIENT_SECRET != '' && startsWith(env.STATE_SOURCE_TAG, 'build-release')
-      env:
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        AZURE_INTEGRATION_TESTING_SUB_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      run: |
-        echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
-        echo "## End ##"
-        python cicd/python/build.py --robot-test-integration
-    
-    - name: Prepare Test DB
-      if: success()
-      run: cp test/db/db.sqlite test/db/tmp/python-tests-tmp-db.sqlite
-
-    - name: Test Script
-      if: success()
-      run: python3 "${TESTSCRIPT}"
-      env:
-        TESTSCRIPT: ${{env.TESTSCRIPT}}
-
     - name: Upload Artifact
       uses: actions/upload-artifact@v4.3.1
       if: success()
@@ -435,26 +383,6 @@ jobs:
         # depends: 'libc6 (>= 2.2.1), git'
         desc: 'stackql treats the internet as a relational database'
         homepage: 'https://stackql.io'
-    
-    - name: install and test deb package
-      run: |
-        mkdir -p deb_test
-        cp stackql_${{env.BUILDMAJORVERSION}}.${{env.BUILDMINORVERSION}}.${{env.BUILDPATCHVERSION}}_amd64.deb deb_test/
-        sudo dpkg -i ./deb_test/stackql_${{env.BUILDMAJORVERSION}}.${{env.BUILDMINORVERSION}}.${{env.BUILDPATCHVERSION}}_amd64.deb
-        sudo apt-get install -f
-        echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
-        echo "## End ##"
-        python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true", "CONCURRENCY_LIMIT": -1, "USE_STACKQL_PREINSTALLED": "true"  } }'
-        stackqlLocation="$(which stackql 2>&1 | head -n 1)"
-        stackqlVersion="$(stackql --version 2>&1 | head -n 1)"
-        echo "stackql location: ${stackqlLocation}"
-        echo "stackql version: ${stackqlVersion}"
-    
-    - name: Output from mocked deb package functional tests
-      if: always()
-      run: |
-        cat ./test/robot/reports/output.xml
 
     - name: Upload deb Artifact
       uses: actions/upload-artifact@v4.3.1
@@ -463,6 +391,218 @@ jobs:
         name: amd64-artifact-deb
         path: |
           ./*.deb
+
+  linuxtest:
+    name: Linux Test
+    needs:
+      - linuxbuild
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        registry:
+          - test/registry-mocked
+          - test/registry
+    timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4.1.1
+
+    - name: Download Artifact
+      uses: actions/download-artifact@v4.1.2
+      with:
+        name: stackql_linux_amd64
+        path: build
+
+    
+    - name: Download deb Artifact
+      uses: actions/download-artifact@v4.1.2
+      with:
+        name: amd64-artifact-deb
+        path: .
+
+    - name: Check archive presence
+      run:  |
+        ls -al .
+      
+    
+    - name: Stackql permissions
+      run:  |
+        sudo chmod a+rwx build/stackql
+        ls -al build/stackql
+        ls -al .
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v5.0.0
+      with:
+        go-version: ^1.21
+        check-latest: true
+        cache: true
+      id: go
+    
+    - name: Setup Python
+      uses: actions/setup-python@v5.0.0
+      with:
+        cache: pip
+        python-version: '3.11' 
+    
+    - name: Git Ref Parse
+      id: git_ref_parse
+      run: |
+          {
+            echo "SOURCE_NAME=${GITHUB_REF#refs/*/}"
+            echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}"
+            echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}"
+          } >> "${GITHUB_STATE}"
+    
+    - name: Generate Version Env Vars
+      env:
+        BUILDCOMMITSHA: ${{github.sha}}
+        BUILDBRANCH: ${{github.ref}}
+        BUILDPLATFORM: ${{runner.os}}
+        BUILDPATCHVERSION: ${{github.run_number}}
+        CGO_ENABLED: 1
+        CGO_LDFLAGS: '-static'
+      run: |
+        source cicd/version.txt
+        export BUILDMAJORVERSION="$MajorVersion"
+        export BUILDMINORVERSION="$MinorVersion"
+        if [[ ! "$BUILDBRANCH" == "*develop" ]]
+          then
+          # shellcheck disable=2269
+          export BUILDPATCHVERSION="${BUILDPATCHVERSION}"
+        fi
+        BUILDSHORTCOMMITSHA="$(echo "${BUILDCOMMITSHA}" | cut -c 1-7)"
+        export BUILDSHORTCOMMITSHA
+        BUILDDATE="$(date)"
+        export BUILDDATE
+        echo "BUILDMAJORVERSION: ${BUILDMAJORVERSION}"
+        echo "BUILDMINORVERSION: ${BUILDMINORVERSION}"
+        echo "BUILDPATCHVERSION: ${BUILDPATCHVERSION}"
+        echo "BUILDBRANCH: ${BUILDBRANCH}"
+        echo "BUILDCOMMITSHA: ${BUILDCOMMITSHA}"
+        echo "BUILDSHORTCOMMITSHA: ${BUILDSHORTCOMMITSHA}"
+        echo "BUILDDATE: ${BUILDDATE}"
+        echo "BUILDPLATFORM: ${BUILDPLATFORM}"
+
+        {
+          echo "BUILDMAJORVERSION=${BUILDMAJORVERSION}"
+          echo "BUILDMINORVERSION=${BUILDMINORVERSION}"
+          echo "BUILDPATCHVERSION=${BUILDPATCHVERSION}"
+        } >> "${GITHUB_ENV}"
+        
+        if [ "${{ matrix.registry }}" = "test/registry" ]; then
+          echo '127.0.0.1   storage.googleapis.com' | sudo tee -a /etc/hosts
+        fi
+
+
+    - name: Install testing dependencies
+      run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends postgresql-client
+          if [ "${{ matrix.registry }}" = "test/registry" ]; then
+            sudo apt-get install -y curl gnupg2 ca-certificates lsb-release ubuntu-keyring
+            curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
+              | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+            gpg --dry-run --quiet --no-keyring --import --import-options import-show /usr/share/keyrings/nginx-archive-keyring.gpg
+            echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+              http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" \
+                  | sudo tee /etc/apt/sources.list.d/nginx.list
+            sudo apt-get update
+            sudo apt-get install nginx
+            sudo nginx -c "$(pwd)/test/tcp/reverse-proxy/nginx/elegant-sni-proxy.conf"
+          fi
+
+    - name: Install Python dependencies
+      run: |
+        pip3 install -r cicd/requirements.txt
+    
+    - name: Generate rewritten registry for simulations
+      if: ${{ matrix.registry  != 'test/registry' }}
+      run: |
+        python3 test/python/registry-rewrite.py
+
+    - name: Create certificates for robot tests
+      run: |
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_server_key.pem -out test/server/mtls/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_client_key.pem -out test/server/mtls/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_rubbish_key.pem -out test/server/mtls/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365 
+
+    - name: Run robot mocked functional tests
+      if: success()
+      run: |
+        if [ "${{ matrix.registry }}" = "test/registry" ]; then
+          robot \
+            --variable 'SUNDRY_CONFIG:{"registry_path": "test/registry"}' \
+            --variable SHOULD_RUN_DOCKER_EXTERNAL_TESTS:true \
+            --include tls_proxied \
+            -d test/robot/reports \
+            test/robot/functional
+        else
+          python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true" } }'
+        fi
+
+    - name: Output from mocked functional tests
+      if: always()
+      run: |
+        cat ./test/robot/reports/output.xml
+
+    - name: Run robot mocked functional tests with aggressive concurrency
+      if: success() && matrix.registry != 'test/registry'
+      run: |
+        echo "## Stray flask apps to be killed before robot tests ##"
+        pgrep -f flask | xargs kill -9 || true
+        echo "## End ##"
+        python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true", "CONCURRENCY_LIMIT": -1  } }'
+
+    - name: Output from mocked functional tests with aggressive concurrency
+      if: always() && matrix.registry != 'test/registry'
+      run: |
+        cat ./test/robot/reports/output.xml
+    
+    - name: Run robot integration tests
+      if: env.AZURE_CLIENT_SECRET != '' && startsWith(env.STATE_SOURCE_TAG, 'build-release') && matrix.registry != 'test/registry'
+      env:
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_INTEGRATION_TESTING_SUB_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      run: |
+        echo "## Stray flask apps to be killed before robot tests ##"
+        pgrep -f flask | xargs kill -9 || true
+        echo "## End ##"
+        python cicd/python/build.py --robot-test-integration
+    
+    - name: Prepare Test DB
+      if: success() && matrix.registry != 'test/registry'
+      run: cp test/db/db.sqlite test/db/tmp/python-tests-tmp-db.sqlite
+
+    - name: Test Script
+      if: success() && matrix.registry != 'test/registry'
+      run: python3 "${TESTSCRIPT}"
+      env:
+        TESTSCRIPT: ${{env.TESTSCRIPT}}
+    
+    - name: install and test deb package
+      if: matrix.registry != 'test/registry'
+      run: |
+        mkdir -p deb_test
+        cp stackql_${{env.BUILDMAJORVERSION}}.${{env.BUILDMINORVERSION}}.${{env.BUILDPATCHVERSION}}_amd64.deb deb_test/
+        sudo dpkg -i ./deb_test/stackql_${{env.BUILDMAJORVERSION}}.${{env.BUILDMINORVERSION}}.${{env.BUILDPATCHVERSION}}_amd64.deb
+        sudo apt-get install -f
+        echo "## Stray flask apps to be killed before robot tests ##"
+        pgrep -f flask | xargs kill -9 || true
+        echo "## End ##"
+        python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true", "CONCURRENCY_LIMIT": -1, "USE_STACKQL_PREINSTALLED": "true"  } }'
+        stackqlLocation="$(which stackql 2>&1 | head -n 1)"
+        stackqlVersion="$(stackql --version 2>&1 | head -n 1)"
+        echo "stackql location: ${stackqlLocation}"
+        echo "stackql version: ${stackqlVersion}"
+    
+    - name: Output from mocked deb package functional tests
+      if: always() && matrix.registry != 'test/registry'
+      run: |
+        cat ./test/robot/reports/output.xml
 
   linuxarmbuild:
     name: Linux arm64 Build
@@ -636,7 +776,7 @@ jobs:
       if: success()
       run: |
         echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
+        pgrep -f flask | xargs kill -9 || true
         echo "## End ##"
         python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true", "CONCURRENCY_LIMIT": -1  } }'
 
@@ -654,7 +794,7 @@ jobs:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       run: |
         echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
+        pgrep -f flask | xargs kill -9 || true
         echo "## End ##"
         python cicd/python/build.py --robot-test-integration
     
@@ -726,7 +866,7 @@ jobs:
         sudo dpkg -i "./deb_test/${DEB_FILE}"
         sudo apt-get install -f
         echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
+        pgrep -f flask | xargs kill -9 || true
         echo "## End ##"
         python cicd/python/build.py --robot-test  --config='{ "variables": { "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": "true", "CONCURRENCY_LIMIT": -1, "USE_STACKQL_PREINSTALLED": "true"  } }'
         stackqlLocation="$(which stackql 2>&1 | head -n 1)"
@@ -852,7 +992,7 @@ jobs:
             export BUILDPATCHVERSION="${BUILDPATCHVERSION}"
           fi
           echo "## Stray flask apps to be killed before robot tests ##"
-          pgrep -f flask | xargs kill -9
+          pgrep -f flask | xargs kill -9 || true
           echo "## End ##"
           python3 cicd/python/build.py --robot-test-integration --config='{ "variables":  { "IS_WSL": true } }'
 
@@ -971,7 +1111,7 @@ jobs:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       run: |
         echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
+        pgrep -f flask | xargs kill -9 || true
         echo "## End ##"
         python cicd/python/build.py --robot-test-integration
     
@@ -1081,7 +1221,7 @@ jobs:
   ##
   dockerbuild:
     name: Docker Build
-    runs-on: ubuntu-22-04-m
+    runs-on: ${{  matrix.platform == 'linux/arm64' && 'ubuntu-22-04-arm64-m' || 'ubuntu-22-04-m' }}
     timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
     strategy:
       fail-fast: false
@@ -1111,12 +1251,6 @@ jobs:
       
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
-    - name: Setup Python
-      uses: actions/setup-python@v5.0.0
-      with:
-        cache: pip
-        python-version: '3.11'
     
     - name: Git Ref Parse
       id: git_ref_parse
@@ -1152,9 +1286,6 @@ jobs:
             ); \
         then
           PUSH_IMAGE_REQUIRED="true"
-        fi
-        if [ "${{ matrix.platform }}" == "linux/arm64" ] && [ "${PUSH_IMAGE_REQUIRED}" = "false" ]; then
-          BUILD_IMAGE_REQUIRED="false"
         fi
         {
           echo "IMAGE_PLATFORM_SAN=$( sed 's/\//_/g' <<< '${{ matrix.platform }}' )";
@@ -1195,25 +1326,6 @@ jobs:
           echo "UID=${UID}"
           echo "GID=${GID}"
         } >> "${GITHUB_ENV}"
-    
-    - name: Install psql
-      if: env.BUILD_IMAGE_REQUIRED == 'true'
-      run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            postgresql-client \
-            ca-certificates \
-            openssl
-
-    # for some reason skipping this with env.BUILD_IMAGE_REQUIRED == 'true' breaks python cleanup where it can't find pip cache
-    - name: Install Python dependencies
-      run: |
-        pip3 install -r cicd/requirements.txt
-    
-    - name: Generate rewritten registry for simulations
-      if: env.BUILD_IMAGE_REQUIRED == 'true'
-      run: |
-        python3 test/python/registry-rewrite.py --replacement-host=host.docker.internal
 
     - name: Pull Docker base images for cache purposes
       if: env.BUILD_IMAGE_REQUIRED == 'true'
@@ -1225,16 +1337,6 @@ jobs:
       if: env.BUILD_IMAGE_REQUIRED == 'true'
       run: |
         docker pull --platform ${{ matrix.platform }} stackql/stackql:latest || echo 'could not pull image for cache purposes'
-
-    - name: Create certificates for robot tests
-      if: env.BUILD_IMAGE_REQUIRED == 'true'
-      run: |
-        openssl req -x509 -keyout test/server/mtls/credentials/pg_server_key.pem -out test/server/mtls/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
-        openssl req -x509 -keyout test/server/mtls/credentials/pg_client_key.pem -out test/server/mtls/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
-        openssl req -x509 -keyout test/server/mtls/credentials/pg_rubbish_key.pem -out test/server/mtls/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365 
-        openssl req -x509 -keyout cicd/vol/srv/credentials/pg_server_key.pem -out  cicd/vol/srv/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
-        openssl req -x509 -keyout cicd/vol/srv/credentials/pg_client_key.pem -out  cicd/vol/srv/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
-        openssl req -x509 -keyout cicd/vol/srv/credentials/pg_rubbish_key.pem -out cicd/vol/srv/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365
 
     - name: Build image precursors
       if: env.BUILD_IMAGE_REQUIRED == 'true'
@@ -1269,7 +1371,7 @@ jobs:
       run: |
         mkdir -p ${{ runner.temp }}/digests
         digest="${{ steps.img_build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests/${digest#sha256:}"          
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"        
 
     - name: Upload digest
       if: env.BUILD_IMAGE_REQUIRED == 'true'
@@ -1279,11 +1381,111 @@ jobs:
         path: ${{ runner.temp }}/digests/*
         if-no-files-found: error
 
+  
+  dockertest:
+    name: Docker Test
+    needs:
+      - dockerbuild
+    runs-on: ${{  matrix.platform == 'linux/arm64' && 'ubuntu-22-04-arm64-m' || 'ubuntu-22-04-m' }}
+    timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+        db_backend:
+          - sqlite
+          - postgres_tcp
+    steps:
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> "${GITHUB_ENV}"
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4.1.1
+    
+    
+    - name: Image  env sanitize
+      run: |
+        BUILD_IMAGE_REQUIRED="true"
+        PUSH_IMAGE_REQUIRED="false"
+        if [ "$( grep '^build-elide.*' <<< '${{ github.ref_name }}' )" !=  "" ]; then
+          BUILD_IMAGE_REQUIRED="false"
+        fi
+        # shellcheck disable=SC2235
+        if  ( \
+                [ "${{ github.repository }}" = "stackql/stackql" ] \
+                || [ "${{ github.repository }}" != "stackql/stackql-devel" ] \
+            ) \
+            && [ "${{ vars.CI_SKIP_DOCKER_PUSH }}" != "true" ] \
+            && [ "$( grep '^build-elide.*' <<< '${{ github.ref_name }}' )" =  "" ] \
+            && ( \
+                [ "${{ github.ref_type }}" = "branch" ] \
+                && [ "${{ github.ref_name }}" = "main" ] \
+                && [ "${{ github.event_name }}" = "push" ] \
+            ) \
+            || ( \
+                [ "${{ github.ref_type }}" = "tag" ] \
+                && [ "$( grep '^build-release.*' <<< '${{ github.ref_name }}' )" !=  "" ] \
+            ); \
+        then
+          PUSH_IMAGE_REQUIRED="true"
+        fi
+        {
+          echo "IMAGE_PLATFORM_SAN=$( sed 's/\//_/g' <<< '${{ matrix.platform }}' )";
+          echo "PUSH_IMAGE_REQUIRED=${PUSH_IMAGE_REQUIRED}";
+          echo "BUILD_IMAGE_REQUIRED=${BUILD_IMAGE_REQUIRED}";
+        } | tee -a "${GITHUB_ENV}"
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.STACKQL_IMAGE_NAME }}
+
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      if: env.BUILD_IMAGE_REQUIRED == 'true'
+      with:
+        path: ${{ runner.temp }}/digests
+        name: digests-${{ env.PLATFORM_PAIR }}
+
+    - name: Prepare digest information
+      working-directory: ${{ runner.temp }}/digests
+      run: |
+        platform=${{ matrix.platform }}
+        THIS_STACKQL_DIGEST="$(printf '%s' *)"
+        echo "THIS_STACKQL_DIGEST=${THIS_STACKQL_DIGEST}"
+        echo "platform=${platform}"
+        if [ "${THIS_STACKQL_DIGEST}" = "" ]; then
+          echo "No digest found for platform ${platform}" >&2
+          exit 1
+        fi
+        digestContainsSpaces="$(echo "${THIS_STACKQL_DIGEST}" | grep ' ')" || true
+        if [ "${digestContainsSpaces}" != "" ]; then
+          echo "Digest '${THIS_STACKQL_DIGEST}' contains spaces, as found for platform ${platform}" >&2
+          exit 1
+        fi
+        {
+          echo "THIS_STACKQL_DIGEST=${THIS_STACKQL_DIGEST}"
+        } >> "${GITHUB_ENV}"
+           
+      
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      if: env.BUILD_IMAGE_REQUIRED == 'true'
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
     - name: Pull by digest
       if: env.BUILD_IMAGE_REQUIRED == 'true'
       run: |
-        docker pull --platform ${{ matrix.platform }} ${{ env.STACKQL_IMAGE_NAME }}@${{ steps.img_build.outputs.digest }}
-        docker tag ${{ env.STACKQL_IMAGE_NAME }}@${{ steps.img_build.outputs.digest }} ${{ env.STACKQL_IMAGE_NAME }}:latest
+        docker pull --platform ${{ matrix.platform }} ${{ env.STACKQL_IMAGE_NAME }}@sha256:${{ env.THIS_STACKQL_DIGEST }}
+        docker tag ${{ env.STACKQL_IMAGE_NAME }}@sha256:${{ env.THIS_STACKQL_DIGEST }} ${{ env.STACKQL_IMAGE_NAME }}:latest
 
     - name: Debug info
       if: env.BUILD_IMAGE_REQUIRED == 'true'
@@ -1321,34 +1523,72 @@ jobs:
         echo "### ###"
         echo ""
 
+    - name: Install psql
+      if: env.BUILD_IMAGE_REQUIRED == 'true'
+      run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            postgresql-client \
+            ca-certificates \
+            openssl
+
+    - name: Setup Python
+      uses: actions/setup-python@v5.0.0
+      with:
+        cache: pip
+        python-version: '3.11'
+
+    # for some reason skipping this with env.BUILD_IMAGE_REQUIRED == 'true' breaks python cleanup where it can't find pip cache
+    - name: Install Python dependencies
+      run: |
+        pip3 install -r cicd/requirements.txt
+    
+    - name: Generate rewritten registry for simulations
+      if: env.BUILD_IMAGE_REQUIRED == 'true'
+      run: |
+        python3 test/python/registry-rewrite.py --replacement-host=host.docker.internal
+
+    
+    - name: Create certificates for robot tests
+      if: env.BUILD_IMAGE_REQUIRED == 'true'
+      run: |
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_server_key.pem -out test/server/mtls/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_client_key.pem -out test/server/mtls/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_rubbish_key.pem -out test/server/mtls/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365 
+        openssl req -x509 -keyout cicd/vol/srv/credentials/pg_server_key.pem -out  cicd/vol/srv/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout cicd/vol/srv/credentials/pg_client_key.pem -out  cicd/vol/srv/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout cicd/vol/srv/credentials/pg_rubbish_key.pem -out cicd/vol/srv/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365
+
     - name: Run robot mocked functional tests
-      if: success() && env.CI_IS_EXPRESS != 'true' && matrix.platform == 'linux/amd64' && env.BUILD_IMAGE_REQUIRED == 'true'
+      if: success() && env.CI_IS_EXPRESS != 'true' && matrix.platform == 'linux/amd64' && env.BUILD_IMAGE_REQUIRED == 'true' && matrix.db_backend == 'sqlite'
       timeout-minutes: ${{ vars.DEFAULT_STEP_TIMEOUT_MIN == '' && 20 || vars.DEFAULT_STEP_TIMEOUT_MIN }}
       run: |
+        sudo rm -rf test/tmp || true
+        mkdir -p test/tmp
         python cicd/python/build.py --robot-test --config='{ "variables":  { "EXECUTION_PLATFORM": "docker" } }'
 
     - name: Run POSTGRES BACKEND robot mocked functional tests
-      if: success() && env.CI_IS_EXPRESS != 'true' && matrix.platform == 'linux/amd64' && env.BUILD_IMAGE_REQUIRED == 'true'
+      if: success() && env.CI_IS_EXPRESS != 'true' && matrix.platform == 'linux/amd64' && env.BUILD_IMAGE_REQUIRED == 'true' && matrix.db_backend == 'postgres_tcp'
       timeout-minutes: ${{ vars.DEFAULT_LONG_STEP_TIMEOUT_MIN == '' && 40 || vars.DEFAULT_LONG_STEP_TIMEOUT_MIN }}
       run: |
+        sudo rm -rf test/tmp || true
+        mkdir -p test/tmp
         echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
+        pgrep -f flask | xargs kill -9 || true
         echo "## End ##"
         echo "## Stray docker containers before postgres robot tests ##"
         docker container ls --format "table {{.ID}}\t{{.Names}}\t{{.Ports}}" -a
         echo "## End ##"
         docker compose down
-        # shellcheck disable=SC2046
-        docker stop $(docker ps -a -q)
-        # shellcheck disable=SC2046
-        docker rm $(docker ps -a -q)
+        docker stop "$(docker ps -a -q)" || true
+        docker rm "$(docker ps -a -q)" || true
         echo "## Stray docker containers after clean up commands ##"
         docker container ls --format "table {{.ID}}\t{{.Names}}\t{{.Ports}}" -a
         echo "## End ##"
         python cicd/python/build.py --robot-test --config='{ "variables":  { "EXECUTION_PLATFORM": "docker", "SHOULD_RUN_DOCKER_EXTERNAL_TESTS": true, "SQL_BACKEND": "postgres_tcp" } }'
 
     - name: Output from mocked functional tests
-      if: always() && env.CI_IS_EXPRESS != 'true' && matrix.platform == 'linux/amd64' && env.BUILD_IMAGE_REQUIRED == 'true'
+      if: always() && env.CI_IS_EXPRESS != 'true' && matrix.platform == 'linux/amd64' && env.BUILD_IMAGE_REQUIRED == 'true' 
       run: |
         cat ./test/robot/reports/output.xml
 
@@ -1360,8 +1600,10 @@ jobs:
         AZURE_INTEGRATION_TESTING_SUB_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       run: |
+        sudo rm -rf test/tmp || true
+        mkdir -p test/tmp
         echo "## Stray flask apps to be killed before robot tests ##"
-        pgrep -f flask | xargs kill -9
+        pgrep -f flask | xargs kill -9 || true
         echo "## End ##"
         python cicd/python/build.py --robot-test-integration --config='{ "variables":  { "EXECUTION_PLATFORM": "docker" } }'
 
@@ -1369,6 +1611,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - dockerbuild
+      - dockertest
     steps:
 
       - name: Check out code into the Go module directory

--- a/test/assets/credentials/dummy/google/docker-functional-test-dummy-sa-key.json
+++ b/test/assets/credentials/dummy/google/docker-functional-test-dummy-sa-key.json
@@ -6,7 +6,7 @@
   "client_email": "silly-sa@silly-project-01.iam.gserviceaccount.com",
   "client_id": "11",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "http://host.docker.internal:2091/google/simple/token",
+  "token_uri": "https://host.docker.internal:2091/google/simple/token",
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/silly-sa%40silly-project-01.iam.gserviceaccount.com"
 }

--- a/test/assets/credentials/dummy/google/functional-test-dummy-sa-key.json
+++ b/test/assets/credentials/dummy/google/functional-test-dummy-sa-key.json
@@ -6,7 +6,7 @@
   "client_email": "silly-sa@silly-project-01.iam.gserviceaccount.com",
   "client_id": "11",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "http://localhost:2091/google/simple/token",
+  "token_uri": "https://localhost:2091/google/simple/token",
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/silly-sa%40silly-project-01.iam.gserviceaccount.com"
 }

--- a/test/python/flask/README.md
+++ b/test/python/flask/README.md
@@ -18,74 +18,80 @@ pgrep -f flask | xargs kill -9
 GCP mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/gcp/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port  1080
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/gcp/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port  1080
 ```
 
 Azure mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/azure/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --port 1095
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/azure/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1095
 ```
 
 Okta mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/okta/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port 1090
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/okta/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0  --port 1090
 ```
 
 AWS mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/aws/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port 1091
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/aws/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0  --port 1091
 ```
 
 Github mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/github/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port 1093
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/github/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1093
 ```
 
 Sumologic mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/okta/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port 1096
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/okta/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1096
 ```
 
 Digitalocean mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/digitalocean/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port 1097
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/digitalocean/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1097
 ```
 
 `googleadmin` mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/googleadmin/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port 1098
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/googleadmin/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1098
 ```
 
 stackql auth testing mocks:
 
 ```bash
-flask --app=${HOME}/stackql/stackql-devel/test/python/flask/static_auth/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem  --port  1170
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/static_auth/app run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port  1170
+```
+
+Token server mocks:
+
+```bash
+flask --app=${HOME}/stackql/stackql-devel/test/python/flask/oauth2/token_srv run --cert=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_cert.pem --key=${HOME}/stackql/stackql-devel/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port  2091
 ```
 
 
 ### Manually testing mocks
 
-With embedded `sqlite` (default):
+With embedded `sqlite` (default), from the root of this repository:
 
 ```bash
-export workspaceFolder='/path/to/repository/root'  # change this
+export workspaceFolder="$(pwd)"
 
 stackql --registry="{ \"url\": \"file://${workspaceFolder}/test/registry-mocked\", \"localDocRoot\": \"${workspaceFolder}/test/registry-mocked\", \"verifyConfig\": { \"nopVerify\": true } }" --tls.allowInsecure shell
 ```
 
-With `postgres`:
+With `postgres`, from the root of this repository:
 
 ```bash
 docker compose -f docker-compose-externals.yml up postgres_stackql -d
 
-export workspaceFolder='/path/to/repository/root'  # change this
+export workspaceFolder="$(pwd)"
 
 stackql --registry="{ \"url\": \"file://${workspaceFolder}/test/registry-mocked\", \"localDocRoot\": \"${workspaceFolder}/test/registry-mocked\", \"verifyConfig\": { \"nopVerify\": true } }" --tls.allowInsecure --sqlBackend="{ \"dbEngine\": \"postgres_tcp\", \"sqlDialect\": \"postgres\", \"dsn\": \"postgres://stackql:stackql@127.0.0.1:7432/stackql\" }" shell
 ```

--- a/test/python/flask/gcp/app.py
+++ b/test/python/flask/gcp/app.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def log_request_info():
     logger.info(f"Request: {request.method} {request.path} - Query: {request.args}")
 
-@app.route('/b', methods=['GET'])
+@app.route('/storage/v1/b', methods=['GET'])
 def v1_storage_buckets_list():
     if request.args.get('project') == 'stackql-demo':
         return render_template('buckets-list.json'), 200, {'Content-Type': 'application/json'}
@@ -70,11 +70,11 @@ def v1_projects_testing_project_locations_australia_southeast1_keyRings():
 def v1_projects_testing_project_locations_global_keyRings():
     return render_template('route_13_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/zones/australia-southeast1-a/instances/000000001/getIamPolicy', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/zones/australia-southeast1-a/instances/000000001/getIamPolicy', methods=['GET'])
 def projects_testing_project_zones_australia_southeast1_a_instances_000000001_getIamPolicy():
     return render_template('route_14_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/zones/australia-southeast1-a/machineTypes', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/zones/australia-southeast1-a/machineTypes', methods=['GET'])
 def machine_types():
     import math
 
@@ -146,15 +146,15 @@ def v1_projects_yet_another_project_aggregated_usableSubnetworks():
 def v1_projects_empty_project_aggregated_usableSubnetworks():
     return render_template('route_20_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/zones/australia-southeast1-a/acceleratorTypes', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/zones/australia-southeast1-a/acceleratorTypes', methods=['GET'])
 def projects_testing_project_zones_australia_southeast1_a_acceleratorTypes():
     return render_template('route_21_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/defective-response-content-project/zones/australia-southeast1-a/acceleratorTypes', methods=['GET'])
+@app.route('/compute/v1/projects/defective-response-content-project/zones/australia-southeast1-a/acceleratorTypes', methods=['GET'])
 def projects_testing_project_zones_australia_southeast1_a_acceleratorTypes_defective_response_type():
     return render_template('defective-content-type-accelerator-type-list.json'), 200, {'Content-Type': 'text/plain'}
 
-@app.route('/projects/another-project/zones/australia-southeast1-a/acceleratorTypes', methods=['GET'])
+@app.route('/compute/v1/projects/another-project/zones/australia-southeast1-a/acceleratorTypes', methods=['GET'])
 def projects_another_project_zones_australia_southeast1_a_acceleratorTypes():
     return render_template('route_22_template.json'), 200, {'Content-Type': 'application/json'}
 
@@ -166,27 +166,27 @@ def v3_projects_testproject_getIamPolicy():
 def v3_organizations_123456789012_getIamPolicy():
     return render_template('route_24_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/zones/australia-southeast1-a/disks', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/zones/australia-southeast1-a/disks', methods=['GET'])
 def projects_testing_project_zones_australia_southeast1_a_disks():
     return render_template('route_25_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/zones/australia-southeast1-b/disks', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/zones/australia-southeast1-b/disks', methods=['GET'])
 def projects_testing_project_zones_australia_southeast1_b_disks():
     return render_template('route_26_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/global/networks', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/global/networks', methods=['GET'])
 def projects_testing_project_global_networks():
     return render_template('route_27_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/regions/australia-southeast1/subnetworks', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/regions/australia-southeast1/subnetworks', methods=['GET'])
 def projects_testing_project_regions_australia_southeast1_subnetworks():
     return render_template('route_28_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/zones/australia-southeast1-a/instances', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/zones/australia-southeast1-a/instances', methods=['GET'])
 def projects_testing_project_zones_australia_southeast1_a_instances():
     return render_template('route_29_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/aggregated/instances', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/aggregated/instances', methods=['GET'])
 def projects_testing_project_aggregated_instances():
     return render_template('route_30_template.json'), 200, {'Content-Type': 'application/json'}
 
@@ -199,15 +199,15 @@ def v1_projects_testing_project_assets():
     # Increment the call counter
     return render_template('route_32_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/global/firewalls/allow-spark-ui', methods=['PUT'])
+@app.route('/compute/v1/projects/testing-project/global/firewalls/allow-spark-ui', methods=['PUT'])
 def projects_testing_project_global_firewalls_allow_spark_ui():
     return render_template('route_33_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/global/firewalls/some-other-firewall', methods=['PATCH'])
+@app.route('/compute/v1/projects/testing-project/global/firewalls/some-other-firewall', methods=['PATCH'])
 def projects_testing_project_global_firewalls_some_other_firewall():
     return render_template('route_34_template.json'), 200, {'Content-Type': 'application/json'}
 
-@app.route('/projects/testing-project/global/firewalls', methods=['GET'])
+@app.route('/compute/v1/projects/testing-project/global/firewalls', methods=['GET'])
 def projects_testing_project_global_firewalls():
     return render_template('route_35_template.json'), 200, {'Content-Type': 'application/json'}
 
@@ -215,7 +215,7 @@ def projects_testing_project_global_firewalls():
 # Initialize a counter to track the number of calls
 call_counter = {"firewalls": 0}
 
-@app.route('/projects/changing-project/global/firewalls', methods=['GET'])
+@app.route('/compute/v1/projects/changing-project/global/firewalls', methods=['GET'])
 def firewalls():
     # Increment the call counter
     call_counter["firewalls"] += 1

--- a/test/python/flask/static_auth/expectations.json
+++ b/test/python/flask/static_auth/expectations.json
@@ -2,7 +2,7 @@
   {
     "httpRequest": {
       "method": "GET",
-      "path": "/v1/collectors",
+      "path": "/api/v1/collectors",
       "headers": {
         "DD-API-KEY": ["^myusername$" ],
         "DD-APPLICATION-KEY": ["^mypassword$" ]
@@ -19,7 +19,7 @@
   {
     "httpRequest": {
       "method": "GET",
-      "path": "/v1/collectors/100000001",
+      "path": "/api/v1/collectors/100000001",
       "headers": {
         "Authorization": ["^Bearer\\ some-dummy-token$" ]
       }

--- a/test/python/flask/sumologic/expectations.json
+++ b/test/python/flask/sumologic/expectations.json
@@ -2,7 +2,7 @@
   {
     "httpRequest": {
       "method": "GET",
-      "path": "/v1/collectors"
+      "path": "/api/v1/collectors"
     },
     "httpResponse": {
       "template": "collectors-list-01.json",

--- a/test/registry/registry-verb-matching-src-docker/googleapis.com/v2.0.1/services-split/compute/compute-v1.yaml
+++ b/test/registry/registry-verb-matching-src-docker/googleapis.com/v2.0.1/services-split/compute/compute-v1.yaml
@@ -68593,7 +68593,7 @@ paths:
     - $ref: '#/components/parameters/uploadType'
     - $ref: '#/components/parameters/userIp'
 servers:
-- url: https://host.docker.internal:1080/
+- url: https://host.docker.internal:1080/compute/v1
 tags:
 - name: acceleratorTypes
 - name: addresses

--- a/test/registry/registry-verb-matching-src/googleapis.com/v2.0.1/services-split/compute/compute-v1.yaml
+++ b/test/registry/registry-verb-matching-src/googleapis.com/v2.0.1/services-split/compute/compute-v1.yaml
@@ -68593,7 +68593,7 @@ paths:
     - $ref: '#/components/parameters/uploadType'
     - $ref: '#/components/parameters/userIp'
 servers:
-- url: https://localhost:1080/
+- url: https://localhost:1080/compute/v1
 tags:
 - name: acceleratorTypes
 - name: addresses

--- a/test/registry/src/stackql_oauth2_testing/v0.1.0/provider.yaml
+++ b/test/registry/src/stackql_oauth2_testing/v0.1.0/provider.yaml
@@ -27,7 +27,7 @@ config:
     client_secret_env_var: 'YOUR_OAUTH2_CLIENT_SECRET_ENV_VAR'
     type: "oauth2"
     grant_type: "client_credentials"
-    token_url: 'http://localhost:2091/{{ .__env__YOUR_OAUTH2_SOME_SYSTEM_ACCOUNT_ID }}/simple/token'
+    token_url: 'https://localhost:2091/{{ .__env__YOUR_OAUTH2_SOME_SYSTEM_ACCOUNT_ID }}/simple/token'
     scopes:
       - 'scope-01'
       - 'scope-02'

--- a/test/robot/README.md
+++ b/test/robot/README.md
@@ -9,6 +9,17 @@
 - [x] fix library lifetimes issue; as per https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#creating-test-library-class-or-module.
 
 
+## Distributed testing
+
+It is convenient for development- and release-critical robot tests to reside in this repository, because it accelerates the 
+delivery cycle.  There are other repositories in the org that can re-use much of this functionality; ironically the best examples are dependencies:
+
+- [`any-sdk`](https://github.com/stackql/any-sdk).
+- [`stackql-provider-registry`](https://github.com/stackql/stackql-provider-registry).
+
+These may consume entire testing modules, or more nuanced [tag-based](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#tagging-test-cases) approaches, with [include](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#by-tag-names) and [skip](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#skip) capabilities.
+
+
 ## Running yourself
 
 ### Running mocked provider tests

--- a/test/robot/functional/stackql.resource
+++ b/test/robot/functional/stackql.resource
@@ -6,11 +6,13 @@ ${IS_WSL}                              false   # to be overridden from command l
 ${SHOULD_RUN_DOCKER_EXTERNAL_TESTS}    false   # to be overridden from command line, with string "true"
 ${CONCURRENCY_LIMIT}                   1       # to be overridden from command line, with integer value, -1 for no limit
 ${USE_STACKQL_PREINSTALLED}            false   # to be overridden from command line, with string "true"
+${SUNDRY_CONFIG}                       {}  # to be overridden from command line, with string value
 
 *** Settings ***
 Library           Process
 Library           OperatingSystem 
 Variables         ${LOCAL_LIB_HOME}/stackql_context.py    ${EXECUTION_PLATFORM}    ${SQL_BACKEND}    ${USE_STACKQL_PREINSTALLED}
+...               ${SUNDRY_CONFIG}
 Library           Process
 Library           OperatingSystem
 Library           String
@@ -21,18 +23,20 @@ Library           ${LOCAL_LIB_HOME}/web_service_keywords.py
 *** Keywords ***
 
 Start All Mock Servers
-    Create OAuth2 Client Credentials Web Service    ${MOCKSERVER_PORT_OAUTH_CLIENT_CREDENTIALS_TOKEN}
-    Create Github Web Service    ${MOCKSERVER_PORT_GITHUB}
-    Create GCP Web Service    ${MOCKSERVER_PORT_GOOGLE}
-    Create Okta Web Service    ${MOCKSERVER_PORT_OKTA}
-    Create AWS Web Service    ${MOCKSERVER_PORT_AWS}
-    Create Static Auth Web Service    ${MOCKSERVER_PORT_STACKQL_AUTH_TESTING}
-    Create Google Admin Web Service    ${MOCKSERVER_PORT_GOOGLEADMIN}
-    Create K8S Web Service    ${MOCKSERVER_PORT_K8S}
-    Create Registry Web Service    ${MOCKSERVER_PORT_REGISTRY}
-    Create Azure Web Service    ${MOCKSERVER_PORT_AZURE}
-    Create Sumologic Web Service    ${MOCKSERVER_PORT_SUMOLOGIC}
-    Create Digitalocean Web Service    ${MOCKSERVER_PORT_DIGITALOCEAN}
+    ${port_dict} =    Create Dictionary    
+    ...    oauth_client_credentials_token=${MOCKSERVER_PORT_OAUTH_CLIENT_CREDENTIALS_TOKEN}
+    ...    github=${MOCKSERVER_PORT_GITHUB}
+    ...    google=${MOCKSERVER_PORT_GOOGLE}
+    ...    okta=${MOCKSERVER_PORT_OKTA}
+    ...    aws=${MOCKSERVER_PORT_AWS}
+    ...    stackql_auth_testing=${MOCKSERVER_PORT_STACKQL_AUTH_TESTING}
+    ...    googleadmin=${MOCKSERVER_PORT_GOOGLEADMIN}
+    ...    k8s=${MOCKSERVER_PORT_K8S}
+    ...    registry=${MOCKSERVER_PORT_REGISTRY}
+    ...    azure=${MOCKSERVER_PORT_AZURE}
+    ...    sumologic=${MOCKSERVER_PORT_SUMOLOGIC}
+    ...    digitalocean=${MOCKSERVER_PORT_DIGITALOCEAN}
+    Start All Webservers    port_dict=${port_dict}
 
 
 Prepare StackQL Environment

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -4289,7 +4289,7 @@ Oauth2 CLient Credentials Auth Should Fail with Invalid Config
     Set Environment Variable    YOUR_OAUTH2_CLIENT_ID_ENV_VAR    dummy-client-id
     Set Environment Variable    YOUR_OAUTH2_CLIENT_SECRET_ENV_VAR    dummy-client-secret
     ${outputErrStr} =    Catenate    SEPARATOR=\n
-    ...    Get "https://${LOCAL_HOST_ALIAS}:1170/v1/collectors/100000001?": oauth2: cannot fetch token: 401 UNAUTHORIZED
+    ...    Get "https://${LOCAL_HOST_ALIAS}:1170/api/v1/collectors/100000001?": oauth2: cannot fetch token: 401 UNAUTHORIZED
     ...    Response: {"msg": "auth failed"}
     Should Stackql Exec Inline Equal Both Streams
     ...    ${STACKQL_EXE}
@@ -7365,7 +7365,7 @@ Busted Auth Throws Error Then Set Statement Update Auth Scenario Working
     ...    stderr=${CURDIR}/tmp/Busted-Auth-Throws-Error-Then-Set-Statement-Update-Auth-Scenario-Working-Working-stderr.tmp
 
 Alternate App Root Persists All Temp Materials in Alotted Directory
-    [Teardown]    Remove Directory    ${TEST_TMP_EXEC_APP_ROOT_NATIVE}    recursive=True
+    # [Teardown]    Remove Directory    ${TEST_TMP_EXEC_APP_ROOT_NATIVE}    recursive=True # does not work for docker
     ${inputStr} =    Catenate
     ...    registry pull google v0.1.2;
     ...    show providers;
@@ -7427,6 +7427,7 @@ View Tuple Replacement Working As Exemplified by AWS EC2 Instances List and Deta
     ...    repeat_count=20
 
 Google Buckets List With Date Logic Exemplifies Use of SQLite Math Functions
+    [Tags]   registry    tls_proxied
     Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    This is a valid case where the test is targetted at SQLite only
     ${inputStr} =    Catenate
     ...    SELECT name, timeCreated, floor(julianday('2025-01-27')-julianday(timeCreated)) as days_since_ceiling 

--- a/test/robot/integration/stackql.resource
+++ b/test/robot/integration/stackql.resource
@@ -4,11 +4,13 @@ ${EXECUTION_PLATFORM}          native   # to be overridden from command line, eg
 ${SQL_BACKEND}                 sqlite_embedded   # to be overridden from command line, eg "postgres_tcp"
 ${IS_WSL}                      false   # to be overridden from command line, with string "true"
 ${USE_STACKQL_PREINSTALLED}    false   # to be overridden from command line, with string "true"
+${SUNDRY_CONFIG}               {}  # to be overridden from command line, with string value
 
 *** Settings ***
 Library           Process
 Library           OperatingSystem 
 Variables         ${LOCAL_LIB_HOME}/stackql_context.py    ${EXECUTION_PLATFORM}    ${SQL_BACKEND}    ${USE_STACKQL_PREINSTALLED}
+...               ${SUNDRY_CONFIG}
 Library           Process
 Library           OperatingSystem
 Library           String

--- a/test/robot/lib/web_service_keywords.py
+++ b/test/robot/lib/web_service_keywords.py
@@ -8,32 +8,65 @@ from requests import get, post, Response
 
 import os
 
-from typing import Union, Tuple, List
+from typing import Union, Tuple, List, Optional
 
 @library
 class web_service_keywords(Process):
 
     _DEFAULT_SQLITE_DB_PATH: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "tmp", "robot_cli_affirmation_store.db"))
 
+    _DEFAULT_APP_ROOT: str = 'test/python/flask'
+
+    _DEFAULT_LOG_ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log'))
+
+    _DEFAULT_TLS_KEY_PATH: str = 'test/server/mtls/credentials/pg_server_key.pem'
+
+    _DEFAULT_TLS_CERT_PATH: str = 'test/server/mtls/credentials/pg_server_cert.pem'
+
+    _DEFAULT_MOCKSERVER_PORT_GOOGLE                         = 1080
+    _DEFAULT_MOCKSERVER_PORT_GOOGLEADMIN                    = 1098
+    _DEFAULT_MOCKSERVER_PORT_STACKQL_AUTH_TESTING           = 1170
+    _DEFAULT_MOCKSERVER_PORT_OKTA                           = 1090
+    _DEFAULT_MOCKSERVER_PORT_AWS                            = 1091
+    _DEFAULT_MOCKSERVER_PORT_K8S                            = 1092
+    _DEFAULT_MOCKSERVER_PORT_GITHUB                         = 1093
+    _DEFAULT_MOCKSERVER_PORT_AZURE                          = 1095
+    _DEFAULT_MOCKSERVER_PORT_SUMOLOGIC                      = 1096
+    _DEFAULT_MOCKSERVER_PORT_DIGITALOCEAN                   = 1097
+    _DEFAULT_MOCKSERVER_PORT_OAUTH_CLIENT_CREDENTIALS_TOKEN = 2091
+    _DEFAULT_MOCKSERVER_PORT_REGISTRY                       = 1094
+
     def _get_dsn(self) -> str:
         return self._DEFAULT_SQLITE_DB_PATH
 
-    def __init__(self):
+    def __init__(
+        self,
+        log_root: Optional[str] = None,
+        app_root: Optional[str] = None,
+        tls_key_path: Optional[str] = None,
+        tls_cert_path: Optional[str] = None
+    ):
+        _app_root: str = app_root if app_root else self._DEFAULT_APP_ROOT
+
+        self._log_root: str = log_root if log_root else self._DEFAULT_LOG_ROOT
+
         self._affirmation_store_web_service = None
-        self._web_server_app: str = 'test/python/flask/oauth2/token_srv'
-        self._github_app: str = 'test/python/flask/github/app'
-        self._gcp_app: str = 'test/python/flask/gcp/app'
-        self._okta_app: str = 'test/python/flask/okta/app'
-        self._static_auth_testing_app: str = 'test/python/flask/static_auth/app'
-        self._aws_app: str = 'test/python/flask/aws/app'
-        self._azure_app: str = 'test/python/flask/azure/app'
-        self._digitalocean_app: str = 'test/python/flask/digitalocean/app'
-        self._googleadmin_app: str = 'test/python/flask/googleadmin/app'
-        self._k8s_app: str = 'test/python/flask/k8s/app'
-        self._registry_app: str = 'test/python/flask/registry/app'
-        self._sumologic_app: str = 'test/python/flask/sumologic/app'
-        self._tls_key_path: str = 'test/server/mtls/credentials/pg_server_key.pem'
-        self._tls_cert_path: str = 'test/server/mtls/credentials/pg_server_cert.pem'
+
+        self._web_server_app: str = f'{_app_root}/oauth2/token_srv'
+        self._github_app: str = f'{_app_root}/github/app'
+        self._gcp_app: str = f'{_app_root}/gcp/app'
+        self._okta_app: str = f'{_app_root}/okta/app'
+        self._static_auth_testing_app: str = f'{_app_root}/static_auth/app'
+        self._aws_app: str = f'{_app_root}/aws/app'
+        self._azure_app: str = f'{_app_root}/azure/app'
+        self._digitalocean_app: str = f'{_app_root}/digitalocean/app'
+        self._googleadmin_app: str = f'{_app_root}/googleadmin/app'
+        self._k8s_app: str = f'{_app_root}/k8s/app'
+        self._registry_app: str = f'{_app_root}/registry/app'
+        self._sumologic_app: str = f'{_app_root}/sumologic/app'
+
+        self._tls_key_path: str = tls_key_path if tls_key_path else self._DEFAULT_TLS_KEY_PATH
+        self._tls_cert_path: str = tls_cert_path if tls_cert_path else self._DEFAULT_TLS_CERT_PATH
         super().__init__()
 
     @keyword
@@ -51,8 +84,10 @@ class web_service_keywords(Process):
             'run',
             f'--host={host}', # generally, `0.0.0.0`; otherwise, invisible on `docker.host.internal` etc
             f'--port={port}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'token-client-credentials-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'token-client-credentials-{port}-stderr.txt'))
+            f'--cert={self._tls_cert_path}',
+            f'--key={self._tls_key_path}',
+            stdout=os.path.abspath(os.path.join(self._log_root, f'token-client-credentials-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'token-client-credentials-{port}-stderr.txt'))
         )
     
     @keyword
@@ -72,8 +107,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'github-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'github-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'github-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'github-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -93,8 +128,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'gcp-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'gcp-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'gcp-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'gcp-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -114,8 +149,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'okta-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'okta-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'okta-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'okta-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -135,8 +170,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'aws-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'aws-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'aws-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'aws-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -156,8 +191,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'static-auth-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'static-auth-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'static-auth-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'static-auth-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -177,8 +212,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'google-admin-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'google-admin-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'google-admin-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'google-admin-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -198,8 +233,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'k8s-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'k8s-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'k8s-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'k8s-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -219,8 +254,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             # f'--cert={self._tls_cert_path}',
             # f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'registry-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'registry-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'registry-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'registry-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -240,8 +275,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'azure-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'azure-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'azure-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'azure-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -261,8 +296,8 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'sumologic-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'sumologic-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'sumologic-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'sumologic-server-{port}-stderr.txt'))
         )
     
     @keyword
@@ -282,9 +317,26 @@ class web_service_keywords(Process):
             f'--port={port}',
             f'--cert={self._tls_cert_path}',
             f'--key={self._tls_key_path}',
-            stdout=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'digitalocean-server-{port}-stdout.txt')),
-            stderr=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'log', f'digitalocean-server-{port}-stderr.txt'))
+            stdout=os.path.abspath(os.path.join(self._log_root, f'digitalocean-server-{port}-stdout.txt')),
+            stderr=os.path.abspath(os.path.join(self._log_root, f'digitalocean-server-{port}-stderr.txt'))
         )
+    
+    @keyword
+    def start_all_webservers(self, port_dict: Optional[dict] = None) -> None:
+        _port_dict: dict = port_dict if port_dict else {}
+
+        self.create_digitalocean_web_service(_port_dict.get('digitalocean', self._DEFAULT_MOCKSERVER_PORT_DIGITALOCEAN))
+        self.create_sumologic_web_service(_port_dict.get('sumologic', self._DEFAULT_MOCKSERVER_PORT_SUMOLOGIC))
+        self.create_registry_web_service(_port_dict.get('registry', self._DEFAULT_MOCKSERVER_PORT_REGISTRY))
+        self.create_k8s_web_service(_port_dict.get('k8s', self._DEFAULT_MOCKSERVER_PORT_K8S))
+        self.create_google_admin_web_service(_port_dict.get('googleadmin', self._DEFAULT_MOCKSERVER_PORT_GOOGLEADMIN))
+        self.create_azure_web_service(_port_dict.get('azure', self._DEFAULT_MOCKSERVER_PORT_AZURE))
+        self.create_aws_web_service(_port_dict.get('aws', self._DEFAULT_MOCKSERVER_PORT_AWS))
+        self.create_static_auth_web_service(_port_dict.get('static_auth_testing', self._DEFAULT_MOCKSERVER_PORT_STACKQL_AUTH_TESTING))
+        self.create_okta_web_service(_port_dict.get('okta', self._DEFAULT_MOCKSERVER_PORT_OKTA))
+        self.create_gcp_web_service(_port_dict.get('gcp', self._DEFAULT_MOCKSERVER_PORT_GOOGLE))
+        self.create_github_web_service(_port_dict.get('github', self._DEFAULT_MOCKSERVER_PORT_GITHUB))
+        self.create_oauth2_client_credentials_web_service(_port_dict.get('oauth_client_credentials_token', self._DEFAULT_MOCKSERVER_PORT_OAUTH_CLIENT_CREDENTIALS_TOKEN))
 
     @keyword
     def send_get_request(

--- a/test/tcp/reverse-proxy/nginx/README.md
+++ b/test/tcp/reverse-proxy/nginx/README.md
@@ -1,0 +1,43 @@
+
+
+## Runnning nginx as a pass through TCP proxy
+
+
+### Automated testing scenario
+
+This scenario requires `nginx` >= version `1.27.3` (and all of the `pip` requirements of this repository).
+
+This is not ideal for local running; great for CI lifecycles.  If you do this locally, you **must** restore `/etc/hosts`.
+
+We will need superuser privileges at times (via `sudo`) because we are editing `/etc/hosts` and using the protected port `443`.
+
+Please run all commands from the root of the repository:
+
+```bash
+{
+  echo '127.0.0.1   storage.googleapis.com'
+} | sudo tee -a /etc/hosts
+
+sudo nginx -c $(pwd)/test/tcp/reverse-proxy/nginx/tls-pass-through.conf
+
+```
+
+Then, run the robot tests that are suitable (as tags evolve, you may want to be more selective):
+
+```bash
+
+robot \
+  --variable 'SUNDRY_CONFIG:{"registry_path": "test/registry"}' \
+  --include tls_proxied \
+  -d test/robot/reports \
+  test/robot/functional
+
+```
+
+**Very important**; after this, restore `/etc/hosts` (BSD and GNU compatible, clunky expression):
+
+```bash
+
+sed '/storage.googleapis.com/d' /etc/hosts | sudo tee /etc/hosts
+
+```

--- a/test/tcp/reverse-proxy/nginx/elegant-sni-proxy.conf
+++ b/test/tcp/reverse-proxy/nginx/elegant-sni-proxy.conf
@@ -1,0 +1,31 @@
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+stream {  
+
+  map $ssl_preread_server_name $targetBackend {
+    storage.googleapis.com  127.0.0.1:1080;
+    localhost  127.0.0.1:2091;
+  }   
+ 
+  server {
+    listen 443; 
+        
+    proxy_connect_timeout 1s;
+    proxy_timeout 3s;
+    resolver 1.1.1.1;
+    
+    proxy_pass $targetBackend;       
+    ssl_preread on;
+  }
+}


### PR DESCRIPTION
Summary:

- TCP load-balanced mocking with unchanged provider docs in place.
- CI function for unchanged provider docs.
- Mocked provider APIs now compatible with actual path prefixes.
- Robot components configurable and reusable.
- Fit for sharing across `stackql` estate.
- Integration test more configurable.
- Integration testing by tag.
- Spped up and paralellise build and test.
- Split docker build and test.


## Description

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

Closes https://github.com/stackql/stackql/issues/393

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- All existing robot tests pass with new, improved path prefix mocks with total fidelity to original services.
- Verified to work for TCP (reverse) proxied provider mocks, per the new `Linux Test (test/registry)` job. 

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
