### PR TITLE
test-contains-both-streams

### DIFF
--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -2688,7 +2688,7 @@ Registry Pull Google Provider Specific Version Prerelease
     ...    successfully installed
 
 Registry Pull Google Provider Implicit Latest Version
-    Should Stackql Exec Inline Contain Stderr
+    Should Stackql Exec Inline Contain Both Streams
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
     ...    ${GITHUB_SECRET_STR}
@@ -2697,6 +2697,7 @@ Registry Pull Google Provider Implicit Latest Version
     ...    ${AUTH_CFG_STR}
     ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
     ...    registry pull google ;
+    ...    ${EMPTY}
     ...    successfully installed
 
 
@@ -3566,7 +3567,7 @@ Basic View Select Star of Cloud Control Resource Returns Expected Result
     ...    ${CURDIR}/tmp/Basic-View-Select-Star-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
 Select Star of EC2 Instances Returns Expected Result
-    Should StackQL Exec Inline Contain
+    Should StackQL Exec Inline Contain Both Streams
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
     ...    ${GITHUB_SECRET_STR}
@@ -3576,6 +3577,7 @@ Select Star of EC2 Instances Returns Expected Result
     ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
     ...    select * from aws.ec2.instances where region \= 'us-east-1' ;
     ...    vol-1234567890abcdef0
+    ...    ${EMPTY}
     ...    stdout=${CURDIR}/tmp/Select-Star-of-EC2-Instances-Returns-Expected-Result.tmp
 
 Select With IN Scalars inside WHERE Clause Returns Expected Result

--- a/test/robot/integration/stackql_integration_from_cmd_line.robot
+++ b/test/robot/integration/stackql_integration_from_cmd_line.robot
@@ -23,7 +23,7 @@ Azure Authenticated VM Sizes
     ...    stdout=${CURDIR}/tmp/Azure-Authenticated-VM-Sizes.tmp
 
 Faulty Auth Azure Authenticated VM Sizes
-    Should Stackql Exec Inline Contain stderr
+    Should Stackql Exec Inline Contain Both Streams
     ...    ${STACKQL_EXE}
     ...    ${OKTA_SECRET_STR}
     ...    ${GITHUB_SECRET_STR}
@@ -32,6 +32,7 @@ Faulty Auth Azure Authenticated VM Sizes
     ...    ${AUTH_AZURE_FAULTY}
     ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
     ...    ${AZURE_VM_SIZES_ENUMERATION}
+    ...    ${EMPTY}
     ...    credentials error
     ...    stdout=${CURDIR}/tmp/Faulty-Azure-Authenticated-VM-Sizes.tmp
     ...    stderr=${CURDIR}/tmp/Faulty-Azure-Authenticated-VM-Sizes-stderr.tmp

--- a/test/robot/lib/StackQLInterfaces.py
+++ b/test/robot/lib/StackQLInterfaces.py
@@ -101,6 +101,11 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       return stdout_ok and stderr_ok
     stderr_ok = self.should_be_equal(result.stderr, expected_stderr_output)
     return stdout_ok and stderr_ok
+  
+  def _contain_both_streams(self, result, expected_output, expected_stderr_output):
+    stdout_ok = self.should_contain(result.stdout, expected_output)
+    stderr_ok = self.should_contain(result.stderr, expected_stderr_output)
+    return stdout_ok and stderr_ok
 
   def _run_sqlite_command(self, sqlite_exe :str, sqlite_db_file :str, query :str, *args, **cfg):
     self.log_to_console(f"sqlite_exe = '{sqlite_exe}'")
@@ -927,6 +932,36 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
       **cfg
     )
     return self.should_contain(result.stdout, expected_output)
+  
+  @keyword
+  def should_stackql_exec_inline_contain_both_streams(
+    self, 
+    stackql_exe :str, 
+    okta_secret_str :str,
+    github_secret_str :str,
+    k8s_secret_str :str,
+    registry_cfg :RegistryCfg, 
+    auth_cfg_str :str,
+    sql_backend_cfg_str :str,
+    query :str,
+    expected_output :str,
+    expected_output_stderr :str,
+    *args,
+    **cfg
+  ):
+    result = self._run_stackql_exec_command(
+      stackql_exe, 
+      okta_secret_str,
+      github_secret_str,
+      k8s_secret_str,
+      registry_cfg, 
+      auth_cfg_str, 
+      sql_backend_cfg_str,
+      query,
+      *args,
+      **cfg
+    )
+    return self._contain_both_streams(result, expected_output, expected_output_stderr)
 
 
   @keyword


### PR DESCRIPTION
## Description

- Added new robot testing keyword `Should Stackql Exec Inline Contain Both Streams`.
- Updated selected positive and negative scenarios to use new keyword.
- Robot test `Registry Pull Google Provider Implicit Latest Version` uses new keyword for positive scenario.
- Robot test `Select Star of EC2 Instances Returns Expected Result` uses new keyword for positive scenario.
- Robot test `Faulty Auth Azure Authenticated VM Sizes` uses new keyword for negative scenario.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Robot test `Registry Pull Google Provider Implicit Latest Version` uses new keyword for positive scenario.
- Robot test `Select Star of EC2 Instances Returns Expected Result` uses new keyword for positive scenario.
- Robot test `Faulty Auth Azure Authenticated VM Sizes` uses new keyword for negative scenario.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
