### PR TITLE
docker-compose-testing-capability

### DIFF
--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -1,0 +1,393 @@
+
+   
+services:
+  credentialsgen:
+    restart: "no"
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/stackql/srv/credentials:rw
+    command: 
+      - bash
+      - -c
+      - |
+        openssl req -x509 -keyout /opt/stackql/srv/credentials/pg_server_key.pem -out /opt/stackql/srv/credentials/pg_server_cert.pem  -config /opt/test/stackql/test/server/mtls/openssl.cnf -days 365 \
+        && openssl req -x509 -keyout /opt/stackql/srv/credentials/pg_client_key.pem -out  /opt/stackql/srv/credentials/pg_client_cert.pem  -config /opt/test/stackql/test/server/mtls/openssl.cnf -days 365 \
+        && openssl req -x509 -keyout /opt/stackql/srv/credentials/pg_rubbish_key.pem -out /opt/stackql/srv/credentials/pg_rubbish_cert.pem -config /opt/test/stackql/test/server/mtls/openssl.cnf -days 365
+  github_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - github.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1093:1093/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/github/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1093
+  google_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - googleapis.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1080:1080/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/gcp/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1080
+  azure_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - azure.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1095:1095/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/azure/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1095
+  okta_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - okta.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1090:1090/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/okta/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1090
+  aws_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - aws.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1091:1091/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/aws/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1091
+  sumologic_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - sumologic.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1096:1096/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/sumologic/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1096
+  digitalocean_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - digitalocean.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1097:1097/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/digitalocean/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1097
+  googleadmin_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - googleadmin.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1098:1098/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/googleadmin/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1098
+  static_auth_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - staticauth.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1170:1170/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/static_auth/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1170
+  token_srv_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - staticauth.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "2091:2091/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/oauth2/token_srv \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        2091
+  k8s_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - k8s.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1092:1092/tcp"
+    depends_on:
+      - credentialsgen
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/k8s/app \
+        run \
+        --cert=/opt/testlib/test/server/mtls/credentials/pg_server_cert.pem \
+        --key=/opt/testlib/test/server/mtls/credentials/pg_server_key.pem \
+        --host 0.0.0.0 \
+        --port  \
+        1092
+  registry_mockserver:
+    networks:
+      testing-network:
+        aliases:
+          - registry.com
+    image: stackql/testlib
+    build:
+      context: .
+      dockerfile: testLib.Dockerfile
+      # cache_from: 
+      #   - stackql/testlib
+    volumes:
+      - ./test/server/mtls/credentials:/opt/testlib/test/server/mtls/credentials:ro
+    ports:
+      - "1094:1094/tcp"
+    environment:
+      IS_DOCKER: "${IS_DOCKER:-false}"
+    command: 
+      - bash
+      - -c
+      - |
+        flask \
+        --app=/opt/testlib/test/python/stackql_test_tooling/flask/registry/app \
+        run \
+        --host 0.0.0.0 \
+        --port  \
+        1094
+
+networks:
+  testing-network:
+    driver: bridge
+

--- a/test/python/stackql_test_tooling/flask/README.md
+++ b/test/python/stackql_test_tooling/flask/README.md
@@ -12,10 +12,27 @@ One pertinent fact in life with `flask` is that processes die hard; so it genera
 pgrep -f flask | xargs kill -9
 ```
 
+### Running in docker
 
-### To Run
+This is far and away the easiest option, given you have docker on your system.  You must let the sequence run before starting any `stackql` client, or the TLS credentials will be overwritten.  Then:
 
-In order to get the environmental variables required, you can go to the repository root ans then `source cicd/scripts/context.sh`, or set manually; hopefully self-explanatory.
+```bash
+
+docker compose -f docker-compose-testing.yml up -d --build --force-recreate
+
+```
+
+To kill all:
+
+```bash
+
+docker compose -f docker-compose-testing.yml down --volumes
+
+```
+
+### To Run Natively
+
+In order to get the environmental variables required, you can go to the repository root and then `source cicd/scripts/context.sh`, or set manually; hopefully self-explanatory.
 
 GCP mocks:
 
@@ -50,7 +67,7 @@ flask --app=${REPOSITORY_ROOT}/test/python/stackql_test_tooling/flask/github/app
 Sumologic mocks:
 
 ```bash
-flask --app=${REPOSITORY_ROOT}/test/python/stackql_test_tooling/flask/okta/app run --cert=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_cert.pem --key=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1096
+flask --app=${REPOSITORY_ROOT}/test/python/stackql_test_tooling/flask/sumologic/app run --cert=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_cert.pem --key=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1096
 ```
 
 Digitalocean mocks:
@@ -63,6 +80,12 @@ flask --app=${REPOSITORY_ROOT}/test/python/stackql_test_tooling/flask/digitaloce
 
 ```bash
 flask --app=${REPOSITORY_ROOT}/test/python/stackql_test_tooling/flask/googleadmin/app run --cert=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_cert.pem --key=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1098
+```
+
+`k8s` mocks:
+
+```bash
+flask --app=${REPOSITORY_ROOT}/test/python/stackql_test_tooling/flask/k8s/app run --cert=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_cert.pem --key=${REPOSITORY_ROOT}/test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1092
 ```
 
 stackql auth testing mocks:

--- a/test/python/stackql_test_tooling/web_service_keywords.py
+++ b/test/python/stackql_test_tooling/web_service_keywords.py
@@ -345,6 +345,15 @@ class web_service_keywords(Process):
     
     @keyword
     def start_all_webservers(self, port_dict: Optional[dict] = None) -> None:
+        # if system has docker installed, use that to run mock servers
+        if os.system('which docker >/dev/null 2>&1') == 0:
+            ## inherits env vars from parent process so IS_DOCKER env var is passed along
+            rv = os.system('docker compose -f docker-compose-testing.yml up -d --build --force-recreate')
+            if rv != 0:
+                raise RuntimeError('failed to start mock servers via docker compose')
+            return
+
+
         _port_dict: dict = port_dict if port_dict else {}
 
         self.create_digitalocean_web_service(_port_dict.get('digitalocean', self._DEFAULT_MOCKSERVER_PORT_DIGITALOCEAN))

--- a/testLib.Dockerfile
+++ b/testLib.Dockerfile
@@ -1,0 +1,19 @@
+
+FROM python:3.14.2-trixie AS utility
+
+RUN --mount=type=bind,source=cicd/requirements.txt,target=/tmp/requirements.txt \
+    pip install --requirement /tmp/requirements.txt \
+    && mkdir -p /opt/testlib/test/python \
+    && mkdir -p /opt/testlib/cicd/vol/srv/credentials
+
+COPY test/python/stackql_test_tooling /opt/testlib/test/python/stackql_test_tooling
+
+RUN --mount=type=bind,source=cicd/requirements.txt,target=/tmp/requirements.txt \
+    pip install --requirement /tmp/requirements.txt
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates openssl netcat-traditional jq dnsutils \
+    && update-ca-certificates
+
+CMD ["python", "-c", "print('Hello from testlib')"]
+


### PR DESCRIPTION

## Description

- Mock servers in containers.
- Automated testing uses `docker compose` where available.
- Added how to documentation.
- All test cases continue to pass, on both:
   - Platforms supporting `docker` and therefore following the new pattern.
   - Platforms **not** supporting `docker` and therefore **not** following the new pattern.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- All test cases continue to pass, on both:
   - Platforms supporting `docker` and therefore following the new pattern.
   - Platforms **not** supporting `docker` and therefore **not** following the new pattern.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is accrued in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
