### PR TITLE
mcp-type-adaptability

### DIFF
--- a/internal/stackql/cmd/mcp.go
+++ b/internal/stackql/cmd/mcp.go
@@ -67,7 +67,9 @@ var mcpSrvCmd = &cobra.Command{
 func runMCPServer(handlerCtx handler.HandlerContext) {
 	var config mcp_server.Config
 	json.Unmarshal([]byte(mcpConfig), &config) //nolint:errcheck // TODO: investigate
-	config.Server.Transport = mcpServerType
+	if config.Server.Transport == "" {
+		config.Server.Transport = mcpServerType
+	}
 	var isReadOnly bool
 	if config.Server.IsReadOnly != nil {
 		isReadOnly = *config.Server.IsReadOnly
@@ -75,7 +77,6 @@ func runMCPServer(handlerCtx handler.HandlerContext) {
 	var backend mcp_server.Backend
 	var backendErr error
 	if mcpServerType == "reverse_proxy" {
-		config.Server.Transport = "http"
 		dsn := config.GetBackendConnectionString()
 		// conn
 		var cfg dto.SQLBackendCfg


### PR DESCRIPTION
## Description

- Remove server transoprt hardcoded overwrite.
- The positive scenario is covered by the pre-existing robot test `Concurrent psql and Reverse Proxy MCP HTTP Server Query Tool`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- The positive scenario is covered by the pre-existing robot test `Concurrent psql and Reverse Proxy MCP HTTP Server Query Tool`.


<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
