### PR TITLE
mcp-server-improve

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -185,8 +185,20 @@
         "replace /*+ AWAIT */ google.compute.firewalls set data__disabled = 'true'  where project = 'mutable-project'  and firewall = 'replacable-firewall'  returning *;",
         "select role_name from pgi.information_schema.applicable_roles order by role_name desc;",
         "SELECT * FROM datadog.organization.users;",
+        "explain select 1 as foo;",
+        "explain select name from google.compute.networks where project = 'stackql-demo';",
+        "explain select * from aws.ec2.instances where region = 'ap-southeast-2';",
       ], 
       "default": "show providers;"
+    },
+    {
+      "type": "pickString",
+      "id": "mcpSrvCfgStr",
+      "description": "MCP Server Configuration",
+      "options": [
+        "{\"server\": {\"transport\": \"http\", \"address\": \"127.0.0.1:9992\"} }"
+      ],
+      "default": "{\"server\": {\"transport\": \"http\", \"address\": \"127.0.0.1:9992\"} }"
     },
     {
       "type": "pickString",
@@ -385,7 +397,7 @@
       "type": "pickString",
       "id": "mcpServerType",
       "description": "MCP server type",
-      "default": "stdio",
+      "default": "http",
       "options": [
         "http",
         "stdio"
@@ -464,6 +476,8 @@
       "program": "${workspaceFolder}/stackql",
       "args": [
         "mcp",
+        "--mcp.server.type=${input:mcpServerType}",
+        "--mcp.config=${input:mcpSrvCfgStr}",
         "--pgsrv.port=6555",
         "--tls.allowInsecure",
         "--auth=${input:authString}",
@@ -475,7 +489,6 @@
         "--dbInternal=${input:dbInternalString}",
         "--export.alias=${input:exportAliasString}",
         "--pgsrv.debug.enable=${input:serverDebugPublish}",
-        "--mcp.server.type=${input:mcpServerType}",
       ],
     },
     {

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,68 @@
+
+## Running the MCP server
+
+If necessary, rebuild stackql with:
+
+```bash
+python cicd/python/build.py --build
+```
+
+**Note**: before starting an MCP server, remember to export all appropriate auth env vars.
+
+We have a nice debug config for running an MCP server with `vscode`, please see [the `vscode` debug launch config](/.vscode/launch.json) for that.  Otherwise, you can run with stackql (assuming locally built into `./build/stackql`):
+
+
+```bash
+
+./build/stackql mcp --mcp.server.type=http --mcp.config '{"server": {"transport": "http", "address": "127.0.0.1:9992"} }'
+
+
+```
+
+
+## Using the MCP Client
+
+This is very much a development tool, not currently recommended for production.
+
+Build:
+
+```bash
+python cicd/python/build.py --build-mcp-client
+```
+
+Then, assuming you have a `stackql` MCP server serving streamable HTTP on port `9992`, you ca access any edpoint.  The below examples are somewhat illustrative of a canonical agent pattern for agent behaviour.
+
+
+```bash
+
+## List available providers.
+./build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action      list_providers
+
+## List available services.  
+## **must** supply <provider>
+./build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action      list_services --exec.args '{"provider": "google"}'
+
+## List available resources.  
+## **must** supply <provider>, <service>
+./build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action      list_resources --exec.args '{"provider": "google", "service": "compute"}'
+
+## List access methods.  
+## **must** supply <provider>, <service>, <resource>
+./build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action      list_methods --exec.args '{"provider": "google", "service": "compute", "resource": "networks"}'
+
+## Describe published relation
+## **must** supply <provider>, <service>, <resource>
+./build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action      meta_describe_table --exec.args '{"provider": "google", "service": "compute", "resource": "networks"}'
+
+## Validate query AOT.  Only works for SELECT at this stage.
+./build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action validate_query_json_v2      --exec.args '{"sql": "select name from google.compute.networks where project = '"'"'stackql-demo'"'"';"}'
+
+## Run query
+./build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action query_json_v2      --exec.args '{"sql": "select name from google.compute.networks where project = '"'"'stackql-demo'"'"';"}'
+
+## Exec query pattern; for non-read operations
+## Tread carefully!!!
+## These are almost always mutations
+# /build/stackql_mcp_client exec --client-type=http  --url=http://127.0.0.1:9992 --exec.action exec_query_json_v2      --exec.args '{"sql": "delete from google.compute.networks where project = '"'"'<my-bucket-name>'"'"';"}'
+
+```

--- a/internal/stackql/astanalysis/earlyanalysis/first_passes.go
+++ b/internal/stackql/astanalysis/earlyanalysis/first_passes.go
@@ -219,6 +219,12 @@ func (sp *standardInitialPasses) initialPasses(
 		return err
 	}
 	ast := result.AST
+	//nolint:gocritic // prefer switch
+	switch node := ast.(type) {
+	case *sqlparser.Explain:
+		ast = node.Statement
+	}
+
 	annotatedAST, err := annotatedast.NewAnnotatedAst(sp.parentAnnotatedAST, ast)
 	if err != nil {
 		return err
@@ -235,6 +241,8 @@ func (sp *standardInitialPasses) initialPasses(
 		switch node := subjectAST.(type) {
 		case *sqlparser.DDL:
 			subjectAST = node.SelectStatement
+			// case *sqlparser.Explain:
+			// 	subjectAST = node.Statement
 		}
 		pbi, pbiErr := planbuilderinput.NewPlanBuilderInput(
 			annotatedAST,
@@ -326,7 +334,7 @@ func (sp *standardInitialPasses) initialPasses(
 	pbi, err := planbuilderinput.NewPlanBuilderInput(
 		annotatedAST,
 		handlerCtx,
-		ast,
+		result.AST,
 		threeToFiveAgg.GetTables(),
 		threeToFiveAgg.GetAliasedColumns(),
 		threeToFiveAgg.GetAliasMap(),

--- a/internal/stackql/planbuilder/entrypoint.go
+++ b/internal/stackql/planbuilder/entrypoint.go
@@ -38,7 +38,7 @@ func (pb *standardPlanBuilder) BuildUndoPlanFromContext(_ handler.HandlerContext
 	return nil, nil
 }
 
-//nolint:funlen,gocognit,errcheck // no big deal
+//nolint:funlen,gocognit,errcheck,gocyclo,cyclop // no big deal
 func (pb *standardPlanBuilder) BuildPlanFromContext(handlerCtx handler.HandlerContext) (plan.Plan, error) {
 	defer handlerCtx.GetGarbageCollector().Close()
 	tcc, err := internaldto.NewTxnControlCounters(handlerCtx.GetTxnCounterMgr())
@@ -161,6 +161,14 @@ func (pb *standardPlanBuilder) BuildPlanFromContext(handlerCtx handler.HandlerCo
 		if createInstructionError != nil {
 			return nil, createInstructionError
 		}
+	}
+
+	//nolint:gocritic // prefer switch
+	switch statement.(type) {
+	case *sqlparser.Explain:
+		// explain plans are never cacheable and always readonly
+		qPlan.SetCacheable(false)
+		qPlan.SetReadOnly(true)
 	}
 
 	if pGBuilder.getPlanGraphHolder().ContainsIndirect() {

--- a/internal/stackql/planbuilderinput/plan_builder_input.go
+++ b/internal/stackql/planbuilderinput/plan_builder_input.go
@@ -46,6 +46,7 @@ type PlanBuilderInput interface {
 	GetUpdate() (*sqlparser.Update, bool)
 	GetUse() (*sqlparser.Use, bool)
 	GetSet() (*sqlparser.Set, bool)
+	GetExplain() (*sqlparser.Explain, bool)
 	IsTccSetAheadOfTime() bool
 	SetIsTccSetAheadOfTime(bool)
 	SetPrepStmtOffset(int)
@@ -387,6 +388,11 @@ func (pbi *StandardPlanBuilderInput) GetUse() (*sqlparser.Use, bool) {
 
 func (pbi *StandardPlanBuilderInput) GetSet() (*sqlparser.Set, bool) {
 	rv, ok := pbi.stmt.(*sqlparser.Set)
+	return rv, ok
+}
+
+func (pbi *StandardPlanBuilderInput) GetExplain() (*sqlparser.Explain, bool) {
+	rv, ok := pbi.stmt.(*sqlparser.Explain)
 	return rv, ok
 }
 

--- a/internal/stackql/primitivebuilder/explain.go
+++ b/internal/stackql/primitivebuilder/explain.go
@@ -1,0 +1,85 @@
+package primitivebuilder
+
+import (
+	"time"
+
+	"github.com/stackql/any-sdk/public/sqlengine"
+	"github.com/stackql/stackql/internal/stackql/handler"
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stackql/stackql/internal/stackql/primitive"
+	"github.com/stackql/stackql/internal/stackql/primitivegraph"
+	"github.com/stackql/stackql/internal/stackql/util"
+)
+
+var (
+	defaultConcludeExplainMessages []string = []string{"OK"} //nolint:revive,gochecknoglobals // prefer declarative
+)
+
+type ExplainBuilder struct {
+	graph          primitivegraph.PrimitiveGraphHolder
+	handlerCtx     handler.HandlerContext
+	root           primitivegraph.PrimitiveNode
+	sqlEngine      sqlengine.SQLEngine
+	messages       []string
+	instructionErr error
+}
+
+func NewExplainBuilder(
+	graph primitivegraph.PrimitiveGraphHolder,
+	txnControlCounters internaldto.TxnControlCounters, //nolint:revive // future proofing
+	handlerCtx handler.HandlerContext,
+	sqlEngine sqlengine.SQLEngine,
+	messages []string,
+	instructionErr error,
+) Builder {
+	if len(messages) == 0 {
+		messages = []string{}
+	}
+	messages = append(messages, defaultConcludeExplainMessages...)
+	return &ExplainBuilder{
+		graph:          graph,
+		handlerCtx:     handlerCtx,
+		sqlEngine:      sqlEngine,
+		messages:       messages,
+		instructionErr: instructionErr,
+	}
+}
+
+func (nb *ExplainBuilder) Build() error {
+	pr := primitive.NewLocalPrimitive(
+		//nolint:revive // no big deal
+		func(pc primitive.IPrimitiveCtx) internaldto.ExecutorOutput {
+			if nb.instructionErr != nil {
+				return internaldto.NewErroneousExecutorOutput(nb.instructionErr)
+			}
+			oneLinerOutput := time.Now().Format("2006-01-02T15:04:05-07:00 MST")
+			resultMap := map[string]any{
+				"query":     nb.handlerCtx.GetQuery(),
+				"timestamp": oneLinerOutput,
+				"result":    "OK",
+				"valid":     true,
+			}
+			columns := []string{"query", "result", "timestamp", "valid"}
+			return util.PrepareResultSet(
+				internaldto.NewPrepareResultSetPlusRawDTO(
+					nil,
+					map[string]map[string]any{"0": resultMap},
+					columns,
+					nil,
+					nil,
+					internaldto.NewBackendMessages(nb.messages), nil,
+					nb.handlerCtx.GetTypingConfig()),
+			)
+		},
+	)
+	nb.root = nb.graph.CreatePrimitiveNode(pr)
+	return nil
+}
+
+func (nb *ExplainBuilder) GetRoot() primitivegraph.PrimitiveNode {
+	return nb.root
+}
+
+func (nb *ExplainBuilder) GetTail() primitivegraph.PrimitiveNode {
+	return nb.root
+}

--- a/internal/stackql/primitivegenerator/primitive_generator.go
+++ b/internal/stackql/primitivegenerator/primitive_generator.go
@@ -34,6 +34,7 @@ type PrimitiveGenerator interface {
 	AddChildPrimitiveGenerator(ast sqlparser.SQLNode, leaf symtab.SymTab) PrimitiveGenerator
 	AnalyzeInsert(pbi planbuilderinput.PlanBuilderInput) error
 	AnalyzeNop(pbi planbuilderinput.PlanBuilderInput) error
+	AnalyzeExplain(pbi planbuilderinput.PlanBuilderInput, messages []string, instructionErr error) error
 	AnalyzeUpdate(pbi planbuilderinput.PlanBuilderInput) error
 	AnalyzePGInternal(pbi planbuilderinput.PlanBuilderInput) error
 	AnalyzeRegistry(pbi planbuilderinput.PlanBuilderInput) error

--- a/internal/stackql/primitivegraph/graph_holder.go
+++ b/internal/stackql/primitivegraph/graph_holder.go
@@ -11,6 +11,7 @@ var (
 
 //nolint:revive // acceptable nomenclature
 type PrimitiveGraphHolder interface {
+	Blank() error
 	AddInverseTxnControlCounters(t internaldto.TxnControlCounters)
 	AddTxnControlCounters(t internaldto.TxnControlCounters)
 	ContainsIndirect() bool
@@ -34,8 +35,9 @@ type PrimitiveGraphHolder interface {
 }
 
 type standardPrimitiveGraphHolder struct {
-	pg  PrimitiveGraph
-	ipg PrimitiveGraph
+	concurrencyLimit int
+	pg               PrimitiveGraph
+	ipg              PrimitiveGraph
 }
 
 func (pgh *standardPrimitiveGraphHolder) GetPrimitiveGraph() PrimitiveGraph {
@@ -122,7 +124,14 @@ func NewPrimitiveGraphHolder(concurrencyLimit int) PrimitiveGraphHolder {
 	pg := newPrimitiveGraph(concurrencyLimit)
 	ipg := newSequentialPrimitiveGraph(concurrencyLimit)
 	return &standardPrimitiveGraphHolder{
-		pg:  pg,
-		ipg: ipg,
+		concurrencyLimit: concurrencyLimit,
+		pg:               pg,
+		ipg:              ipg,
 	}
+}
+
+func (pgh *standardPrimitiveGraphHolder) Blank() error {
+	pgh.pg = newPrimitiveGraph(pgh.concurrencyLimit)
+	pgh.ipg = newSequentialPrimitiveGraph(pgh.concurrencyLimit)
+	return nil
 }

--- a/pkg/mcp_server/backend.go
+++ b/pkg/mcp_server/backend.go
@@ -25,6 +25,12 @@ type Backend interface {
 	// Execute a SQL query with typed input (preferred)
 	RunQuery(ctx context.Context, args dto.QueryInput) (string, error)
 
+	// Execute a SQL query that does not return rows
+	ExecQuery(ctx context.Context, query string) (map[string]any, error)
+
+	// Execute a SQL query that does not return rows
+	ValidateQuery(ctx context.Context, query string) ([]map[string]any, error)
+
 	// Execute a SQL query and return JSON rows with typed input (preferred)
 	RunQueryJSON(ctx context.Context, input dto.QueryJSONInput) ([]map[string]interface{}, error)
 
@@ -47,22 +53,20 @@ type Backend interface {
 	ListTablesJSONPage(ctx context.Context, input dto.ListTablesPageInput) (map[string]interface{}, error)
 
 	// List all schemas in the database
-	ListProviders(ctx context.Context) (string, error)
+	ListProviders(ctx context.Context) ([]map[string]any, error)
 
-	ListServices(ctx context.Context, hI dto.HierarchyInput) (string, error)
+	ListServices(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error)
 
-	ListResources(ctx context.Context, hI dto.HierarchyInput) (string, error)
-
-	ListMethods(ctx context.Context, hI dto.HierarchyInput) (string, error)
-
+	ListResources(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error)
+	ListMethods(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error)
 	// List all tables in a specific schema
 	// ListTables(ctx context.Context, hI HierarchyInput) (string, error)
 
 	// Get detailed information about a table
-	DescribeTable(ctx context.Context, hI dto.HierarchyInput) (string, error)
+	DescribeTable(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error)
 
 	// Get foreign key information for a table
-	GetForeignKeys(ctx context.Context, hI dto.HierarchyInput) (string, error)
+	GetForeignKeys(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error)
 
 	// Find both explicit and implied relationships for a table
 	FindRelationships(ctx context.Context, hI dto.HierarchyInput) (string, error)

--- a/pkg/mcp_server/example_backend.go
+++ b/pkg/mcp_server/example_backend.go
@@ -52,6 +52,10 @@ func (b *ExampleBackend) RunQueryJSON(ctx context.Context, input dto.QueryJSONIn
 	return []map[string]interface{}{}, nil
 }
 
+func (b *ExampleBackend) ValidateQuery(ctx context.Context, query string) ([]map[string]any, error) {
+	return []map[string]any{}, nil
+}
+
 // func (b *ExampleBackend) ListTableResources(ctx context.Context, hI dto.HierarchyInput) ([]string, error) {
 // 	return []string{}, nil
 // }
@@ -76,36 +80,40 @@ func (b *ExampleBackend) ListTablesJSONPage(ctx context.Context, input dto.ListT
 	return map[string]interface{}{}, nil
 }
 
-func (b *ExampleBackend) ListTables(ctx context.Context, hI dto.HierarchyInput) (string, error) {
-	return "stub", nil
+func (b *ExampleBackend) ListTables(ctx context.Context, hI dto.HierarchyInput) ([]map[string]interface{}, error) {
+	return []map[string]interface{}{}, nil
 }
 
-func (b *ExampleBackend) ListMethods(ctx context.Context, hI dto.HierarchyInput) (string, error) {
-	return "stub", nil
+func (b *ExampleBackend) ListMethods(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
 }
 
-func (b *ExampleBackend) DescribeTable(ctx context.Context, hI dto.HierarchyInput) (string, error) {
-	return "stub", nil
+func (b *ExampleBackend) DescribeTable(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
 }
 
-func (b *ExampleBackend) GetForeignKeys(ctx context.Context, hI dto.HierarchyInput) (string, error) {
-	return ExplainerForeignKeyStackql, nil
+func (b *ExampleBackend) GetForeignKeys(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
 }
 
 func (b *ExampleBackend) FindRelationships(ctx context.Context, hI dto.HierarchyInput) (string, error) {
 	return ExplainerFindRelationships, nil
 }
 
-func (b *ExampleBackend) ListProviders(ctx context.Context) (string, error) {
-	return "stub", nil
+func (b *ExampleBackend) ExecQuery(ctx context.Context, query string) (map[string]any, error) {
+	return map[string]any{}, nil
 }
 
-func (b *ExampleBackend) ListServices(ctx context.Context, hI dto.HierarchyInput) (string, error) {
-	return "stub", nil
+func (b *ExampleBackend) ListProviders(ctx context.Context) ([]map[string]any, error) {
+	return []map[string]any{}, nil
 }
 
-func (b *ExampleBackend) ListResources(ctx context.Context, hI dto.HierarchyInput) (string, error) {
-	return "stub", nil
+func (b *ExampleBackend) ListServices(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
+}
+
+func (b *ExampleBackend) ListResources(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
 }
 
 // NewExampleBackend creates a new example backend instance.

--- a/test/robot/functional/mcp.robot
+++ b/test/robot/functional/mcp.robot
@@ -315,8 +315,8 @@ MCP HTTPS Server JSON DTO Query V3 JSON
     ...    query_v3
     ...    \-\-exec.args
     ...    {"sql":"show providers;","format":"json"}
-    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-query-v2-json.txt
-    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-query-v2-json-stderr.txt
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-query-v3-json.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-query-v3-json-stderr.txt
     Should Be Equal As Integers    ${query_json.rc}    0
     ${query_obj}=    Parse MCP JSON Output    ${query_json.stdout}
     Should Be Equal    ${query_obj["format"]}    json
@@ -381,8 +381,7 @@ MCP HTTPS Server JSON DTO Meta Get Foreign Keys
     ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-meta-get-foreign-keys.txt
     ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-meta-get-foreign-keys-stderr.txt
     Should Be Equal As Integers    ${meta_fk.rc}    0
-    ${meta_fk_obj}=    Parse MCP JSON Output    ${meta_fk.stdout}
-    Dictionary Should Contain Key    ${meta_fk_obj}    text
+    Should Contain    ${meta_fk.stdout}    not implemented
 
 MCP HTTPS Server JSON DTO Meta Find Relationships
     [Documentation]     Future proofing: relationship graph inference pending; placeholder output.
@@ -403,3 +402,165 @@ MCP HTTPS Server JSON DTO Meta Find Relationships
     Should Be Equal As Integers    ${meta_rels.rc}    0
     ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
     Dictionary Should Contain Key    ${meta_rels_obj}    text
+
+
+MCP HTTPS List Providers Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    list_providers
+    ...    \-\-exec.args
+    ...    {"provider": "google"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-list-providers-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-list-providers-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    rows
+    Should Not Be Empty        ${meta_rels_obj['rows']}
+
+MCP HTTPS List Services Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    list_services
+    ...    \-\-exec.args
+    ...    {"provider": "google"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-list-services-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-list-services-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    rows
+    Should Not Be Empty        ${meta_rels_obj['rows']}
+
+MCP HTTPS List Resources Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    list_resources
+    ...    \-\-exec.args
+    ...    {"provider": "google", "service": "compute"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-list-resources-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-list-resources-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    rows
+    Should Not Be Empty        ${meta_rels_obj['rows']}
+
+
+MCP HTTPS List Methods Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    list_methods
+    ...    \-\-exec.args
+    ...    {"provider": "google", "service": "compute", "resource": "networks"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-list-methods-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-list-methods-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    rows
+    Should Not Be Empty        ${meta_rels_obj['rows']}
+
+
+MCP HTTPS Describe Table Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    describe_table
+    ...    \-\-exec.args
+    ...    {"provider": "google", "service": "compute", "resource": "networks"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-describe-table-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-describe-table-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    rows
+    Should Not Be Empty        ${meta_rels_obj['rows']}
+
+MCP HTTPS Server Validate Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    validate_query_json_v2
+    ...    \-\-exec.args
+    ...    {"sql":"select * from google.storage.buckets where project \= 'stackql\-demo';"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-validate-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-validate-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    rows
+    Length Should Be    ${meta_rels_obj['rows']}    1
+
+MCP HTTPS Server Query Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    query_json_v2
+    ...    \-\-exec.args
+    ...    {"sql":"select name, id from google.storage.buckets where project \= 'stackql\-demo';"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-Query-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-Query-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    rows
+    Length Should Be    ${meta_rels_obj['rows']}    7
+
+MCP HTTPS Server Exec Query Canonical
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    # Future proofing: raw text format reserved; may gain structured hints later.
+    ${meta_rels}=    Run Process
+    ...    ${STACKQL_MCP_CLIENT_EXE}
+    ...    exec
+    ...    \-\-client\-type\=http
+    ...    \-\-url\=https://127.0.0.1:9004
+    ...    \-\-client\-cfg
+    ...    { "apply_tls_globally": true, "insecure_skip_verify": true, "ca_file": "test/server/mtls/credentials/pg_server_cert.pem", "promote_leaf_to_ca": true }
+    ...    \-\-exec.action
+    ...    exec_query_json_v2
+    ...    \-\-exec.args
+    ...    {"sql":"delete from google.compute.firewalls where project \= 'mutable\-project' and firewall \= 'deletable\-firewall';"}
+    ...    stdout=${CURDIR}${/}tmp${/}MCP-HTTPS-Exec-Query-canonical.txt
+    ...    stderr=${CURDIR}${/}tmp${/}MCP-HTTPS-Exec-Query-canonical-stderr.txt
+    ${meta_rels_obj}=    Parse MCP JSON Output    ${meta_rels.stdout}
+    Dictionary Should Contain Key    ${meta_rels_obj}    timestamp

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -9013,4 +9013,48 @@ Delete Await Returning Generates Error
     ...    ${EMPTY}
     ...    ${outputErrStr}
     ...    stdout=${CURDIR}/tmp/Delete-Await-Returning-Generates-Error.tmp
-    ...    stderr=${CURDIR}/tmp/Delete-Await-Returning-Generates-Error-stderr.tmp
+    ...    stderr=${CURDIR}/tmp/Delete-Await-Returning-Generates-Error-stderr.tmp 
+
+Explain Select Repeatably Generates Messagez
+    [Documentation]    This is fairly crude but useful in particular for MCP functions.
+    ${inputStr} =    Catenate
+    ...    explain select * from google.storage.buckets where project = 'stackql-demo';
+    ...    explain select * from google.storage.buckets where project = 'stackql-demo';
+    ...    explain select * from aws.ec2.instances where region = 'ap-southeast-2';
+    ...    explain select * from aws.ec2.instances where region = 'ap-southeast-2';
+    ...    explain select 1 as foo;
+    ...    explain select 1 as foo;
+    ...    explain select * from google.storage.buckets;
+    ...    explain select * from google.storage.buckets;
+    ...    explain select * from google.storage.buckets where project = 'stackql-demo';
+    ...    explain select * from google.storage.buckets where project = 'stackql-demo';
+    ${outputErrStrNative} =    Catenate    SEPARATOR=\n
+    ...    Execution plan generated successfully
+    ...    OK
+    ...    Execution plan generated successfully
+    ...    OK
+    ...    Execution plan generated successfully
+    ...    OK
+    ...    Execution plan generated successfully
+    ...    OK
+    ...    OK
+    ...    OK
+    ...    cannot find matching operation, possible causes include missing required parameters or an unsupported method for the resource, to find required parameters for supported methods run SHOW METHODS IN google.storage.buckets: no appropriate method = 'select' for resource = 'buckets'
+    ...    cannot find matching operation, possible causes include missing required parameters or an unsupported method for the resource, to find required parameters for supported methods run SHOW METHODS IN google.storage.buckets: no appropriate method = 'select' for resource = 'buckets'
+    ...    Execution plan generated successfully
+    ...    OK
+    ...    Execution plan generated successfully
+    ...    OK
+    ${outputErrStr} =    Set Variable If    "${EXECUTION_PLATFORM}" == "docker"    OK   ${outputErrStrNative}
+    Should Stackql Exec Inline Equal Stderr
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputErrStr}
+    ...    stdout=${CURDIR}/tmp/Explain-Select-Repeatably-Generates-Messages.tmp
+    ...    stderr=${CURDIR}/tmp/Explain-Select-Repeatably-Generates-Messages-stderr.tmp


### PR DESCRIPTION
## Description

- MCP `v0.1.1.`
- Better MCP server docs.
- `json`-centric MCP API.
- Minimal `EXPLAIN` supported, for `SELECT` queries only, ie: `EXPLAIN SELECT...`.
- Added robot test `Explain Select Repeatably Generates Messages`.
- Added robot test `MCP HTTPS Server Validate Canonical`.
- Added robot test `MCP HTTPS Server Query Canonical`.
- Added robot test `MCP HTTPS List Providers Canonical`.
- Added robot test `MCP HTTPS List Services Canonical`.
- Added robot test `MCP HTTPS List Resources Canonical`.
- Added robot test `MCP HTTPS List Methods Canonical`.
- Added robot test `MCP HTTPS Describe Table Canonical`.
- Added robot test `MCP HTTPS Server Exec Query Canonical`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence


- Added robot test `Explain Select Repeatably Generates Messages`.
- Added robot test `MCP HTTPS Server Validate Canonical`.
- Added robot test `MCP HTTPS Server Query Canonical`.
- Added robot test `MCP HTTPS List Providers Canonical`.
- Added robot test `MCP HTTPS List Services Canonical`.
- Added robot test `MCP HTTPS List Resources Canonical`.
- Added robot test `MCP HTTPS List Methods Canonical`.
- Added robot test `MCP HTTPS Describe Table Canonical`.
- Added robot test `MCP HTTPS Server Exec Query Canonical`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is added in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
