### PR TITLE
mcp-v2

### DIFF
--- a/internal/stackql/cmd/root.go
+++ b/internal/stackql/cmd/root.go
@@ -199,8 +199,8 @@ func init() {
 	rootCmd.AddCommand(srvCmd)
 	rootCmd.AddCommand(mcpSrvCmd)
 
-	mcpSrvCmd.PersistentFlags().StringVar(&mcpConfig, "mcp.config", "{}", "MCP server config file path (YAML or JSON)")
-	mcpSrvCmd.PersistentFlags().StringVar(&mcpServerType, "mcp.server.type", "http", "MCP server type (http or stdio for now)")
+	rootCmd.PersistentFlags().StringVar(&mcpConfig, "mcp.config", "{}", "MCP server config file path (YAML or JSON)")
+	rootCmd.PersistentFlags().StringVar(&mcpServerType, "mcp.server.type", "", "MCP server type (http or stdio for now)")
 }
 
 func mergeConfigFromFile(runtimeCtx *dto.RuntimeCtx, flagSet pflag.FlagSet) {

--- a/internal/stackql/cmd/srv.go
+++ b/internal/stackql/cmd/srv.go
@@ -48,6 +48,9 @@ var srvCmd = &cobra.Command{
 		sbe := driver.NewStackQLDriverFactory(handlerCtx, runtimeCtx.PGSrvIsDebugNoticesEnabled)
 		server, err := psqlwire.MakeWireServer(sbe, runtimeCtx)
 		iqlerror.PrintErrorAndExitOneIfError(err)
+		if mcpServerType != "" {
+			go runMCPServer(handlerCtx.Clone()) //nolint:errcheck // TODO: investigate
+		}
 		server.Serve() //nolint:errcheck // TODO: investigate
 	},
 }

--- a/test/robot/functional/mcp.robot
+++ b/test/robot/functional/mcp.robot
@@ -146,10 +146,15 @@ Concurrent psql and MCP HTTP Server Query Tool
     ...                  stderr=${CURDIR}${/}tmp${/}MCP-HTTP-Server-Query-Tool-stderr.txt
     Should Contain       ${mcp_client_result.stdout}       cloudkms.googleapis.com
     Should Be Equal As Integers    ${mcp_client_result.rc}    0
-    ${psql_client_result}=    Run Process          ${PSQL_EXE}
-    ...                  postgres:\/\/stackql:stackql@127.0.0.1:5665
-    ...                  \-c
-    ...                  SELECT assetType, count(*) as asset_count FROM google.cloudasset.assets WHERE parentType \= 'projects' and parent \= 'testing-project' GROUP BY assetType order by count(*) desc, assetType desc;
+    ${posixInput} =     Catenate
+    ...    "${PSQL_EXE}"    -d     postgres://stackql:stackql@127.0.0.1:5665   -c
+    ...    "SELECT assetType, count(*) as asset_count FROM google.cloudasset.assets WHERE parentType = 'projects' and parent = 'testing-project' GROUP BY assetType order by count(*) desc, assetType desc;"
+    ${windowsInput} =     Catenate
+    ...    &    ${posixInput}
+    ${input} =    Set Variable If    "${IS_WINDOWS}" == "1"    ${windowsInput}    ${posixInput}
+    ${shellExe} =    Set Variable If    "${IS_WINDOWS}" == "1"    powershell    sh
+    ${psql_client_result}=    Run Process
+    ...                  ${shellExe}     \-c    ${input}
     ...                  stdout=${CURDIR}${/}tmp${/}Concurrent-psql-and-MCP-HTTP-Server-Query-Tool.txt
     ...                  stderr=${CURDIR}${/}tmp${/}Concurrent-psql-and-MCP-HTTP-Server-Query-Tool-stderr.txt
     Should Contain       ${psql_client_result.stdout}       cloudkms.googleapis.com

