### PR TITLE
mcp-tls-support

### DIFF
--- a/mcp_client/cmd/exec.go
+++ b/mcp_client/cmd/exec.go
@@ -42,9 +42,15 @@ var execCmd = &cobra.Command{
 	Long: `simple mcp client example
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		clientCfgMap := make(map[string]any)
+		jsonErr := json.Unmarshal([]byte(clientCfgJSON), &clientCfgMap)
+		if jsonErr != nil {
+			panic(fmt.Sprintf("error unmarshaling client cfg json: %v", jsonErr))
+		}
 		client, setupErr := mcp_server.NewMCPClient(
 			clientType,
 			url,
+			clientCfgMap,
 			nil,
 		)
 		if setupErr != nil {
@@ -64,9 +70,9 @@ var execCmd = &cobra.Command{
 			outputString = string(output)
 		default:
 			var args map[string]any
-			jsonErr := json.Unmarshal([]byte(actionArgs), &args)
-			if jsonErr != nil {
-				panic(fmt.Sprintf("error unmarshaling action args: %v", jsonErr))
+			jsonCfgErr := json.Unmarshal([]byte(actionArgs), &args)
+			if jsonCfgErr != nil {
+				panic(fmt.Sprintf("error unmarshaling action args: %v", jsonCfgErr))
 			}
 			rv, rvErr := client.CallToolText(actionName, args)
 			if rvErr != nil {

--- a/mcp_client/cmd/root.go
+++ b/mcp_client/cmd/root.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	clientType = "http"
-	url        = "127.0.0.1:9191"
+	clientType    = "http"
+	url           = "127.0.0.1:9191"
+	clientCfgJSON = "{}"
 )
 
 //nolint:revive,gochecknoglobals // explicit preferred
@@ -68,6 +69,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&clientType, "client-type", mcp_server.MCPClientTypeSTDIO, "MCP client type (http or stdio for now)")
 	rootCmd.PersistentFlags().StringVar(&url, "url", "http://127.0.0.1:9876", "MCP server URL.  Relevant for http and sse client types.")
+	rootCmd.PersistentFlags().StringVar(&clientCfgJSON, "client-cfg", "{}", "MCP client configuration as JSON string")
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/pkg/mcp_server/client.go
+++ b/pkg/mcp_server/client.go
@@ -3,9 +3,16 @@ package mcp_server //nolint:revive // fine for now
 // create an http client that can talk to the mcp server
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
+	"net/url"
+	"os"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/sirupsen/logrus"
@@ -21,10 +28,10 @@ type MCPClient interface {
 	CallToolText(toolName string, args map[string]any) (string, error)
 }
 
-func NewMCPClient(clientType string, baseURL string, logger *logrus.Logger) (MCPClient, error) {
+func NewMCPClient(clientType string, baseURL string, clientCfgMap map[string]any, logger *logrus.Logger) (MCPClient, error) {
 	switch clientType {
 	case MCPClientTypeHTTP:
-		return newHTTPMCPClient(baseURL, logger)
+		return newHTTPMCPClient(baseURL, clientCfgMap, logger)
 	case MCPClientTypeSTDIO:
 		return newStdioMCPClient(logger)
 	default:
@@ -32,15 +39,228 @@ func NewMCPClient(clientType string, baseURL string, logger *logrus.Logger) (MCP
 	}
 }
 
-func newHTTPMCPClient(baseURL string, logger *logrus.Logger) (MCPClient, error) {
+//nolint:nestif,gocognit,gocyclo,cyclop,funlen // complex but acceptable for now
+func getHTTPClient(logger *logrus.Logger, clientCfgMap map[string]any) (*http.Client, error) {
+	if clientCfgMap != nil && clientCfgMap["ca_file"] != nil {
+		logger.Infof("Configuring HTTP client with custom CA certificate")
+		caFile, isString := clientCfgMap["ca_file"].(string)
+		if !isString {
+			return nil, fmt.Errorf("ca_file must be a string")
+		}
+		caBytes, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA file '%s': %w", caFile, err)
+		}
+		logger.Infof("Read CA file '%s' (%d bytes)", caFile, len(caBytes))
+
+		// Start from system pool when possible
+		var caCertPool *x509.CertPool
+		if sysPool, sysErr := x509.SystemCertPool(); sysErr == nil && sysPool != nil {
+			caCertPool = sysPool
+			logger.Debug("Using system cert pool as base")
+		} else {
+			caCertPool = x509.NewCertPool()
+			logger.Debug("System cert pool unavailable; using new pool")
+		}
+
+		// Capture the first certificate (candidate leaf) for promote_leaf_to_ca.
+		var firstCertRaw []byte
+		{
+			tmp := caBytes
+			for {
+				var blk *pem.Block
+				blk, tmp = pem.Decode(tmp)
+				if blk == nil {
+					break
+				}
+				if blk.Type == "CERTIFICATE" {
+					firstCertRaw = blk.Bytes
+					break
+				}
+			}
+		}
+
+		if ok := caCertPool.AppendCertsFromPEM(caBytes); !ok {
+			// Fallback: manual decode to provide diagnostics
+			logger.Warn("AppendCertsFromPEM returned false; attempting manual PEM decode for diagnostics")
+			blockCount := 0
+			validCerts := 0
+			rest := caBytes
+			for {
+				var b *pem.Block
+				b, rest = pem.Decode(rest)
+				if b == nil {
+					break
+				}
+				blockCount++
+				if b.Type == "CERTIFICATE" {
+					if _, perr := x509.ParseCertificate(b.Bytes); perr == nil {
+						validCerts++
+					} else {
+						logger.Errorf("Failed to parse certificate PEM block %d: %v", blockCount, perr)
+					}
+				} else {
+					logger.Debugf("Ignoring non-certificate PEM block type=%s", b.Type)
+				}
+			}
+			return nil, fmt.Errorf("failed to append CA certificate '%s' into trust store: no valid CERTIFICATE PEM blocks found (blocks=%d, valid=%d)", caFile, blockCount, validCerts)
+		} else {
+			logger.Infof("Successfully appended custom CA(s) from '%s'", caFile)
+			// Added: inspect for CA certificates
+			rest := caBytes
+			certBlockIdx := 0
+			caCount := 0
+			for {
+				var b *pem.Block
+				b, rest = pem.Decode(rest)
+				if b == nil {
+					break
+				}
+				if b.Type != "CERTIFICATE" {
+					continue
+				}
+				certBlockIdx++
+				parsed, perr := x509.ParseCertificate(b.Bytes)
+				if perr != nil {
+					logger.Debugf("Skipping unparsable certificate block %d: %v", certBlockIdx, perr)
+					continue
+				}
+				if parsed.IsCA {
+					caCount++
+				}
+			}
+			if caCount == 0 {
+				logger.Warnf("No CA certificates (IsCA=true) found in '%s'. If this file contains only the server leaf certificate it cannot establish standard trust. Supply the issuing CA (or chain) or enable 'promote_leaf_to_ca'.", caFile)
+			} else {
+				logger.Debugf("Detected %d CA certificate(s) in '%s'", caCount, caFile)
+			}
+		}
+
+		// Read optional flags
+		promoteLeaf := false
+		if v, ok := clientCfgMap["promote_leaf_to_ca"]; ok {
+			b, okb := v.(bool)
+			if !okb {
+				return nil, fmt.Errorf("promote_leaf_to_ca must be a boolean")
+			}
+			promoteLeaf = b
+		}
+
+		insecureSkipVerify := false
+		if v, ok := clientCfgMap["insecure_skip_verify"]; ok {
+			suppliedSkipVerify, isBool := v.(bool)
+			if !isBool {
+				return nil, fmt.Errorf("insecure_skip_verify must be a boolean")
+			}
+			insecureSkipVerify = suppliedSkipVerify
+		}
+
+		var serverName string
+		if v, ok := clientCfgMap["server_name"]; ok {
+			if s, ok2 := v.(string); ok2 {
+				serverName = s
+			} else {
+				return nil, fmt.Errorf("server_name must be a string")
+			}
+		}
+
+		// If server_name not supplied and base URL host differs from cert common name/SAN (common in IP usage),
+		// user should supply server_name explicitly; we just log hint.
+		if serverName == "" {
+			if rawURL, ok := clientCfgMap["base_url"].(string); ok {
+				if parsed, perr := url.Parse(rawURL); perr == nil && parsed.Hostname() != "" {
+					// SNI will default to this hostname; log for clarity.
+					logger.Debugf("Using implicit SNI server name '%s'", parsed.Hostname())
+				}
+			}
+		} else {
+			logger.Infof("Using explicit TLS server_name (SNI): %s", serverName)
+		}
+
+		//nolint:gosec // testing client only
+		tlsConfig := &tls.Config{
+			RootCAs:            caCertPool,
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: insecureSkipVerify, // may be overridden below if promoting leaf
+			ServerName:         serverName,
+		}
+
+		// If no CA certs and user wants to promote the leaf, install custom verifier.
+		if promoteLeaf {
+			if firstCertRaw == nil {
+				return nil, fmt.Errorf("promote_leaf_to_ca enabled but no certificate PEM blocks found in '%s'", caFile)
+			}
+			// Re-parse to log fingerprint
+			if leafCert, perr := x509.ParseCertificate(firstCertRaw); perr == nil {
+				fp := sha256.Sum256(leafCert.Raw)
+				logger.Warnf("Promoting leaf certificate (CN=%s, SHA256=%X) to trust anchor (non-CA). NOT recommended for production.", leafCert.Subject.CommonName, fp[:8])
+			} else {
+				logger.Warnf("Promoting leaf certificate (parse error for fingerprint: %v)", perr)
+			}
+			tlsConfig.InsecureSkipVerify = true // we will verify manually
+			expected := make([]byte, len(firstCertRaw))
+			copy(expected, firstCertRaw)
+
+			tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+				if len(rawCerts) == 0 {
+					return fmt.Errorf("no server certificates presented")
+				}
+				if !bytes.Equal(rawCerts[0], expected) {
+					return fmt.Errorf("server leaf certificate mismatch with promoted leaf")
+				}
+				// Optionally parse for additional sanity
+				if cert, certParseErr := x509.ParseCertificate(rawCerts[0]); certParseErr == nil {
+					if serverName != "" && serverName != cert.Subject.CommonName {
+						// Do hostname verification if a serverName was forced.
+						if verr := cert.VerifyHostname(serverName); verr != nil {
+							return fmt.Errorf("hostname verification failed for promoted leaf: %w", verr)
+						}
+					}
+				}
+				return nil
+			}
+		}
+
+		tr := &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
+
+		// Optionally apply TLS config globally so libraries using http.DefaultClient inherit it.
+		if v, ok := clientCfgMap["apply_tls_globally"]; ok {
+			if b, okb := v.(bool); !okb {
+				return nil, fmt.Errorf("apply_tls_globally must be a boolean")
+			} else if b {
+				if defTr, okd := http.DefaultTransport.(*http.Transport); okd {
+					// Shallow clone to avoid races; copy keeps other fields (proxy, dialer, etc.)
+					cloned := defTr.Clone()
+					cloned.TLSClientConfig = tlsConfig
+					http.DefaultTransport = cloned
+					logger.Warn("Applied custom TLS config globally (http.DefaultTransport). This affects all outbound HTTP requests in this process.")
+				} else {
+					logger.Warn("apply_tls_globally requested but http.DefaultTransport is not *http.Transport; skipped")
+				}
+			}
+		}
+
+		return &http.Client{Transport: tr}, nil
+	}
+	return http.DefaultClient, nil
+}
+
+func newHTTPMCPClient(baseURL string, clientCfgMap map[string]any, logger *logrus.Logger) (MCPClient, error) {
 	if logger == nil {
 		logger = logrus.New()
 		logger.SetLevel(logrus.InfoLevel)
 	}
+	httpClient, httpClientErr := getHTTPClient(logger, clientCfgMap)
+	if httpClientErr != nil {
+		return nil, fmt.Errorf("error creating HTTP client: %w", httpClientErr)
+	}
 	return &httpMCPClient{
 		baseURL:    baseURL,
-		httpClient: http.DefaultClient,
+		httpClient: httpClient,
 		logger:     logger,
+		clientCfg:  clientCfgMap,
 	}, nil
 }
 
@@ -48,6 +268,7 @@ type httpMCPClient struct {
 	baseURL    string
 	httpClient *http.Client
 	logger     *logrus.Logger
+	clientCfg  map[string]any
 }
 
 func (c *httpMCPClient) connect() (*mcp.ClientSession, error) {

--- a/pkg/mcp_server/config.go
+++ b/pkg/mcp_server/config.go
@@ -59,7 +59,10 @@ type ServerConfig struct {
 	// Version is the server version advertised to clients.
 	Version string `json:"version" yaml:"version"`
 
-	ConnectionCfg map[string]any `json:"connection_cfg,omitempty" yaml:"connection_cfg,omitempty"`
+	TLSCertFile string `json:"tls_cert_file,omitempty" yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile  string `json:"tls_key_file,omitempty" yaml:"tls_key_file,omitempty"`
+
+	TransportCfg map[string]any `json:"transport_cfg,omitempty" yaml:"transport_cfg,omitempty"`
 
 	// Description is a human-readable description of the server.
 	Description string `json:"description" yaml:"description"`


### PR DESCRIPTION
## Description

- Basic TLS support for MCP server and MCP testing client.
- Added robot test `Concurrent psql and Reverse Proxy MCP HTTPS Server Query Tool`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Concurrent psql and Reverse Proxy MCP HTTPS Server Query Tool`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

The tesig client has support for self signed leaf certificates bodged in to decrease testing overhead.  There is [a ticket](https://github.com/stackql/stackql/issues/582) to address this.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
