### PR TITLE
added aws_json_equal sqlite ext function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jackc/pgx/v5 v5.0.4
 	github.com/lib/pq v1.10.4
 	github.com/magiconair/properties v1.8.6
-	github.com/mattn/go-sqlite3 v1.0.3-stackql
+	github.com/mattn/go-sqlite3 v1.0.4-stackql
 	github.com/olekukonko/tablewriter v0.0.0-20180130162743-b8a9be070da4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/snowflakedb/gosnowflake v1.6.16
@@ -131,4 +131,4 @@ require (
 
 replace github.com/chzyer/readline => github.com/stackql/readline v0.0.2-alpha05
 
-replace github.com/mattn/go-sqlite3 => github.com/stackql/stackql-go-sqlite3 v1.0.3-stackql
+replace github.com/mattn/go-sqlite3 => github.com/stackql/stackql-go-sqlite3 v1.0.4-stackql

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -6726,6 +6726,50 @@ Run JSON_EQUAL Tests
     ...    stdout=${CURDIR}/tmp/JSON_EQUAL_test_output.tmp
     ...    stderr=${CURDIR}/tmp/JSON_EQUAL_test_stderr.tmp
 
+Run AWS_POLICY_EQUAL Tests
+    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    TODO: FIX THIS... Skipping postgres backend test due to unsupported function aws_policy_equal
+    ${inputStr} =    Catenate
+    ...    SELECT
+    ...    aws_policy_equal(
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}',
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}'
+    ...    ) AS identical_policy_match,
+    ...    aws_policy_equal(
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:PutObject"],"Resource":"*"}]}',
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:PutObject","s3:GetObject"],"Resource":"*"}]}'
+    ...    ) AS unordered_action_match,
+    ...    aws_policy_equal(
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":"*"}]}',
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}'
+    ...    ) AS array_string_match,
+    ...    aws_policy_equal(
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:role/role1"},"Action":"s3:*","Resource":"*"}]}',
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:role/role1"},"Action":"s3:*","Resource":"*"}]}'
+    ...    ) AS principal_match,
+    ...    aws_policy_equal(
+    ...      '{"Version":"2012-10-17","Statement":[{"Condition":{"StringEquals":{"sts:ExternalId":"0000"}},"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::414351767826:role/role-name"}}]}',
+    ...      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::414351767826:role/role-name"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"0000"}}}]}'
+    ...    ) AS condition_reordering_match;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |----------------------|----------------------|-------------------|----------------|--------------------------|
+    ...    |${SPACE}identical_policy_match${SPACE}|${SPACE}unordered_action_match${SPACE}|${SPACE}array_string_match${SPACE}|${SPACE}principal_match${SPACE}|${SPACE}condition_reordering_match${SPACE}|
+    ...    |----------------------|----------------------|-------------------|----------------|--------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}1${SPACE}|
+    ...    |----------------------|----------------------|-------------------|----------------|--------------------------|
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/AWS_POLICY_EQUAL_test_output.tmp
+    ...    stderr=${CURDIR}/tmp/AWS_POLICY_EQUAL_test_stderr.tmp
+
 Sum on Materialized View as Exemplified By Okta Apps
     ${sqliteInputStr} =    Catenate
     ...    create or replace materialized view okta_apps as 


### PR DESCRIPTION
## Description

Added sqlite extension function `aws_policy_equal` to compare two AWS policy documents (where all lists are considered to be unordered).  

Code was built and tested here : [__stackql/sqlite-ext-functions__](https://github.com/stackql/sqlite-ext-functions/tree/main/src/aws_policy_equal)  

then added to the `sqlite3-binding.c` amalgam in [__stackql/stackql-go-sqlite3__](https://github.com/stackql/stackql-go-sqlite3/releases/tag/v1.0.4-stackql) (tag `v1.0.4-stackql`), this was built as a test using `go build`  

then `go.mod` was updated here, along with the addition of a robot test for the new function.

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

No issue created.

## Evidence

Tested in [__stackql/sqlite-ext-functions__](https://github.com/stackql/sqlite-ext-functions) 

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

None.

## Tech Debt

None.
