### PR TITLE
mac-os-runner-arm-by-default

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,3 +7,4 @@ self-hosted-runner:
     - arm-ubuntu-22-04-runner-one
     - macos-14 # should not be necessary
     - macos-15 # should not be necessary
+    - macos-15-intel # should not be necessary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1268,7 +1268,7 @@ jobs:
 
   macosbuild:
     name: MacOS Build
-    runs-on: macos-15
+    runs-on: macos-15-intel
     timeout-minutes: ${{ vars.DEFAULT_JOB_TIMEOUT_MIN == '' && 120 || vars.DEFAULT_JOB_TIMEOUT_MIN }}
     steps:
     - name: Check out code into the Go module directory


### PR DESCRIPTION
## Description

At some recent point in time, the `macos-15` runner image switched from `amd64` to `arm64`, per Figure D1.  This change pins the `amd64` job image accordingly.  This fixes the adverse outcome where the desired `amd` build is in fact `arm`.

<img width="848" height="146" alt="Screenshot 2026-01-14 at 6 06 50 PM" src="https://github.com/user-attachments/assets/1ce27560-4166-4c41-9539-a5b15f2a5a5c" />



**Figure D1**:  Runner image platforms.

---

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

The image-pinned `amd` executable is compiled on and for the correct platform, per Figure E1.


<img width="800" height="57" alt="Screenshot 2026-01-14 at 6 21 10 PM" src="https://github.com/user-attachments/assets/fa4c80fb-73e4-485e-a468-7adbc1c30f50" />


**Figure E1**: The `amd` builder pinning forces intel silicon.  Shown is `file` output for the artifact from the build associated with this change.

---

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

This change does not introduce technical debt.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