--- a/test/robot/functional/mcp.robot
+++ b/test/robot/functional/mcp.robot
@@ -139,7 +139,7 @@ Concurrent psql and MCP HTTP Server Query Tool
     ${mcp_client_result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
     ...                  exec
     ...                  \-\-client\-type\=http 
-    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-url\=http://127.0.0.1:9913
     ...                  \-\-exec.action      query_v2
     ...                  \-\-exec.args        {"sql": "SELECT assetType, count(*) as asset_count FROM google.cloudasset.assets WHERE parentType \= 'projects' and parent \= 'testing-project' GROUP BY assetType order by count(*) desc, assetType desc;"}
     ...                  stdout=${CURDIR}${/}tmp${/}MCP-HTTP-Server-Query-Tool.txt

--- a/test/robot/functional/mcp.robot
+++ b/test/robot/functional/mcp.robot
@@ -3,7 +3,7 @@ Resource          ${CURDIR}${/}stackql.resource
 
 
 *** Keywords ***
-Start MCP HTTP Server
+Start MCP Servers
     Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
     Start Process                         ${STACKQL_EXE}
     ...                                   mcp
@@ -15,10 +15,22 @@ Start MCP HTTP Server
     ...                                   \-\-auth
     ...                                   ${AUTH_CFG_STR}
     ...                                   \-\-tls.allowInsecure
+    Start Process                         ${STACKQL_EXE}
+    ...                                   srv
+    ...                                   \-\-mcp.server.type\=http
+    ...                                   \-\-mcp.config
+    ...                                   {"server": {"transport": "http", "address": "127.0.0.1:9913"} }
+    ...                                   \-\-registry
+    ...                                   ${REGISTRY_NO_VERIFY_CFG_JSON_STR}
+    ...                                   \-\-auth
+    ...                                   ${AUTH_CFG_STR}
+    ...                                   \-\-tls.allowInsecure
+    ...                                   \-\-pgsrv.port
+    ...                                   5665
     Sleep         5s
 
 *** Settings ***
-Suite Setup     Start MCP HTTP Server
+Suite Setup     Start MCP Servers
 
 
 *** Test Cases *** 
@@ -120,3 +132,25 @@ MCP HTTP Server Query Tool
     Should Contain       ${result.stdout}       cloudkms.googleapis.com
     Should Be Equal As Integers    ${result.rc}    0
 
+
+Concurrent psql and MCP HTTP Server Query Tool
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${mcp_client_result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http 
+    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-exec.action      query_v2
+    ...                  \-\-exec.args        {"sql": "SELECT assetType, count(*) as asset_count FROM google.cloudasset.assets WHERE parentType \= 'projects' and parent \= 'testing-project' GROUP BY assetType order by count(*) desc, assetType desc;"}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-HTTP-Server-Query-Tool.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-HTTP-Server-Query-Tool-stderr.txt
+    Should Contain       ${mcp_client_result.stdout}       cloudkms.googleapis.com
+    Should Be Equal As Integers    ${mcp_client_result.rc}    0
+    ${psql_client_result}=    Run Process          ${PSQL_EXE}
+    ...                  postgres:\/\/stackql:stackql@127.0.0.1:5665
+    ...                  \-c
+    ...                  SELECT assetType, count(*) as asset_count FROM google.cloudasset.assets WHERE parentType \= 'projects' and parent \= 'testing-project' GROUP BY assetType order by count(*) desc, assetType desc;
+    ...                  stdout=${CURDIR}${/}tmp${/}Concurrent-psql-and-MCP-HTTP-Server-Query-Tool.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}Concurrent-psql-and-MCP-HTTP-Server-Query-Tool-stderr.txt
+    Should Contain       ${psql_client_result.stdout}       cloudkms.googleapis.com
+    Should Be Equal As Integers    ${psql_client_result.rc}    0


### PR DESCRIPTION
## Description

- MCP server and postgres server run concurrently.
- Added robot test `Concurrent psql and MCP HTTP Server Query Tool`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Concurrent psql and MCP HTTP Server Query Tool`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
