### PR TITLE
test: add methodselect unit testing

### DIFF
--- a/internal/stackql/methodselect/methodselect.go
+++ b/internal/stackql/methodselect/methodselect.go
@@ -55,7 +55,7 @@ func (sel *DefaultMethodSelector) GetMethodForAction(
 			"iql action = '%s' curently not supported, there is no method mapping possible for any resource",
 			iqlAction)
 	}
-	m, err := sel.getMethodByNameAndParameters(resource, methodName, parameters)
+	m, err := sel.GetMethodByNameAndParameters(resource, methodName, parameters)
 	return m, methodName, err
 }
 
@@ -73,7 +73,7 @@ func (sel *DefaultMethodSelector) getMethodByName(
 	return m, nil
 }
 
-func (sel *DefaultMethodSelector) getMethodByNameAndParameters(
+func (sel *DefaultMethodSelector) GetMethodByNameAndParameters(
 	resource anysdk.Resource, methodName string,
 	parameters parserutil.ColumnKeyedDatastore) (anysdk.StandardOperationStore, error) {
 	stringifiedParams := parameters.GetStringified()

--- a/internal/stackql/methodselect/methodselect_test.go
+++ b/internal/stackql/methodselect/methodselect_test.go
@@ -1,0 +1,156 @@
+package methodselect_test
+
+import (
+	"testing"
+
+	"github.com/stackql/any-sdk/anysdk"
+	"github.com/stackql/stackql/internal/stackql/methodselect"
+	"github.com/stackql/stackql/internal/stackql/parserutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMethodForAction(t *testing.T) {
+	sel := &methodselect.DefaultMethodSelector{}
+	vr := "v0.1.0"
+	svc, err := anysdk.LoadProviderAndServiceFromPaths(
+		"./testdata/registry/src/aws/"+vr+"/provider.yaml",
+		"./testdata/registry/src/aws/"+vr+"/services/s3.yaml",
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, svc)
+
+	resource, err := svc.GetResource("bucket_acls")
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+
+	tests := []struct {
+		name       string
+		action     string
+		parameters parserutil.ColumnKeyedDatastore
+		wantErr    bool
+		wantMethod string
+	}{
+		{"SELECT action", "SELECT", parserutil.NewParameterMap(), false, "select"},
+		{"UNSUPPORTED action", "UNSUPPORTED", parserutil.NewParameterMap(), true, ""},
+		{"Mixed case action", "SeLeCt", parserutil.NewParameterMap(), false, "select"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			method, methodName, err := sel.GetMethodForAction(resource, tt.action, tt.parameters)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantMethod, methodName)
+			assert.NotNil(t, method)
+		})
+	}
+}
+
+func TestGetMethod(t *testing.T) {
+	sel := &methodselect.DefaultMethodSelector{}
+	vr := "v0.1.0"
+	svc, err := anysdk.LoadProviderAndServiceFromPaths(
+		"./testdata/registry/src/aws/"+vr+"/provider.yaml",
+		"./testdata/registry/src/aws/"+vr+"/services/s3.yaml",
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, svc)
+
+	resource, err := svc.GetResource("bucket_acls")
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+
+	tests := []struct {
+		name       string
+		methodName string
+		wantErr    bool
+	}{
+		{"Existing method", "get_bucket_acl", false},
+		{"Non-existent method", "nonexistent", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			method, err := sel.GetMethod(resource, tt.methodName)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, method)
+		})
+	}
+}
+
+func TestGetMethodByNameAndParameters(t *testing.T) {
+	sel := &methodselect.DefaultMethodSelector{}
+	vr := "v0.1.0"
+	svc, err := anysdk.LoadProviderAndServiceFromPaths(
+		"./testdata/registry/src/aws/"+vr+"/provider.yaml",
+		"./testdata/registry/src/aws/"+vr+"/services/s3.yaml",
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, svc)
+
+	resource, err := svc.GetResource("bucket_acls")
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+
+	tests := []struct {
+		name       string
+		methodName string
+		parameters parserutil.ColumnKeyedDatastore
+		wantErr    bool
+	}{
+		{
+			"Existing method with parameters",
+			"select",
+			parserutil.NewParameterMap(),
+			false,
+		},
+		{
+			"Non-existent method with parameters",
+			"nonexistent",
+			parserutil.NewParameterMap(),
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			method, err := sel.GetMethodByNameAndParameters(resource, tt.methodName, tt.parameters)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, method)
+		})
+	}
+}
+
+func TestNewMethodSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		version  string
+		wantErr  bool
+	}{
+		{"Default provider", "aws", "v0.1.0", false},
+		{"Unsupported provider", "unsupported", "v0.1.0", false}, // Defaults to Google
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selector, err := methodselect.NewMethodSelector(tt.provider, tt.version)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, selector)
+		})
+	}
+}

--- a/internal/stackql/methodselect/testdata/registry/src/aws/v0.1.0/provider.yaml
+++ b/internal/stackql/methodselect/testdata/registry/src/aws/v0.1.0/provider.yaml
@@ -1,0 +1,19 @@
+id: aws
+name: aws
+version: v0.1.0
+providerServices:
+  s3:
+    description: s3
+    id: s3:v0.1.0
+    name: s3
+    preferred: true
+    service:
+      $ref: aws/v0.1.0/services/s3.yaml
+    title: S3
+    version: v0.1.0
+openapi: 3.0.0
+config:
+  auth:
+    type: "aws_signing_v4"
+    credentialsenvvar: "AWS_SECRET_ACCESS_KEY"
+    keyIDenvvar: "AWS_ACCESS_KEY_ID"

--- a/internal/stackql/methodselect/testdata/registry/src/aws/v0.1.0/services/s3.yaml
+++ b/internal/stackql/methodselect/testdata/registry/src/aws/v0.1.0/services/s3.yaml
@@ -1,0 +1,13857 @@
+openapi: 3.1.0
+info:
+  contact:
+    name: StackQL Studios
+    url: https://stackql.io/
+    email: info@stackql.io
+  x-aws-modelFile: https://github.com/aws/api-models-aws/tree/main/models/s3/service/2006-03-01/s3-2006-03-01.json
+  version: '2006-03-01'
+  title: Amazon Simple Storage Service
+  description: ""
+  x-serviceName: s3
+  x-aws-modelProtocol: aws.protocols#restXml
+servers:
+- description: The Amazon Simple Storage Service regional endpoint
+  url: https://s3.{region}.amazonaws.com
+  variables:
+    region:
+      description: The AWS region
+      enum:
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - us-west-2
+      - us-gov-west-1
+      - us-gov-east-1
+      - ca-central-1
+      - eu-north-1
+      - eu-west-1
+      - eu-west-2
+      - eu-west-3
+      - eu-central-1
+      - eu-south-1
+      - af-south-1
+      - ap-northeast-1
+      - ap-northeast-2
+      - ap-northeast-3
+      - ap-southeast-1
+      - ap-southeast-2
+      - ap-east-1
+      - ap-south-1
+      - sa-east-1
+      - me-south-1
+      default: us-east-1
+paths:
+  /?abac:
+    servers:
+    - url: 'https://{Bucket}.s3-{region}.amazonaws.com'
+      variables:
+        Bucket:
+          default: stackql-trial-bucket-02
+        region:
+          default: us-east-1
+    get:
+      operationId: GetBucketAbac
+      description: |-
+        Returns the attribute-based access control (ABAC) property of the general purpose bucket. If ABAC is enabled on your bucket, you can use tags on the bucket for access control. For more information, see [Enabling ABAC in general purpose buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html).
+      parameters:
+      - name: x-amz-content-sha256
+        in: header
+        required: false
+        schema:
+          type: string
+          default: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      - name: x-amz-expected-bucket-owner
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/AccountId'
+      responses:
+        '200':
+          description: Success
+          content:
+            text/xml:
+              schema:
+                $ref: '#/components/schemas/GetBucketAbacOutput'
+    put:
+      operationId: PutBucketAbac
+      description: |-
+        Sets the attribute-based access control (ABAC) property of the general purpose bucket. You must have `s3:PutBucketABAC` permission to perform this action. When you enable ABAC, you can use tags for access control on your buckets. Additionally, when ABAC is enabled, you must use the [TagResource](https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_TagResource.html) and [UntagResource](https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_UntagResource.html) actions to manage tags on your buckets. You can nolonger use the [PutBucketTagging](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html) and [DeleteBucketTagging](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html) actions to tag your bucket. For more information, see [Enabling ABAC in general purpose buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html).
+      parameters:
+      - name: Content-MD5
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/ContentMD5'
+      - name: x-amz-sdk-checksum-algorithm
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+      - name: x-amz-expected-bucket-owner
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/AccountId'
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/AbacStatus'
+      responses:
+        '200':
+          description: Success
+  /?acl:
+    servers:
+    - url: 'https://{Bucket:.+}.s3-{region}.amazonaws.com'
+      variables:
+        Bucket:
+          default: stackql-trial-bucket-02
+        region:
+          default: us-east-1
+    get:
+      operationId: GetBucketAcl
+      description: |-
+        This operation is not supported for directory buckets.
+
+        This implementation of the `GET` action uses the `acl` subresource to return the access control list (ACL) of a bucket. To use `GET` to return the ACL of the bucket, you must have the `READ_ACP` access to the bucket. If `READ_ACP` permission is granted to the anonymous user, you can return the ACL of the bucket without using an authorization header.
+
+        When you use this API operation with an access point, provide the alias of the access point in place of the bucket name.
+
+        When you use this API operation with an Object Lambda access point, provide the alias of the Object Lambda access point in place of the bucket name. If the Object Lambda access point alias in a request is not valid, the error code `InvalidAccessPointAliasError` is returned. For more information about `InvalidAccessPointAliasError`, see [List of Error Codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).
+
+        If your bucket uses the bucket owner enforced setting for S3 Object Ownership, requests to read ACLs are still supported and return the `bucket-owner-full-control` ACL with the owner being the account that created the bucket. For more information, see [ Controlling object ownership and disabling ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) in the _Amazon S3 User Guide_.
+
+        You must URL encode any signed header values that contain spaces. For example, if your header value is `my file.txt`, containing two spaces after `my`, you must URL encode this value to `my%20%20file.txt`.
+
+        The following operations are related to `GetBucketAcl`:
+
+          * [ListObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html)
+      parameters:
+      - name: created_date
+        in: context
+        required: false
+        schema:
+          type: string
+      - name: x-amz-expected-bucket-owner
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/AccountId'
+      responses:
+        '200':
+          description: Success
+          content:
+            text/xml:
+              schema:
+                $ref: '#/components/schemas/GetBucketAclOutput'
+    put:
+      operationId: PutBucketAcl
+      description: "End of support notice: As of October 1, 2025, Amazon S3 has discontinued\
+        \ support for Email Grantee Access Control Lists (ACLs). If you attempt to\
+        \ use an Email Grantee ACL in a request after October 1, 2025, the request\
+        \ will receive an `HTTP 405` (Method Not Allowed) error.\n\nThis change affects\
+        \ the following Amazon Web Services Regions: US East (N. Virginia), US West\
+        \ (N. California), US West (Oregon), Asia Pacific (Singapore), Asia Pacific\
+        \ (Sydney), Asia Pacific (Tokyo), Europe (Ireland), and South America (São\
+        \ Paulo).\n\nThis operation is not supported for directory buckets.\n\nSets\
+        \ the permissions on an existing bucket using access control lists (ACL).\
+        \ For more information, see [Using ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).\
+        \ To set the ACL of a bucket, you must have the `WRITE_ACP` permission.\n\n\
+        You can use one of the following two ways to set a bucket's permissions:\n\
+        \n  * Specify the ACL in the request body\n\n  * Specify permissions using\
+        \ request headers\n\nYou cannot specify access permission using both the body\
+        \ and the request headers.\n\nDepending on your application needs, you may\
+        \ choose to set the ACL on a bucket using either the request body or the headers.\
+        \ For example, if you have an existing application that updates a bucket ACL\
+        \ using the request body, then you can continue to use that approach.\n\n\
+        If your bucket uses the bucket owner enforced setting for S3 Object Ownership,\
+        \ ACLs are disabled and no longer affect permissions. You must use policies\
+        \ to grant access to your bucket and the objects in it. Requests to set ACLs\
+        \ or update ACLs fail and return the `AccessControlListNotSupported` error\
+        \ code. Requests to read ACLs are still supported. For more information, see\
+        \ [Controlling object ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)\
+        \ in the _Amazon S3 User Guide_.\n\nPermissions\n\n    \n\nYou can set access\
+        \ permissions by using one of the following methods:\n\n  * Specify a canned\
+        \ ACL with the `x-amz-acl` request header. Amazon S3 supports a set of predefined\
+        \ ACLs, known as _canned ACLs_. Each canned ACL has a predefined set of grantees\
+        \ and permissions. Specify the canned ACL name as the value of `x-amz-acl`.\
+        \ If you use this header, you cannot use other access control-specific headers\
+        \ in your request. For more information, see [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).\n\
+        \n  * Specify access permissions explicitly with the `x-amz-grant-read`, `x-amz-grant-read-acp`,\
+        \ `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers. When using\
+        \ these headers, you specify explicit access permissions and grantees (Amazon\
+        \ Web Services accounts or Amazon S3 groups) who will receive the permission.\
+        \ If you use these ACL-specific headers, you cannot use the `x-amz-acl` header\
+        \ to set a canned ACL. These parameters map to the set of permissions that\
+        \ Amazon S3 supports in an ACL. For more information, see [Access Control\
+        \ List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).\n\
+        \nYou specify each grantee as a type=value pair, where the type is one of\
+        \ the following:\n\n    * `id` – if the value specified is the canonical user\
+        \ ID of an Amazon Web Services account\n\n    * `uri` – if you are granting\
+        \ permissions to a predefined group\n\n    * `emailAddress` – if the value\
+        \ specified is the email address of an Amazon Web Services account\n\nUsing\
+        \ email addresses to specify a grantee is only supported in the following\
+        \ Amazon Web Services Regions:\n\n      * US East (N. Virginia)\n\n      *\
+        \ US West (N. California)\n\n      * US West (Oregon)\n\n      * Asia Pacific\
+        \ (Singapore)\n\n      * Asia Pacific (Sydney)\n\n      * Asia Pacific (Tokyo)\n\
+        \n      * Europe (Ireland)\n\n      * South America (São Paulo)\n\nFor a list\
+        \ of all the Amazon S3 supported Regions and endpoints, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)\
+        \ in the Amazon Web Services General Reference.\n\nFor example, the following\
+        \ `x-amz-grant-write` header grants create, overwrite, and delete objects\
+        \ permission to LogDelivery group predefined by Amazon S3 and two Amazon Web\
+        \ Services accounts identified by their email addresses.\n\n`x-amz-grant-write:\
+        \ uri=\"http://acs.amazonaws.com/groups/s3/LogDelivery\", id=\"111122223333\"\
+        , id=\"555566667777\" `\n\nYou can use either a canned ACL or specify access\
+        \ permissions explicitly. You cannot do both.\n\nGrantee Values\n\n    \n\n\
+        You can specify the person (grantee) to whom you're assigning access rights\
+        \ (using request elements) in the following ways. For examples of how to specify\
+        \ these grantee values in JSON format, see the Amazon Web Services CLI example\
+        \ in [ Enabling Amazon S3 server access logging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)\
+        \ in the _Amazon S3 User Guide_.\n\n  * By the person's ID:\n\n`<>ID<><>GranteesEmail<>\
+        \ `\n\nDisplayName is optional and ignored in the request\n\n  * By URI:\n\
+        \n`<>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<>`\n\n  * By\
+        \ Email address:\n\n`<>Grantees@email.com<>&`\n\nThe grantee is resolved to\
+        \ the CanonicalUser and, in a response to a GET Object acl request, appears\
+        \ as the CanonicalUser.\n\nUsing email addresses to specify a grantee is only\
+        \ supported in the following Amazon Web Services Regions:\n\n    * US East\
+        \ (N. Virginia)\n\n    * US West (N. California)\n\n    * US West (Oregon)\n\
+        \n    * Asia Pacific (Singapore)\n\n    * Asia Pacific (Sydney)\n\n    * Asia\
+        \ Pacific (Tokyo)\n\n    * Europe (Ireland)\n\n    * South America (São Paulo)\n\
+        \nFor a list of all the Amazon S3 supported Regions and endpoints, see [Regions\
+        \ and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)\
+        \ in the Amazon Web Services General Reference.\n\nThe following operations\
+        \ are related to `PutBucketAcl`:\n\n  * [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html)\n\
+        \n  * [DeleteBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html)\n\
+        \n  * [GetObjectAcl](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html)\n\
+        \nYou must URL encode any signed header values that contain spaces. For example,\
+        \ if your header value is `my file.txt`, containing two spaces after `my`,\
+        \ you must URL encode this value to `my%20%20file.txt`."
+      parameters:
+      - name: x-amz-acl
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/BucketCannedACL'
+      - name: Bucket
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/BucketName'
+      - name: Content-MD5
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/ContentMD5'
+      - name: x-amz-sdk-checksum-algorithm
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+      - name: x-amz-grant-full-control
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/GrantFullControl'
+      - name: x-amz-grant-read
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/GrantRead'
+      - name: x-amz-grant-read-acp
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/GrantReadACP'
+      - name: x-amz-grant-write
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/GrantWrite'
+      - name: x-amz-grant-write-acp
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/GrantWriteACP'
+      - name: x-amz-expected-bucket-owner
+        in: header
+        required: false
+        schema:
+          $ref: '#/components/schemas/AccountId'
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/AccessControlPolicy'
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    AbacInputOverride:
+      type: object
+      description: A convenience for presentation
+      properties:
+        line_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbacInputOverrideJunk'
+        status:
+          type: string
+    AbacInputOverrideJunk:
+      type: object
+      properties:
+        comment:
+          type: string
+        source:
+          type: string
+        id:
+          type: number
+    AbacStatus:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/BucketAbacStatus'
+          description: The ABAC status of the general purpose bucket.
+      description: The ABAC status of the general purpose bucket. When ABAC is enabled
+        for the general purpose bucket, you can use tags to manage access to the general
+        purpose buckets as well as for cost tracking purposes. When ABAC is disabled
+        for the general purpose buckets, you can only use tags for cost tracking purposes.
+        For more information, see [Using tags with S3 general purpose buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html).
+    AbortDate:
+      type: string
+      format: date-time
+    AbortIncompleteMultipartUpload:
+      type: object
+      properties:
+        DaysAfterInitiation:
+          $ref: '#/components/schemas/DaysAfterInitiation'
+          description: Specifies the number of days after which Amazon S3 aborts an
+            incomplete multipart upload.
+      description: Specifies the days since the initiation of an incomplete multipart
+        upload that Amazon S3 will wait before permanently removing all parts of the
+        upload. For more information, see [ Aborting Incomplete Multipart Uploads
+        Using a Bucket Lifecycle Configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config)
+        in the _Amazon S3 User Guide_.
+    AbortMultipartUploadOutput:
+      type: object
+      properties:
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    AbortMultipartUploadRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name to which the upload was taking place.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Key of the object for which the multipart upload was initiated.
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: Upload ID that identifies the multipart upload.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        IfMatchInitiatedTime:
+          $ref: '#/components/schemas/IfMatchInitiatedTime'
+          description: 'If present, this header aborts an in progress multipart upload
+            only if it was initiated on the provided timestamp. If the initiated timestamp
+            of the multipart upload does not match the provided value, the operation
+            returns a `412 Precondition Failed` error. If the initiated timestamp
+            matches or if the multipart upload doesn’t exist, the operation returns
+            a `204 Success (No Content)` response.
+
+
+            This functionality is only supported for directory buckets.'
+      required:
+      - Bucket
+      - Key
+      - UploadId
+    AbortRuleId:
+      type: string
+    AccelerateConfiguration:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/BucketAccelerateStatus'
+          description: Specifies the transfer acceleration status of the bucket.
+      description: Configures the transfer acceleration state for an Amazon S3 bucket.
+        For more information, see [Amazon S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html)
+        in the _Amazon S3 User Guide_.
+    AcceptRanges:
+      type: string
+    AccessControlPolicy:
+      type: object
+      properties:
+        Grants:
+          $ref: '#/components/schemas/Grants'
+          description: A list of grants.
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: Container for the bucket owner's display name and ID.
+      description: Contains the elements that set the ACL permissions for an object
+        per grantee.
+    AccessControlTranslation:
+      type: object
+      properties:
+        Owner:
+          $ref: '#/components/schemas/OwnerOverride'
+          description: Specifies the replica ownership. For default and valid values,
+            see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html)
+            in the _Amazon S3 API Reference_.
+      required:
+      - Owner
+      description: A container for information about access control for replicas.
+    AccessKeyIdValue:
+      type: string
+    AccessPointAlias:
+      type: boolean
+    AccessPointArn:
+      type: string
+    AccountId:
+      type: string
+    AllowQuotedRecordDelimiter:
+      type: boolean
+    AllowedHeader:
+      type: string
+    AllowedHeaders:
+      type: array
+      items:
+        $ref: '#/components/schemas/AllowedHeader'
+    AllowedMethod:
+      type: string
+    AllowedMethods:
+      type: array
+      items:
+        $ref: '#/components/schemas/AllowedMethod'
+    AllowedOrigin:
+      type: string
+    AllowedOrigins:
+      type: array
+      items:
+        $ref: '#/components/schemas/AllowedOrigin'
+    AnalyticsAndOperator:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'The prefix to use when evaluating an AND predicate: The prefix
+            that an object must have to be included in the metrics results.'
+        Tags:
+          $ref: '#/components/schemas/TagSet'
+          description: The list of tags to use when evaluating an AND predicate.
+      description: A conjunction (logical AND) of predicates, which is used in evaluating
+        a metrics filter. The operator must have at least two predicates in any combination,
+        and an object must match all of the predicates for the filter to apply.
+    AnalyticsConfiguration:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/AnalyticsId'
+          description: The ID that identifies the analytics configuration.
+        Filter:
+          $ref: '#/components/schemas/AnalyticsFilter'
+          description: The filter used to describe a set of objects for analyses.
+            A filter must have exactly one prefix, one tag, or one conjunction (AnalyticsAndOperator).
+            If no filter is provided, all objects will be considered in any analysis.
+        StorageClassAnalysis:
+          $ref: '#/components/schemas/StorageClassAnalysis'
+          description: Contains data related to access patterns to be collected and
+            made available to analyze the tradeoffs between different storage classes.
+      required:
+      - Id
+      - StorageClassAnalysis
+      description: Specifies the configuration and any analyses for the analytics
+        filter of an Amazon S3 bucket.
+    AnalyticsConfigurationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/AnalyticsConfiguration'
+    AnalyticsExportDestination:
+      type: object
+      properties:
+        S3BucketDestination:
+          $ref: '#/components/schemas/AnalyticsS3BucketDestination'
+          description: A destination signifying output to an S3 bucket.
+      required:
+      - S3BucketDestination
+      description: Where to publish the analytics results.
+    AnalyticsFilter:
+      allOf:
+      - $ref: '#/components/schemas/Prefix'
+        description: |-
+          The prefix to use when evaluating an analytics filter.
+      - $ref: '#/components/schemas/Tag'
+        description: |-
+          The tag to use when evaluating an analytics filter.
+      - $ref: '#/components/schemas/AnalyticsAndOperator'
+        description: |-
+          A conjunction (logical AND) of predicates, which is used in evaluating an analytics filter. The operator must have at least two predicates.
+      description: |-
+        The filter used to describe a set of objects for analyses. A filter must have exactly one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided, all objects will be considered in any analysis.
+    AnalyticsId:
+      type: string
+    AnalyticsS3BucketDestination:
+      type: object
+      properties:
+        Format:
+          $ref: '#/components/schemas/AnalyticsS3ExportFileFormat'
+          description: Specifies the file format used when exporting data to Amazon
+            S3.
+        BucketAccountId:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID that owns the destination S3 bucket. If no
+            account ID is provided, the owner is not validated before exporting data.
+
+
+            Although this value is optional, we strongly recommend that you set it
+            to help prevent problems if the destination bucket ownership changes.'
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The Amazon Resource Name (ARN) of the bucket to which data
+            is exported.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: The prefix to use when exporting data. The prefix is prepended
+            to all results.
+      required:
+      - Format
+      - Bucket
+      description: Contains information about where to publish the analytics results.
+    AnalyticsS3ExportFileFormat:
+      type: string
+      enum:
+      - CSV
+    ArchiveStatus:
+      type: string
+      enum:
+      - ARCHIVE_ACCESS
+      - DEEP_ARCHIVE_ACCESS
+    BlockedEncryptionTypes:
+      type: object
+      properties:
+        EncryptionType:
+          $ref: '#/components/schemas/EncryptionTypeList'
+          description: 'The object encryption type that you want to block or unblock
+            for an Amazon S3 general purpose bucket.
+
+
+            Currently, this parameter only supports blocking or unblocking server
+            side encryption with customer-provided keys (SSE-C). For more information
+            about SSE-C, see [Using server-side encryption with customer-provided
+            keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).'
+      description: "A bucket-level setting for Amazon S3 general purpose buckets used\
+        \ to prevent the upload of new objects encrypted with the specified server-side\
+        \ encryption type. For example, blocking an encryption type will block `PutObject`,\
+        \ `CopyObject`, `PostObject`, multipart upload, and replication requests to\
+        \ the bucket for objects with the specified encryption type. However, you\
+        \ can continue to read and list any pre-existing objects already encrypted\
+        \ with the specified encryption type. For more information, see [Blocking\
+        \ or unblocking SSE-C for a general purpose bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html).\n\
+        \nThis data type is used with the following actions:\n\n  * [PutBucketEncryption](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html)\n\
+        \n  * [GetBucketEncryption](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html)\n\
+        \n  * [DeleteBucketEncryption](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html)\n\
+        \nPermissions\n\n    \n\nYou must have the `s3:PutEncryptionConfiguration`\
+        \ permission to block or unblock an encryption type for a bucket.\n\nYou must\
+        \ have the `s3:GetEncryptionConfiguration` permission to view a bucket's encryption\
+        \ type."
+    Body:
+      type: string
+      format: byte
+    Bucket:
+      type: object
+      properties:
+        Name:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket.
+        CreationDate:
+          $ref: '#/components/schemas/CreationDate'
+          description: Date the bucket was created. This date can change when making
+            changes to your bucket, such as editing its bucket policy.
+        BucketRegion:
+          $ref: '#/components/schemas/BucketRegion'
+          description: '`BucketRegion` indicates the Amazon Web Services region where
+            the bucket is located. If the request contains at least one valid parameter,
+            it is included in the response.'
+        BucketArn:
+          $ref: '#/components/schemas/S3RegionalOrS3ExpressBucketArnString'
+          description: 'The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely
+            identify Amazon Web Services resources across all of Amazon Web Services.
+
+
+            This parameter is only supported for S3 directory buckets. For more information,
+            see [Using tags with directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html).'
+      description: In terms of implementation, a Bucket is a resource.
+    BucketAbacStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    BucketAccelerateStatus:
+      type: string
+      enum:
+      - Enabled
+      - Suspended
+    BucketAlreadyExists:
+      type: object
+      properties: {}
+      description: The requested bucket name is not available. The bucket namespace
+        is shared by all users of the system. Select a different name and try again.
+    BucketAlreadyOwnedByYou:
+      type: object
+      properties: {}
+      description: The bucket you tried to create already exists, and you own it.
+        Amazon S3 returns this error in all Amazon Web Services Regions except in
+        the North Virginia Region. For legacy compatibility, if you re-create an existing
+        bucket that you already own in the North Virginia Region, Amazon S3 returns
+        200 OK and resets the bucket access control lists (ACLs).
+    BucketCannedACL:
+      type: string
+      enum:
+      - private
+      - public-read
+      - public-read-write
+      - authenticated-read
+    BucketInfo:
+      type: object
+      properties:
+        DataRedundancy:
+          $ref: '#/components/schemas/DataRedundancy'
+          description: The number of Zone (Availability Zone or Local Zone) that's
+            used for redundancy for the bucket.
+        Type:
+          $ref: '#/components/schemas/BucketType'
+          description: The type of bucket.
+      description: 'Specifies the information about the bucket that will be created.
+        For more information about directory buckets, see [Directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-overview.html)
+        in the _Amazon S3 User Guide_.
+
+
+        This functionality is only supported by directory buckets.'
+    BucketKeyEnabled:
+      type: boolean
+    BucketLifecycleConfiguration:
+      type: object
+      properties:
+        Rules:
+          $ref: '#/components/schemas/LifecycleRules'
+          description: A lifecycle rule for individual objects in an Amazon S3 bucket.
+      required:
+      - Rules
+      description: Specifies the lifecycle configuration for objects in an Amazon
+        S3 bucket. For more information, see [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html)
+        in the _Amazon S3 User Guide_.
+    BucketLocationConstraint:
+      type: string
+      enum:
+      - af-south-1
+      - ap-east-1
+      - ap-northeast-1
+      - ap-northeast-2
+      - ap-northeast-3
+      - ap-south-1
+      - ap-south-2
+      - ap-southeast-1
+      - ap-southeast-2
+      - ap-southeast-3
+      - ap-southeast-4
+      - ap-southeast-5
+      - ca-central-1
+      - cn-north-1
+      - cn-northwest-1
+      - EU
+      - eu-central-1
+      - eu-central-2
+      - eu-north-1
+      - eu-south-1
+      - eu-south-2
+      - eu-west-1
+      - eu-west-2
+      - eu-west-3
+      - il-central-1
+      - me-central-1
+      - me-south-1
+      - sa-east-1
+      - us-east-2
+      - us-gov-east-1
+      - us-gov-west-1
+      - us-west-1
+      - us-west-2
+    BucketLocationName:
+      type: string
+    BucketLoggingStatus:
+      type: object
+      properties:
+        LoggingEnabled:
+          $ref: '#/components/schemas/LoggingEnabled'
+      description: Container for logging status information.
+    BucketLogsPermission:
+      type: string
+      enum:
+      - FULL_CONTROL
+      - READ
+      - WRITE
+    BucketName:
+      type: string
+    BucketRegion:
+      type: string
+    BucketType:
+      type: string
+      enum:
+      - Directory
+    BucketVersioningStatus:
+      type: string
+      enum:
+      - Enabled
+      - Suspended
+    Buckets:
+      type: array
+      items:
+        allOf:
+          - $ref: '#/components/schemas/Bucket'
+          - xml:
+              name: Bucket
+
+    BypassGovernanceRetention:
+      type: boolean
+    BytesProcessed:
+      type: integer
+      format: int64
+    BytesReturned:
+      type: integer
+      format: int64
+    BytesScanned:
+      type: integer
+      format: int64
+    CORSConfiguration:
+      type: object
+      properties:
+        CORSRules:
+          $ref: '#/components/schemas/CORSRules'
+          description: A set of origins and methods (cross-origin access that you
+            want to allow). You can add up to 100 rules to the configuration.
+      required:
+      - CORSRules
+      description: Describes the cross-origin access configuration for objects in
+        an Amazon S3 bucket. For more information, see [Enabling Cross-Origin Resource
+        Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) in the
+        _Amazon S3 User Guide_.
+    CORSRule:
+      type: object
+      properties:
+        ID:
+          $ref: '#/components/schemas/ID'
+          description: Unique identifier for the rule. The value cannot be longer
+            than 255 characters.
+        AllowedHeaders:
+          $ref: '#/components/schemas/AllowedHeaders'
+          description: Headers that are specified in the `Access-Control-Request-Headers`
+            header. These headers are allowed in a preflight OPTIONS request. In response
+            to any preflight OPTIONS request, Amazon S3 returns any requested headers
+            that are allowed.
+        AllowedMethods:
+          $ref: '#/components/schemas/AllowedMethods'
+          description: An HTTP method that you allow the origin to execute. Valid
+            values are `GET`, `PUT`, `HEAD`, `POST`, and `DELETE`.
+        AllowedOrigins:
+          $ref: '#/components/schemas/AllowedOrigins'
+          description: One or more origins you want customers to be able to access
+            the bucket from.
+        ExposeHeaders:
+          $ref: '#/components/schemas/ExposeHeaders'
+          description: One or more headers in the response that you want customers
+            to be able to access from their applications (for example, from a JavaScript
+            `XMLHttpRequest` object).
+        MaxAgeSeconds:
+          $ref: '#/components/schemas/MaxAgeSeconds'
+          description: The time in seconds that your browser is to cache the preflight
+            response for the specified resource.
+      required:
+      - AllowedMethods
+      - AllowedOrigins
+      description: Specifies a cross-origin access rule for an Amazon S3 bucket.
+    CORSRules:
+      type: array
+      items:
+        $ref: '#/components/schemas/CORSRule'
+    CSVInput:
+      type: object
+      properties:
+        FileHeaderInfo:
+          $ref: '#/components/schemas/FileHeaderInfo'
+          description: "Describes the first line of input. Valid values are:\n\n \
+            \ * `NONE`: First line is not a header.\n\n  * `IGNORE`: First line is\
+            \ a header, but you can't use the header values to indicate the column\
+            \ in an expression. You can use column position (such as _1, _2, …) to\
+            \ indicate the column (`SELECT s._1 FROM OBJECT s`).\n\n  * `Use`: First\
+            \ line is a header, and you can use the header value to identify a column\
+            \ in an expression (`SELECT \"name\" FROM OBJECT`)."
+        Comments:
+          $ref: '#/components/schemas/Comments'
+          description: 'A single character used to indicate that a row should be ignored
+            when the character is present at the start of that row. You can specify
+            any character to indicate a comment line. The default character is `#`.
+
+
+            Default: `#`'
+        QuoteEscapeCharacter:
+          $ref: '#/components/schemas/QuoteEscapeCharacter'
+          description: A single character used for escaping the quotation mark character
+            inside an already escaped value. For example, the value `""" a , b """`
+            is parsed as `" a , b "`.
+        RecordDelimiter:
+          $ref: '#/components/schemas/RecordDelimiter'
+          description: A single character used to separate individual records in the
+            input. Instead of the default value, you can specify an arbitrary delimiter.
+        FieldDelimiter:
+          $ref: '#/components/schemas/FieldDelimiter'
+          description: A single character used to separate individual fields in a
+            record. You can specify an arbitrary delimiter.
+        QuoteCharacter:
+          $ref: '#/components/schemas/QuoteCharacter'
+          description: 'A single character used for escaping when the field delimiter
+            is part of the value. For example, if the value is `a, b`, Amazon S3 wraps
+            this field value in quotation marks, as follows: `" a , b "`.
+
+
+            Type: String
+
+
+            Default: `"`
+
+
+            Ancestors: `CSV`'
+        AllowQuotedRecordDelimiter:
+          $ref: '#/components/schemas/AllowQuotedRecordDelimiter'
+          description: Specifies that CSV field values may contain quoted record delimiters
+            and such records should be allowed. Default value is FALSE. Setting this
+            value to TRUE may lower performance.
+      description: Describes how an uncompressed comma-separated values (CSV)-formatted
+        input object is formatted.
+    CSVOutput:
+      type: object
+      properties:
+        QuoteFields:
+          $ref: '#/components/schemas/QuoteFields'
+          description: "Indicates whether to use quotation marks around output fields.\n\
+            \n  * `ALWAYS`: Always use quotation marks for output fields.\n\n  * `ASNEEDED`:\
+            \ Use quotation marks for output fields when needed."
+        QuoteEscapeCharacter:
+          $ref: '#/components/schemas/QuoteEscapeCharacter'
+          description: The single character used for escaping the quote character
+            inside an already escaped value.
+        RecordDelimiter:
+          $ref: '#/components/schemas/RecordDelimiter'
+          description: A single character used to separate individual records in the
+            output. Instead of the default value, you can specify an arbitrary delimiter.
+        FieldDelimiter:
+          $ref: '#/components/schemas/FieldDelimiter'
+          description: The value used to separate individual fields in a record. You
+            can specify an arbitrary delimiter.
+        QuoteCharacter:
+          $ref: '#/components/schemas/QuoteCharacter'
+          description: 'A single character used for escaping when the field delimiter
+            is part of the value. For example, if the value is `a, b`, Amazon S3 wraps
+            this field value in quotation marks, as follows: `" a , b "`.'
+      description: Describes how uncompressed comma-separated values (CSV)-formatted
+        results are formatted.
+    CacheControl:
+      type: string
+    Checksum:
+      type: object
+      properties:
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32 checksum` of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the object.
+            This checksum is present if the object was uploaded with the `CRC64NVME`
+            checksum algorithm, or if the object was uploaded without a checksum (and
+            Amazon S3 added the default checksum, `CRC64NVME`, to the uploaded object).
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` digest of the object. This
+            checksum is only present if the checksum was uploaded with the object.
+            When you use the API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` digest of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type that is used to calculate the object’s checksum
+            value. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+      description: Contains all the possible checksum or digest values for an object.
+    ChecksumAlgorithm:
+      type: string
+      enum:
+      - CRC32
+      - CRC32C
+      - SHA1
+      - SHA256
+      - CRC64NVME
+    ChecksumAlgorithmList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ChecksumAlgorithm'
+    ChecksumCRC32:
+      type: string
+    ChecksumCRC32C:
+      type: string
+    ChecksumCRC64NVME:
+      type: string
+    ChecksumMode:
+      type: string
+      enum:
+      - ENABLED
+    ChecksumSHA1:
+      type: string
+    ChecksumSHA256:
+      type: string
+    ChecksumType:
+      type: string
+      enum:
+      - COMPOSITE
+      - FULL_OBJECT
+    ClientToken:
+      type: string
+    Code:
+      type: string
+    Comments:
+      type: string
+    CommonPrefix:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: Container for the specified common prefix.
+      description: Container for all (if there are any) keys between Prefix and the
+        next occurrence of the string specified by a delimiter. CommonPrefixes lists
+        keys that act like subdirectories in the directory specified by Prefix. For
+        example, if the prefix is notes/ and the delimiter is a slash (/) as in notes/summer/july,
+        the common prefix is notes/summer/.
+    CommonPrefixList:
+      type: array
+      items:
+        $ref: '#/components/schemas/CommonPrefix'
+    CompleteMultipartUploadOutput:
+      type: object
+      properties:
+        Location:
+          $ref: '#/components/schemas/Location'
+          description: The URI that identifies the newly created object.
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket that contains the newly created object.
+            Does not return the access point ARN or access point alias if used.
+
+
+            Access points are not supported by directory buckets.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The object key of the newly created object.
+        Expiration:
+          $ref: '#/components/schemas/Expiration'
+          description: 'If the object expiration is configured, this will contain
+            the expiration date (`expiry-date`) and rule ID (`rule-id`). The value
+            of `rule-id` is URL-encoded.
+
+
+            This functionality is not supported for directory buckets.'
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: Entity tag that identifies the newly created object's data.
+            Objects with different object data will have different entity tags. The
+            entity tag is an opaque string. The entity tag may or may not be an MD5
+            digest of the object data. If the entity tag is not an MD5 digest of the
+            object data, it will contain one or more nonhexadecimal characters and/or
+            will consist of less than 32 or more than 32 hexadecimal digits. For more
+            information about how the entity tag is calculated, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32 checksum` of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 64-bit `CRC64NVME` checksum of the
+            object. The `CRC64NVME` checksum is always a full object checksum. For
+            more information, see [Checking object integrity in the Amazon S3 User
+            Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` digest of the object. This
+            checksum is only present if the checksum was uploaded with the object.
+            When you use the API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` digest of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type, which determines how part-level checksums
+            are combined to create an object-level checksum for multipart objects.
+            You can use this header as a data integrity check to verify that the checksum
+            type that is received is the same checksum type that was specified during
+            the `CreateMultipartUpload` request. For more information, see [Checking
+            object integrity in the Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when storing this
+            object in Amazon S3.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID of the newly created object, in case the bucket
+            has versioning turned on.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the multipart upload uses an S3 Bucket Key
+            for server-side encryption with Key Management Service (KMS) keys (SSE-KMS).
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    CompleteMultipartUploadRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'Name of the bucket to which the multipart upload was initiated.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the multipart upload was initiated.
+        MultipartUpload:
+          $ref: '#/components/schemas/CompletedMultipartUpload'
+          description: The container for the multipart upload request information.
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: ID for the initiated multipart upload.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32` checksum of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 64-bit `CRC64NVME` checksum of the
+            object. The `CRC64NVME` checksum is always a full object checksum. For
+            more information, see [Checking object integrity in the Amazon S3 User
+            Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 160-bit `SHA1` digest of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 256-bit `SHA256` digest of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: This header specifies the checksum type of the object, which
+            determines how part-level checksums are combined to create an object-level
+            checksum for multipart objects. You can use this header as a data integrity
+            check to verify that the checksum type that is received is the same checksum
+            that was specified. If the checksum type doesn’t match the checksum type
+            that was specified for the object during the `CreateMultipartUpload` request,
+            it’ll result in a `BadDigest` error. For more information, see Checking
+            object integrity in the Amazon S3 User Guide.
+        MpuObjectSize:
+          $ref: '#/components/schemas/MpuObjectSize'
+          description: The expected total object size of the multipart upload request.
+            If there’s a mismatch between the specified object size value and the
+            actual object size value, it results in an `HTTP 400 InvalidRequest` error.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        IfMatch:
+          $ref: '#/components/schemas/IfMatch'
+          description: 'Uploads the object only if the ETag (entity tag) value provided
+            during the WRITE operation matches the ETag of the object in S3. If the
+            ETag values do not match, the operation returns a `412 Precondition Failed`
+            error.
+
+
+            If a conflicting operation occurs during the upload S3 returns a `409
+            ConditionalRequestConflict` response. On a 409 failure you should fetch
+            the object''s ETag, re-initiate the multipart upload with `CreateMultipartUpload`,
+            and re-upload each part.
+
+
+            Expects the ETag value as a string.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232),
+            or [Conditional requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html)
+            in the _Amazon S3 User Guide_.'
+        IfNoneMatch:
+          $ref: '#/components/schemas/IfNoneMatch'
+          description: 'Uploads the object only if the object key name does not already
+            exist in the bucket specified. Otherwise, Amazon S3 returns a `412 Precondition
+            Failed` error.
+
+
+            If a conflicting operation occurs during the upload S3 returns a `409
+            ConditionalRequestConflict` response. On a 409 failure you should re-initiate
+            the multipart upload with `CreateMultipartUpload` and re-upload each part.
+
+
+            Expects the ''*'' (asterisk) character.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232),
+            or [Conditional requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html)
+            in the _Amazon S3 User Guide_.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'The server-side encryption (SSE) algorithm used to encrypt
+            the object. This parameter is required only when the object was created
+            using a checksum algorithm or if your bucket policy requires the use of
+            SSE-C. For more information, see [Protecting data using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html#ssec-require-condition-key)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'The server-side encryption (SSE) customer managed key. This
+            parameter is needed only when the object was created using a checksum
+            algorithm. For more information, see [Protecting data using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'The MD5 server-side encryption (SSE) customer managed key.
+            This parameter is needed only when the object was created using a checksum
+            algorithm. For more information, see [Protecting data using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+      required:
+      - Bucket
+      - Key
+      - UploadId
+    CompletedMultipartUpload:
+      type: object
+      properties:
+        Parts:
+          $ref: '#/components/schemas/CompletedPartList'
+          description: 'Array of CompletedPart data types.
+
+
+            If you do not supply a valid `Part` with your request, the service sends
+            back an HTTP 400 response.'
+      description: The container for the completed multipart upload details.
+    CompletedPart:
+      type: object
+      properties:
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: Entity tag returned when the part was uploaded.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32` checksum of the part. This
+            checksum is present if the multipart upload request was created with the
+            `CRC32` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the part. This
+            checksum is present if the multipart upload request was created with the
+            `CRC32C` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the part.
+            This checksum is present if the multipart upload request was created with
+            the `CRC64NVME` checksum algorithm to the uploaded object). For more information,
+            see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` checksum of the part. This
+            checksum is present if the multipart upload request was created with the
+            `SHA1` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` checksum of the part.
+            This checksum is present if the multipart upload request was created with
+            the `SHA256` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        PartNumber:
+          $ref: '#/components/schemas/PartNumber'
+          description: "Part number that identifies the part. This is a positive integer\
+            \ between 1 and 10,000.\n\n  * **General purpose buckets** \\- In `CompleteMultipartUpload`,\
+            \ when a additional checksum (including `x-amz-checksum-crc32`, `x-amz-checksum-crc32c`,\
+            \ `x-amz-checksum-sha1`, or `x-amz-checksum-sha256`) is applied to each\
+            \ part, the `PartNumber` must start at 1 and the part numbers must be\
+            \ consecutive. Otherwise, Amazon S3 generates an HTTP `400 Bad Request`\
+            \ status code and an `InvalidPartOrder` error code.\n\n  * **Directory\
+            \ buckets** \\- In `CompleteMultipartUpload`, the `PartNumber` must start\
+            \ at 1 and the part numbers must be consecutive."
+      description: Details of the parts that were uploaded.
+    CompletedPartList:
+      type: array
+      items:
+        $ref: '#/components/schemas/CompletedPart'
+    CompressionType:
+      type: string
+      enum:
+      - NONE
+      - GZIP
+      - BZIP2
+    Condition:
+      type: object
+      properties:
+        HttpErrorCodeReturnedEquals:
+          $ref: '#/components/schemas/HttpErrorCodeReturnedEquals'
+          description: The HTTP error code when the redirect is applied. In the event
+            of an error, if the error code equals this value, then the specified redirect
+            is applied. Required when parent element `Condition` is specified and
+            sibling `KeyPrefixEquals` is not specified. If both are specified, then
+            both must be true for the redirect to be applied.
+        KeyPrefixEquals:
+          $ref: '#/components/schemas/KeyPrefixEquals'
+          description: 'The object key name prefix when the redirect is applied. For
+            example, to redirect requests for `ExamplePage.html`, the key prefix will
+            be `ExamplePage.html`. To redirect request for all pages with the prefix
+            `docs/`, the key prefix will be `/docs`, which identifies all objects
+            in the `docs/` folder. Required when the parent element `Condition` is
+            specified and sibling `HttpErrorCodeReturnedEquals` is not specified.
+            If both conditions are specified, both must be true for the redirect to
+            be applied.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+      description: A container for describing a condition that must be met for the
+        specified redirect to apply. For example, 1. If request is for pages in the
+        `/docs` folder, redirect to the `/documents` folder. 2. If request results
+        in HTTP error 4xx, redirect request to another host where you might process
+        the error.
+    ConfirmRemoveSelfBucketAccess:
+      type: boolean
+    ContentDisposition:
+      type: string
+    ContentEncoding:
+      type: string
+    ContentLanguage:
+      type: string
+    ContentLength:
+      type: integer
+      format: int64
+    ContentMD5:
+      type: string
+    ContentRange:
+      type: string
+    ContentType:
+      type: string
+    ContinuationEvent:
+      type: object
+      properties: {}
+      description: ''
+    CopyObjectOutput:
+      type: object
+      properties:
+        CopyObjectResult:
+          $ref: '#/components/schemas/CopyObjectResult'
+          description: Container for all response elements.
+        Expiration:
+          $ref: '#/components/schemas/Expiration'
+          description: 'If the object expiration is configured, the response includes
+            this header.
+
+
+            Object expiration information is not returned in directory buckets and
+            this header returns the value "`NotImplemented`" in all responses for
+            directory buckets.'
+        CopySourceVersionId:
+          $ref: '#/components/schemas/CopySourceVersionId'
+          description: 'Version ID of the source object that was copied.
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID of the newly created copy.
+
+
+            This functionality is not supported for directory buckets.'
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store this
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to confirm the
+            encryption algorithm that''s used.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to provide the
+            round-trip message integrity verification of the customer-provided encryption
+            key.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: If present, indicates the Amazon Web Services KMS Encryption
+            Context to use for object encryption. The value of this header is a Base64
+            encoded UTF-8 string holding JSON with the encryption context key-value
+            pairs.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the copied object uses an S3 Bucket Key for
+            server-side encryption with Key Management Service (KMS) keys (SSE-KMS).
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    CopyObjectRequest:
+      type: object
+      properties:
+        ACL:
+          $ref: '#/components/schemas/ObjectCannedACL'
+          description: "The canned access control list (ACL) to apply to the object.\n\
+            \nWhen you copy an object, the ACL metadata is not preserved and is set\
+            \ to `private` by default. Only the owner has full access control. To\
+            \ override the default ACL setting, specify a new ACL when you generate\
+            \ a copy request. For more information, see [Using ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).\n\
+            \nIf the destination bucket that you're copying objects to uses the bucket\
+            \ owner enforced setting for S3 Object Ownership, ACLs are disabled and\
+            \ no longer affect permissions. Buckets that use this setting only accept\
+            \ `PUT` requests that don't specify an ACL or `PUT` requests that specify\
+            \ bucket owner full control ACLs, such as the `bucket-owner-full-control`\
+            \ canned ACL or an equivalent form of this ACL expressed in the XML format.\
+            \ For more information, see [Controlling ownership of objects and disabling\
+            \ ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)\
+            \ in the _Amazon S3 User Guide_.\n\n  * If your destination bucket uses\
+            \ the bucket owner enforced setting for Object Ownership, all objects\
+            \ written to the bucket by any account will be owned by the bucket owner.\n\
+            \n  * This functionality is not supported for directory buckets.\n\n \
+            \ * This functionality is not supported for Amazon S3 on Outposts."
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the destination bucket.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Copying objects across different Amazon Web Services Regions isn''t supported
+            when the source or destination bucket is in Amazon Web Services Local
+            Zones. The source and destination buckets must have the same parent Amazon
+            Web Services Region. Otherwise, you get an HTTP `400 Bad Request` error
+            with the error code `InvalidRequest`.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must use the Outpost bucket access point ARN or the access point alias
+            for the destination bucket. You can only copy objects within the same
+            Outpost bucket. It''s not supported to copy objects across different Amazon
+            Web Services Outposts, between buckets on the same Outposts, or between
+            Outposts buckets and any other bucket types. For more information about
+            S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _S3 on Outposts guide_. When you use this action with S3 on Outposts
+            through the REST API, you must direct requests to the S3 on Outposts hostname,
+            in the format ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            The hostname isn''t required when you use the Amazon Web Services CLI
+            or SDKs.'
+        CacheControl:
+          $ref: '#/components/schemas/CacheControl'
+          description: Specifies the caching behavior along the request/reply chain.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm that you want Amazon S3 to use to
+            create the checksum for the object. For more information, see [Checking
+            object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            When you copy an object, if the source object has a checksum, that checksum
+            value will be copied to the new object by default. If the `CopyObject`
+            request does not include this `x-amz-checksum-algorithm` header, the checksum
+            algorithm will be copied from the source object to the destination object
+            (if it''s present on the source object). You can optionally specify a
+            different checksum algorithm to use with the `x-amz-checksum-algorithm`
+            header. Unrecognized or unsupported values will respond with the HTTP
+            status code `400 Bad Request`.
+
+
+            For directory buckets, when you use Amazon Web Services SDKs, `CRC32`
+            is the default checksum algorithm that''s used for performance.'
+        ContentDisposition:
+          $ref: '#/components/schemas/ContentDisposition'
+          description: Specifies presentational information for the object. Indicates
+            whether an object should be displayed in a web browser or downloaded as
+            a file. It allows specifying the desired filename for the downloaded file.
+        ContentEncoding:
+          $ref: '#/components/schemas/ContentEncoding'
+          description: 'Specifies what content encodings have been applied to the
+            object and thus what decoding mechanisms must be applied to obtain the
+            media-type referenced by the Content-Type header field.
+
+
+            For directory buckets, only the `aws-chunked` value is supported in this
+            header field.'
+        ContentLanguage:
+          $ref: '#/components/schemas/ContentLanguage'
+          description: The language the content is in.
+        ContentType:
+          $ref: '#/components/schemas/ContentType'
+          description: A standard MIME type that describes the format of the object
+            data.
+        CopySource:
+          $ref: '#/components/schemas/CopySource'
+          description: "Specifies the source object for the copy operation. The source\
+            \ object can be up to 5 GB. If the source object is an object that was\
+            \ uploaded by using a multipart upload, the object copy will be a single\
+            \ part object after the source object is copied to the destination bucket.\n\
+            \nYou specify the value of the copy source in one of two formats, depending\
+            \ on whether you want to access the source object through an [access point](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html):\n\
+            \n  * For objects not accessed through an access point, specify the name\
+            \ of the source bucket and the key of the source object, separated by\
+            \ a slash (/). For example, to copy the object `reports/january.pdf` from\
+            \ the general purpose bucket `awsexamplebucket`, use `awsexamplebucket/reports/january.pdf`.\
+            \ The value must be URL-encoded. To copy the object `reports/january.pdf`\
+            \ from the directory bucket `awsexamplebucket--use1-az5--x-s3`, use `awsexamplebucket--use1-az5--x-s3/reports/january.pdf`.\
+            \ The value must be URL-encoded.\n\n  * For objects accessed through access\
+            \ points, specify the Amazon Resource Name (ARN) of the object as accessed\
+            \ through the access point, in the format `arn:aws:s3:::accesspoint//object/`.\
+            \ For example, to copy the object `reports/january.pdf` through access\
+            \ point `my-access-point` owned by account `123456789012` in Region `us-west-2`,\
+            \ use the URL encoding of `arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf`.\
+            \ The value must be URL encoded.\n\n    * Amazon S3 supports copy operations\
+            \ using Access points only when the source and destination buckets are\
+            \ in the same Amazon Web Services Region.\n\n    * Access points are not\
+            \ supported by directory buckets.\n\nAlternatively, for objects accessed\
+            \ through Amazon S3 on Outposts, specify the ARN of the object as accessed\
+            \ in the format `arn:aws:s3-outposts:::outpost//object/`. For example,\
+            \ to copy the object `reports/january.pdf` through outpost `my-outpost`\
+            \ owned by account `123456789012` in Region `us-west-2`, use the URL encoding\
+            \ of `arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf`.\
+            \ The value must be URL-encoded.\n\nIf your source bucket versioning is\
+            \ enabled, the `x-amz-copy-source` header by default identifies the current\
+            \ version of an object to copy. If the current version is a delete marker,\
+            \ Amazon S3 behaves as if the object was deleted. To copy a different\
+            \ version, use the `versionId` query parameter. Specifically, append `?versionId=`\
+            \ to the value (for example, `awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893`).\
+            \ If you don't specify a version ID, Amazon S3 copies the latest version\
+            \ of the source object.\n\nIf you enable versioning on the destination\
+            \ bucket, Amazon S3 generates a unique version ID for the copied object.\
+            \ This version ID is different from the version ID of the source object.\
+            \ Amazon S3 returns the version ID of the copied object in the `x-amz-version-id`\
+            \ response header in the response.\n\nIf you do not enable versioning\
+            \ or suspend it on the destination bucket, the version ID that Amazon\
+            \ S3 generates in the `x-amz-version-id` response header is always null.\n\
+            \n**Directory buckets** \\- S3 Versioning isn't enabled and supported\
+            \ for directory buckets."
+        CopySourceIfMatch:
+          $ref: '#/components/schemas/CopySourceIfMatch'
+          description: "Copies the object if its entity tag (ETag) matches the specified\
+            \ tag.\n\nIf both the `x-amz-copy-source-if-match` and `x-amz-copy-source-if-unmodified-since`\
+            \ headers are present in the request and evaluate as follows, Amazon S3\
+            \ returns `200 OK` and copies the data:\n\n  * `x-amz-copy-source-if-match`\
+            \ condition evaluates to true\n\n  * `x-amz-copy-source-if-unmodified-since`\
+            \ condition evaluates to false"
+        CopySourceIfModifiedSince:
+          $ref: '#/components/schemas/CopySourceIfModifiedSince'
+          description: "Copies the object if it has been modified since the specified\
+            \ time.\n\nIf both the `x-amz-copy-source-if-none-match` and `x-amz-copy-source-if-modified-since`\
+            \ headers are present in the request and evaluate as follows, Amazon S3\
+            \ returns the `412 Precondition Failed` response code:\n\n  * `x-amz-copy-source-if-none-match`\
+            \ condition evaluates to false\n\n  * `x-amz-copy-source-if-modified-since`\
+            \ condition evaluates to true"
+        CopySourceIfNoneMatch:
+          $ref: '#/components/schemas/CopySourceIfNoneMatch'
+          description: "Copies the object if its entity tag (ETag) is different than\
+            \ the specified ETag.\n\nIf both the `x-amz-copy-source-if-none-match`\
+            \ and `x-amz-copy-source-if-modified-since` headers are present in the\
+            \ request and evaluate as follows, Amazon S3 returns the `412 Precondition\
+            \ Failed` response code:\n\n  * `x-amz-copy-source-if-none-match` condition\
+            \ evaluates to false\n\n  * `x-amz-copy-source-if-modified-since` condition\
+            \ evaluates to true"
+        CopySourceIfUnmodifiedSince:
+          $ref: '#/components/schemas/CopySourceIfUnmodifiedSince'
+          description: "Copies the object if it hasn't been modified since the specified\
+            \ time.\n\nIf both the `x-amz-copy-source-if-match` and `x-amz-copy-source-if-unmodified-since`\
+            \ headers are present in the request and evaluate as follows, Amazon S3\
+            \ returns `200 OK` and copies the data:\n\n  * `x-amz-copy-source-if-match`\
+            \ condition evaluates to true\n\n  * `x-amz-copy-source-if-unmodified-since`\
+            \ condition evaluates to false"
+        Expires:
+          $ref: '#/components/schemas/Expires'
+          description: The date and time at which the object is no longer cacheable.
+        GrantFullControl:
+          $ref: '#/components/schemas/GrantFullControl'
+          description: "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions\
+            \ on the object.\n\n  * This functionality is not supported for directory\
+            \ buckets.\n\n  * This functionality is not supported for Amazon S3 on\
+            \ Outposts."
+        GrantRead:
+          $ref: '#/components/schemas/GrantRead'
+          description: "Allows grantee to read the object data and its metadata.\n\
+            \n  * This functionality is not supported for directory buckets.\n\n \
+            \ * This functionality is not supported for Amazon S3 on Outposts."
+        GrantReadACP:
+          $ref: '#/components/schemas/GrantReadACP'
+          description: "Allows grantee to read the object ACL.\n\n  * This functionality\
+            \ is not supported for directory buckets.\n\n  * This functionality is\
+            \ not supported for Amazon S3 on Outposts."
+        GrantWriteACP:
+          $ref: '#/components/schemas/GrantWriteACP'
+          description: "Allows grantee to write the ACL for the applicable object.\n\
+            \n  * This functionality is not supported for directory buckets.\n\n \
+            \ * This functionality is not supported for Amazon S3 on Outposts."
+        IfMatch:
+          $ref: '#/components/schemas/IfMatch'
+          description: 'Copies the object if the entity tag (ETag) of the destination
+            object matches the specified tag. If the ETag values do not match, the
+            operation returns a `412 Precondition Failed` error. If a concurrent operation
+            occurs during the upload S3 returns a `409 ConditionalRequestConflict`
+            response. On a 409 failure you should fetch the object''s ETag and retry
+            the upload.
+
+
+            Expects the ETag value as a string.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232).'
+        IfNoneMatch:
+          $ref: '#/components/schemas/IfNoneMatch'
+          description: 'Copies the object only if the object key name at the destination
+            does not already exist in the bucket specified. Otherwise, Amazon S3 returns
+            a `412 Precondition Failed` error. If a concurrent operation occurs during
+            the upload S3 returns a `409 ConditionalRequestConflict` response. On
+            a 409 failure you should retry the upload.
+
+
+            Expects the ''*'' (asterisk) character.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232).'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The key of the destination object.
+        Metadata:
+          $ref: '#/components/schemas/Metadata'
+          description: A map of metadata to store with the object in S3.
+        MetadataDirective:
+          $ref: '#/components/schemas/MetadataDirective'
+          description: 'Specifies whether the metadata is copied from the source object
+            or replaced with metadata that''s provided in the request. When copying
+            an object, you can preserve all metadata (the default) or specify new
+            metadata. If this header isn’t specified, `COPY` is the default behavior.
+
+
+            **General purpose bucket** \- For general purpose buckets, when you grant
+            permissions, you can use the `s3:x-amz-metadata-directive` condition key
+            to enforce certain metadata behavior when objects are uploaded. For more
+            information, see [Amazon S3 condition key examples](https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html)
+            in the _Amazon S3 User Guide_.
+
+
+            `x-amz-website-redirect-location` is unique to each object and is not
+            copied when using the `x-amz-metadata-directive` header. To copy the value,
+            you must specify `x-amz-website-redirect-location` in the request header.'
+        TaggingDirective:
+          $ref: '#/components/schemas/TaggingDirective'
+          description: "Specifies whether the object tag-set is copied from the source\
+            \ object or replaced with the tag-set that's provided in the request.\n\
+            \nThe default value is `COPY`.\n\n**Directory buckets** \\- For directory\
+            \ buckets in a `CopyObject` operation, only the empty tag-set is supported.\
+            \ Any requests that attempt to write non-empty tags into directory buckets\
+            \ will receive a `501 Not Implemented` status code. When the destination\
+            \ bucket is a directory bucket, you will receive a `501 Not Implemented`\
+            \ response in any of the following situations:\n\n  * When you attempt\
+            \ to `COPY` the tag-set from an S3 source object that has non-empty tags.\n\
+            \n  * When you attempt to `REPLACE` the tag-set of a source object and\
+            \ set a non-empty value to `x-amz-tagging`.\n\n  * When you don't set\
+            \ the `x-amz-tagging-directive` header and the source object has non-empty\
+            \ tags. This is because the default value of `x-amz-tagging-directive`\
+            \ is `COPY`.\n\nBecause only the empty tag-set is supported for directory\
+            \ buckets in a `CopyObject` operation, the following situations are allowed:\n\
+            \n  * When you attempt to `COPY` the tag-set from a directory bucket source\
+            \ object that has no tags to a general purpose bucket. It copies an empty\
+            \ tag-set to the destination object.\n\n  * When you attempt to `REPLACE`\
+            \ the tag-set of a directory bucket source object and set the `x-amz-tagging`\
+            \ value of the directory bucket destination object to empty.\n\n  * When\
+            \ you attempt to `REPLACE` the tag-set of a general purpose bucket source\
+            \ object that has non-empty tags and set the `x-amz-tagging` value of\
+            \ the directory bucket destination object to empty.\n\n  * When you attempt\
+            \ to `REPLACE` the tag-set of a directory bucket source object and don't\
+            \ set the `x-amz-tagging` value of the directory bucket destination object.\
+            \ This is because the default value of `x-amz-tagging` is the empty value."
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: "The server-side encryption algorithm used when storing this\
+            \ object in Amazon S3. Unrecognized or unsupported values won’t write\
+            \ a destination object and will receive a `400 Bad Request` response.\n\
+            \nAmazon S3 automatically encrypts all new objects that are copied to\
+            \ an S3 bucket. When copying an object, if you don't specify encryption\
+            \ information in your copy request, the encryption setting of the target\
+            \ object is set to the default encryption configuration of the destination\
+            \ bucket. By default, all buckets have a base level of encryption configuration\
+            \ that uses server-side encryption with Amazon S3 managed keys (SSE-S3).\
+            \ If the destination bucket has a different default encryption configuration,\
+            \ Amazon S3 uses the corresponding encryption key to encrypt the target\
+            \ object copy.\n\nWith server-side encryption, Amazon S3 encrypts your\
+            \ data as it writes your data to disks in its data centers and decrypts\
+            \ the data when you access it. For more information about server-side\
+            \ encryption, see [Using Server-Side Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)\
+            \ in the _Amazon S3 User Guide_.\n\n**General purpose buckets**\n\n  *\
+            \ For general purpose buckets, there are the following supported options\
+            \ for server-side encryption: server-side encryption with Key Management\
+            \ Service (KMS) keys (SSE-KMS), dual-layer server-side encryption with\
+            \ Amazon Web Services KMS keys (DSSE-KMS), and server-side encryption\
+            \ with customer-provided encryption keys (SSE-C). Amazon S3 uses the corresponding\
+            \ KMS key, or a customer-provided key to encrypt the target object copy.\n\
+            \n  * When you perform a `CopyObject` operation, if you want to use a\
+            \ different type of encryption setting for the target object, you can\
+            \ specify appropriate encryption-related headers to encrypt the target\
+            \ object with an Amazon S3 managed key, a KMS key, or a customer-provided\
+            \ key. If the encryption setting in your request is different from the\
+            \ default encryption configuration of the destination bucket, the encryption\
+            \ setting in your request takes precedence. \n\n**Directory buckets**\n\
+            \n  * For directory buckets, there are only two supported options for\
+            \ server-side encryption: server-side encryption with Amazon S3 managed\
+            \ keys (SSE-S3) (`AES256`) and server-side encryption with KMS keys (SSE-KMS)\
+            \ (`aws:kms`). We recommend that the bucket's default encryption uses\
+            \ the desired encryption configuration and you don't override the bucket\
+            \ default encryption in your `CreateSession` requests or `PUT` object\
+            \ requests. Then, new objects are automatically encrypted with the desired\
+            \ encryption settings. For more information, see [Protecting data with\
+            \ server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-serv-side-encryption.html)\
+            \ in the _Amazon S3 User Guide_. For more information about the encryption\
+            \ overriding behaviors in directory buckets, see [Specifying server-side\
+            \ encryption with KMS for new object uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-specifying-kms-encryption.html).\n\
+            \n  * To encrypt new object copies to a directory bucket with SSE-KMS,\
+            \ we recommend you specify SSE-KMS as the directory bucket's default encryption\
+            \ configuration with a KMS key (specifically, a [customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)).\
+            \ The [Amazon Web Services managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)\
+            \ (`aws/s3`) isn't supported. Your SSE-KMS configuration can only support\
+            \ 1 [customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)\
+            \ per directory bucket for the lifetime of the bucket. After you specify\
+            \ a customer managed key for SSE-KMS, you can't override the customer\
+            \ managed key for the bucket's SSE-KMS configuration. Then, when you perform\
+            \ a `CopyObject` operation and want to specify server-side encryption\
+            \ settings for new object copies with SSE-KMS in the encryption-related\
+            \ request headers, you must ensure the encryption key is the same customer\
+            \ managed key that you specified for the directory bucket's default encryption\
+            \ configuration. \n\n  * **S3 access points for Amazon FSx** \\- When\
+            \ accessing data stored in Amazon FSx file systems using S3 access points,\
+            \ the only valid server side encryption option is `aws:fsx`. All Amazon\
+            \ FSx file systems have encryption configured by default and are encrypted\
+            \ at rest. Data is automatically encrypted before being written to the\
+            \ file system, and automatically decrypted as it is read. These processes\
+            \ are handled transparently by Amazon FSx."
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: "If the `x-amz-storage-class` header is not used, the copied\
+            \ object will be stored in the `STANDARD` Storage Class by default. The\
+            \ `STANDARD` storage class provides high durability and high availability.\
+            \ Depending on performance needs, you can specify a different Storage\
+            \ Class.\n\n  * **Directory buckets** \\- Directory buckets only support\
+            \ `EXPRESS_ONEZONE` (the S3 Express One Zone storage class) in Availability\
+            \ Zones and `ONEZONE_IA` (the S3 One Zone-Infrequent Access storage class)\
+            \ in Dedicated Local Zones. Unsupported storage class values won't write\
+            \ a destination object and will respond with the HTTP status code `400\
+            \ Bad Request`.\n\n  * **Amazon S3 on Outposts** \\- S3 on Outposts only\
+            \ uses the `OUTPOSTS` Storage Class.\n\nYou can use the `CopyObject` action\
+            \ to change the storage class of an object that is already stored in Amazon\
+            \ S3 by using the `x-amz-storage-class` header. For more information,\
+            \ see [Storage Classes](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)\
+            \ in the _Amazon S3 User Guide_.\n\nBefore using an object as a source\
+            \ object for the copy operation, you must restore a copy of it if it meets\
+            \ any of the following conditions:\n\n  * The storage class of the source\
+            \ object is `GLACIER` or `DEEP_ARCHIVE`.\n\n  * The storage class of the\
+            \ source object is `INTELLIGENT_TIERING` and it's [S3 Intelligent-Tiering\
+            \ access tier](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html#intel-tiering-tier-definition)\
+            \ is `Archive Access` or `Deep Archive Access`.\n\nFor more information,\
+            \ see [RestoreObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html)\
+            \ and [Copying Objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html)\
+            \ in the _Amazon S3 User Guide_."
+        WebsiteRedirectLocation:
+          $ref: '#/components/schemas/WebsiteRedirectLocation'
+          description: 'If the destination bucket is configured as a website, redirects
+            requests for this object copy to another object in the same bucket or
+            to an external URL. Amazon S3 stores the value of this header in the object
+            metadata. This value is unique to each object and is not copied when using
+            the `x-amz-metadata-directive` header. Instead, you may opt to provide
+            this header in combination with the `x-amz-metadata-directive` header.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when encrypting the object
+            (for example, `AES256`).
+
+
+            When you perform a `CopyObject` operation, if you want to use a different
+            type of encryption setting for the target object, you can specify appropriate
+            encryption-related headers to encrypt the target object with an Amazon
+            S3 managed key, a KMS key, or a customer-provided key. If the encryption
+            setting in your request is different from the default encryption configuration
+            of the destination bucket, the encryption setting in your request takes
+            precedence.
+
+
+            This functionality is not supported when the destination bucket is a directory
+            bucket.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use in encrypting data. This value is used to store the object and
+            then it is discarded. Amazon S3 does not store the encryption key. The
+            key must be appropriate for use with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm`
+            header.
+
+
+            This functionality is not supported when the destination bucket is a directory
+            bucket.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            This functionality is not supported when the destination bucket is a directory
+            bucket.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: 'Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to
+            use for object encryption. All GET and PUT requests for an object protected
+            by KMS will fail if they''re not made via SSL or using SigV4. For information
+            about configuring any of the officially supported Amazon Web Services
+            SDKs and Amazon Web Services CLI, see [Specifying the Signature Version
+            in Request Authentication](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version)
+            in the _Amazon S3 User Guide_.
+
+
+            **Directory buckets** \- To encrypt data using SSE-KMS, it''s recommended
+            to specify the `x-amz-server-side-encryption` header to `aws:kms`. Then,
+            the `x-amz-server-side-encryption-aws-kms-key-id` header implicitly uses
+            the bucket''s default KMS customer managed key ID. If you want to explicitly
+            set the ` x-amz-server-side-encryption-aws-kms-key-id` header, it must
+            match the bucket''s default customer managed key (using key ID or ARN,
+            not alias). Your SSE-KMS configuration can only support 1 [customer managed
+            key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+            per directory bucket''s lifetime. The [Amazon Web Services managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)
+            (`aws/s3`) isn''t supported. Incorrect key specification results in an
+            HTTP `400 Bad Request` error.'
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: 'Specifies the Amazon Web Services KMS Encryption Context as
+            an additional encryption context to use for the destination object encryption.
+            The value of this header is a base64-encoded UTF-8 string holding JSON
+            with the encryption context key-value pairs.
+
+
+            **General purpose buckets** \- This value must be explicitly added to
+            specify encryption context for `CopyObject` requests if you want an additional
+            encryption context for your destination object. The additional encryption
+            context of the source object won''t be copied to the destination object.
+            For more information, see [Encryption context](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context)
+            in the _Amazon S3 User Guide_.
+
+
+            **Directory buckets** \- You can optionally provide an explicit encryption
+            context value. The value must match the default encryption context - the
+            bucket Amazon Resource Name (ARN). An additional encryption context value
+            is not supported.'
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: 'Specifies whether Amazon S3 should use an S3 Bucket Key for
+            object encryption with server-side encryption using Key Management Service
+            (KMS) keys (SSE-KMS). If a target object uses SSE-KMS, you can enable
+            an S3 Bucket Key for the object.
+
+
+            Setting this header to `true` causes Amazon S3 to use an S3 Bucket Key
+            for object encryption with SSE-KMS. Specifying this header with a COPY
+            action doesn’t affect bucket-level settings for S3 Bucket Key.
+
+
+            For more information, see [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Directory buckets** \- S3 Bucket Keys aren''t supported, when you copy
+            SSE-KMS encrypted objects from general purpose buckets to directory buckets,
+            from directory buckets to general purpose buckets, or between directory
+            buckets, through [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html).
+            In this case, Amazon S3 makes a call to KMS every time a copy request
+            is made for a KMS-encrypted object.'
+        CopySourceSSECustomerAlgorithm:
+          $ref: '#/components/schemas/CopySourceSSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when decrypting the source
+            object (for example, `AES256`).
+
+
+            If the source object for the copy is stored in Amazon S3 using SSE-C,
+            you must provide the necessary encryption information in your request
+            so that Amazon S3 can decrypt the object for copying.
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        CopySourceSSECustomerKey:
+          $ref: '#/components/schemas/CopySourceSSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use to decrypt the source object. The encryption key provided in
+            this header must be the same one that was used when the source object
+            was created.
+
+
+            If the source object for the copy is stored in Amazon S3 using SSE-C,
+            you must provide the necessary encryption information in your request
+            so that Amazon S3 can decrypt the object for copying.
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        CopySourceSSECustomerKeyMD5:
+          $ref: '#/components/schemas/CopySourceSSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            If the source object for the copy is stored in Amazon S3 using SSE-C,
+            you must provide the necessary encryption information in your request
+            so that Amazon S3 can decrypt the object for copying.
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        Tagging:
+          $ref: '#/components/schemas/TaggingHeader'
+          description: "The tag-set for the object copy in the destination bucket.\
+            \ This value must be used in conjunction with the `x-amz-tagging-directive`\
+            \ if you choose `REPLACE` for the `x-amz-tagging-directive`. If you choose\
+            \ `COPY` for the `x-amz-tagging-directive`, you don't need to set the\
+            \ `x-amz-tagging` header, because the tag-set will be copied from the\
+            \ source object directly. The tag-set must be encoded as URL Query parameters.\n\
+            \nThe default value is the empty value.\n\n**Directory buckets** \\- For\
+            \ directory buckets in a `CopyObject` operation, only the empty tag-set\
+            \ is supported. Any requests that attempt to write non-empty tags into\
+            \ directory buckets will receive a `501 Not Implemented` status code.\
+            \ When the destination bucket is a directory bucket, you will receive\
+            \ a `501 Not Implemented` response in any of the following situations:\n\
+            \n  * When you attempt to `COPY` the tag-set from an S3 source object\
+            \ that has non-empty tags.\n\n  * When you attempt to `REPLACE` the tag-set\
+            \ of a source object and set a non-empty value to `x-amz-tagging`.\n\n\
+            \  * When you don't set the `x-amz-tagging-directive` header and the source\
+            \ object has non-empty tags. This is because the default value of `x-amz-tagging-directive`\
+            \ is `COPY`.\n\nBecause only the empty tag-set is supported for directory\
+            \ buckets in a `CopyObject` operation, the following situations are allowed:\n\
+            \n  * When you attempt to `COPY` the tag-set from a directory bucket source\
+            \ object that has no tags to a general purpose bucket. It copies an empty\
+            \ tag-set to the destination object.\n\n  * When you attempt to `REPLACE`\
+            \ the tag-set of a directory bucket source object and set the `x-amz-tagging`\
+            \ value of the directory bucket destination object to empty.\n\n  * When\
+            \ you attempt to `REPLACE` the tag-set of a general purpose bucket source\
+            \ object that has non-empty tags and set the `x-amz-tagging` value of\
+            \ the directory bucket destination object to empty.\n\n  * When you attempt\
+            \ to `REPLACE` the tag-set of a directory bucket source object and don't\
+            \ set the `x-amz-tagging` value of the directory bucket destination object.\
+            \ This is because the default value of `x-amz-tagging` is the empty value."
+        ObjectLockMode:
+          $ref: '#/components/schemas/ObjectLockMode'
+          description: 'The Object Lock mode that you want to apply to the object
+            copy.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockRetainUntilDate:
+          $ref: '#/components/schemas/ObjectLockRetainUntilDate'
+          description: 'The date and time when you want the Object Lock of the object
+            copy to expire.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockLegalHoldStatus:
+          $ref: '#/components/schemas/ObjectLockLegalHoldStatus'
+          description: 'Specifies whether you want to apply a legal hold to the object
+            copy.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected destination bucket owner. If
+            the account ID that you provide does not match the actual owner of the
+            destination bucket, the request fails with the HTTP status code `403 Forbidden`
+            (access denied).
+        ExpectedSourceBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected source bucket owner. If the
+            account ID that you provide does not match the actual owner of the source
+            bucket, the request fails with the HTTP status code `403 Forbidden` (access
+            denied).
+      required:
+      - Bucket
+      - CopySource
+      - Key
+    CopyObjectResult:
+      type: object
+      properties:
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: Returns the ETag of the new object. The ETag reflects only
+            changes to the contents of an object, not its metadata.
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Creation date of the object.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type that is used to calculate the object’s checksum
+            value. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32` checksum of the object.
+            This checksum is only present if the object was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the object.
+            This checksum is present if the object being copied was uploaded with
+            the `CRC64NVME` checksum algorithm, or if the object was uploaded without
+            a checksum (and Amazon S3 added the default checksum, `CRC64NVME`, to
+            the uploaded object). For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` digest of the object. This
+            checksum is only present if the checksum was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` digest of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+      description: Container for all response elements.
+    CopyPartResult:
+      type: object
+      properties:
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: Entity tag of the object.
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Date and time at which the object was uploaded.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32` checksum of the part.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32C` checksum of the part.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the part.
+            This checksum is present if the multipart upload request was created with
+            the `CRC64NVME` checksum algorithm to the uploaded object). For more information,
+            see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 160-bit `SHA1` checksum of the part.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 256-bit `SHA256` checksum of the
+            part. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+      description: Container for all response elements.
+    CopySource:
+      type: string
+      pattern: ^\/?.+\/.+$
+    CopySourceIfMatch:
+      type: string
+    CopySourceIfModifiedSince:
+      type: string
+      format: date-time
+    CopySourceIfNoneMatch:
+      type: string
+    CopySourceIfUnmodifiedSince:
+      type: string
+      format: date-time
+    CopySourceRange:
+      type: string
+    CopySourceSSECustomerAlgorithm:
+      type: string
+    CopySourceSSECustomerKey:
+      type: string
+    CopySourceSSECustomerKeyMD5:
+      type: string
+    CopySourceVersionId:
+      type: string
+    CreateBucketConfiguration:
+      type: object
+      properties:
+        LocationConstraint:
+          $ref: '#/components/schemas/BucketLocationConstraint'
+          description: 'Specifies the Region where the bucket will be created. You
+            might choose a Region to optimize latency, minimize costs, or address
+            regulatory requirements. For example, if you reside in Europe, you will
+            probably find it advantageous to create buckets in the Europe (Ireland)
+            Region.
+
+
+            If you don''t specify a Region, the bucket is created in the US East (N.
+            Virginia) Region (us-east-1) by default. Configurations using the value
+            `EU` will create a bucket in `eu-west-1`.
+
+
+            For a list of the valid values for all of the Amazon Web Services Regions,
+            see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+
+
+            This functionality is not supported for directory buckets.'
+        Location:
+          $ref: '#/components/schemas/LocationInfo'
+          description: 'Specifies the location where the bucket will be created.
+
+
+            **Directory buckets** \- The location type is Availability Zone or Local
+            Zone. To use the Local Zone location type, your account must be enabled
+            for Local Zones. Otherwise, you get an HTTP `403 Forbidden` error with
+            the error code `AccessDenied`. To learn more, see [Enable accounts for
+            Local Zones](https://docs.aws.amazon.com/AmazonS3/latest/userguide/opt-in-directory-bucket-lz.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is only supported by directory buckets.'
+        Bucket:
+          $ref: '#/components/schemas/BucketInfo'
+          description: 'Specifies the information about the bucket that will be created.
+
+
+            This functionality is only supported by directory buckets.'
+        Tags:
+          $ref: '#/components/schemas/TagSet'
+          description: 'An array of tags that you can apply to the bucket that you''re
+            creating. Tags are key-value pairs of metadata used to categorize and
+            organize your buckets, track costs, and control access.
+
+
+            You must have the `s3:TagResource` permission to create a general purpose
+            bucket with tags or the `s3express:TagResource` permission to create a
+            directory bucket with tags.
+
+
+            When creating buckets with tags, note that tag-based conditions using
+            `aws:ResourceTag` and `s3:BucketTag` condition keys are applicable only
+            after ABAC is enabled on the bucket. To learn more, see [Enabling ABAC
+            in general purpose buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html).'
+      description: The configuration information for the bucket.
+    CreateBucketMetadataConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that you want to create the metadata
+            configuration for.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: The `Content-MD5` header for the metadata configuration.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: The checksum algorithm to use with your metadata configuration.
+        MetadataConfiguration:
+          $ref: '#/components/schemas/MetadataConfiguration'
+          description: The contents of your metadata configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected owner of the general purpose bucket that corresponds
+            to your metadata configuration.
+      required:
+      - Bucket
+      - MetadataConfiguration
+    CreateBucketMetadataTableConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that you want to create the metadata
+            table configuration for.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: The `Content-MD5` header for the metadata table configuration.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: The checksum algorithm to use with your metadata table configuration.
+        MetadataTableConfiguration:
+          $ref: '#/components/schemas/MetadataTableConfiguration'
+          description: The contents of your metadata table configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected owner of the general purpose bucket that corresponds
+            to your metadata table configuration.
+      required:
+      - Bucket
+      - MetadataTableConfiguration
+    CreateBucketOutput:
+      type: object
+      properties:
+        Location:
+          $ref: '#/components/schemas/Location'
+          description: A forward slash followed by the name of the bucket.
+        BucketArn:
+          $ref: '#/components/schemas/S3RegionalOrS3ExpressBucketArnString'
+          description: 'The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely
+            identify Amazon Web Services resources across all of Amazon Web Services.
+
+
+            This parameter is only supported for S3 directory buckets. For more information,
+            see [Using tags with directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html).'
+    CreateBucketRequest:
+      type: object
+      properties:
+        ACL:
+          $ref: '#/components/schemas/BucketCannedACL'
+          description: 'The canned ACL to apply to the bucket.
+
+
+            This functionality is not supported for directory buckets.'
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket to create.
+
+
+            **General purpose buckets** \- For information about bucket naming restrictions,
+            see [Bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_'
+        CreateBucketConfiguration:
+          $ref: '#/components/schemas/CreateBucketConfiguration'
+          description: The configuration information for the bucket.
+        GrantFullControl:
+          $ref: '#/components/schemas/GrantFullControl'
+          description: 'Allows grantee the read, write, read ACP, and write ACP permissions
+            on the bucket.
+
+
+            This functionality is not supported for directory buckets.'
+        GrantRead:
+          $ref: '#/components/schemas/GrantRead'
+          description: 'Allows grantee to list the objects in the bucket.
+
+
+            This functionality is not supported for directory buckets.'
+        GrantReadACP:
+          $ref: '#/components/schemas/GrantReadACP'
+          description: 'Allows grantee to read the bucket ACL.
+
+
+            This functionality is not supported for directory buckets.'
+        GrantWrite:
+          $ref: '#/components/schemas/GrantWrite'
+          description: 'Allows grantee to create new objects in the bucket.
+
+
+            For the bucket and object owners of existing objects, also allows deletions
+            and overwrites of those objects.
+
+
+            This functionality is not supported for directory buckets.'
+        GrantWriteACP:
+          $ref: '#/components/schemas/GrantWriteACP'
+          description: 'Allows grantee to write the ACL for the applicable bucket.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockEnabledForBucket:
+          $ref: '#/components/schemas/ObjectLockEnabledForBucket'
+          description: 'Specifies whether you want S3 Object Lock to be enabled for
+            the new bucket.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectOwnership:
+          $ref: '#/components/schemas/ObjectOwnership'
+      required:
+      - Bucket
+    CreateMultipartUploadOutput:
+      type: object
+      properties:
+        AbortDate:
+          $ref: '#/components/schemas/AbortDate'
+          description: 'If the bucket has a lifecycle rule configured with an action
+            to abort incomplete multipart uploads and the prefix in the lifecycle
+            rule matches the object name in the request, the response includes this
+            header. The header indicates when the initiated multipart upload becomes
+            eligible for an abort operation. For more information, see [ Aborting
+            Incomplete Multipart Uploads Using a Bucket Lifecycle Configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config)
+            in the _Amazon S3 User Guide_.
+
+
+            The response also includes the `x-amz-abort-rule-id` header that provides
+            the ID of the lifecycle configuration rule that defines the abort action.
+
+
+            This functionality is not supported for directory buckets.'
+        AbortRuleId:
+          $ref: '#/components/schemas/AbortRuleId'
+          description: 'This header is returned along with the `x-amz-abort-date`
+            header. It identifies the applicable lifecycle configuration rule that
+            defines the action to abort incomplete multipart uploads.
+
+
+            This functionality is not supported for directory buckets.'
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket to which the multipart upload was initiated.
+            Does not return the access point ARN or access point alias if used.
+
+
+            Access points are not supported by directory buckets.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the multipart upload was initiated.
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: ID for the initiated multipart upload.
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store this
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to confirm the
+            encryption algorithm that''s used.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to provide the
+            round-trip message integrity verification of the customer-provided encryption
+            key.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: If present, indicates the Amazon Web Services KMS Encryption
+            Context to use for object encryption. The value of this header is a Base64
+            encoded string of a UTF-8 encoded JSON, which contains the encryption
+            context as key-value pairs.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the multipart upload uses an S3 Bucket Key
+            for server-side encryption with Key Management Service (KMS) keys (SSE-KMS).
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: The algorithm that was used to create a checksum of the object.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: Indicates the checksum type that you want Amazon S3 to use
+            to calculate the object’s checksum value. For more information, see [Checking
+            object integrity in the Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+    CreateMultipartUploadRequest:
+      type: object
+      properties:
+        ACL:
+          $ref: '#/components/schemas/ObjectCannedACL'
+          description: "The canned ACL to apply to the object. Amazon S3 supports\
+            \ a set of predefined ACLs, known as _canned ACLs_. Each canned ACL has\
+            \ a predefined set of grantees and permissions. For more information,\
+            \ see [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL)\
+            \ in the _Amazon S3 User Guide_.\n\nBy default, all objects are private.\
+            \ Only the owner has full access control. When uploading an object, you\
+            \ can grant access permissions to individual Amazon Web Services accounts\
+            \ or to predefined groups defined by Amazon S3. These permissions are\
+            \ then added to the access control list (ACL) on the new object. For more\
+            \ information, see [Using ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).\
+            \ One way to grant the permissions using the request headers is to specify\
+            \ a canned ACL with the `x-amz-acl` request header.\n\n  * This functionality\
+            \ is not supported for directory buckets.\n\n  * This functionality is\
+            \ not supported for Amazon S3 on Outposts."
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket where the multipart upload is initiated
+            and where the object is uploaded.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        CacheControl:
+          $ref: '#/components/schemas/CacheControl'
+          description: Specifies caching behavior along the request/reply chain.
+        ContentDisposition:
+          $ref: '#/components/schemas/ContentDisposition'
+          description: Specifies presentational information for the object.
+        ContentEncoding:
+          $ref: '#/components/schemas/ContentEncoding'
+          description: 'Specifies what content encodings have been applied to the
+            object and thus what decoding mechanisms must be applied to obtain the
+            media-type referenced by the Content-Type header field.
+
+
+            For directory buckets, only the `aws-chunked` value is supported in this
+            header field.'
+        ContentLanguage:
+          $ref: '#/components/schemas/ContentLanguage'
+          description: The language that the content is in.
+        ContentType:
+          $ref: '#/components/schemas/ContentType'
+          description: A standard MIME type describing the format of the object data.
+        Expires:
+          $ref: '#/components/schemas/Expires'
+          description: The date and time at which the object is no longer cacheable.
+        GrantFullControl:
+          $ref: '#/components/schemas/GrantFullControl'
+          description: "Specify access permissions explicitly to give the grantee\
+            \ READ, READ_ACP, and WRITE_ACP permissions on the object.\n\nBy default,\
+            \ all objects are private. Only the owner has full access control. When\
+            \ uploading an object, you can use this header to explicitly grant access\
+            \ permissions to specific Amazon Web Services accounts or groups. This\
+            \ header maps to specific permissions that Amazon S3 supports in an ACL.\
+            \ For more information, see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)\
+            \ in the _Amazon S3 User Guide_.\n\nYou specify each grantee as a type=value\
+            \ pair, where the type is one of the following:\n\n  * `id` – if the value\
+            \ specified is the canonical user ID of an Amazon Web Services account\n\
+            \n  * `uri` – if you are granting permissions to a predefined group\n\n\
+            \  * `emailAddress` – if the value specified is the email address of an\
+            \ Amazon Web Services account\n\nUsing email addresses to specify a grantee\
+            \ is only supported in the following Amazon Web Services Regions:\n\n\
+            \    * US East (N. Virginia)\n\n    * US West (N. California)\n\n    *\
+            \ US West (Oregon)\n\n    * Asia Pacific (Singapore)\n\n    * Asia Pacific\
+            \ (Sydney)\n\n    * Asia Pacific (Tokyo)\n\n    * Europe (Ireland)\n\n\
+            \    * South America (São Paulo)\n\nFor a list of all the Amazon S3 supported\
+            \ Regions and endpoints, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)\
+            \ in the Amazon Web Services General Reference.\n\nFor example, the following\
+            \ `x-amz-grant-read` header grants the Amazon Web Services accounts identified\
+            \ by account IDs permissions to read object data and its metadata:\n\n\
+            `x-amz-grant-read: id=\"11112222333\", id=\"444455556666\" `\n\n  * This\
+            \ functionality is not supported for directory buckets.\n\n  * This functionality\
+            \ is not supported for Amazon S3 on Outposts."
+        GrantRead:
+          $ref: '#/components/schemas/GrantRead'
+          description: "Specify access permissions explicitly to allow grantee to\
+            \ read the object data and its metadata.\n\nBy default, all objects are\
+            \ private. Only the owner has full access control. When uploading an object,\
+            \ you can use this header to explicitly grant access permissions to specific\
+            \ Amazon Web Services accounts or groups. This header maps to specific\
+            \ permissions that Amazon S3 supports in an ACL. For more information,\
+            \ see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)\
+            \ in the _Amazon S3 User Guide_.\n\nYou specify each grantee as a type=value\
+            \ pair, where the type is one of the following:\n\n  * `id` – if the value\
+            \ specified is the canonical user ID of an Amazon Web Services account\n\
+            \n  * `uri` – if you are granting permissions to a predefined group\n\n\
+            \  * `emailAddress` – if the value specified is the email address of an\
+            \ Amazon Web Services account\n\nUsing email addresses to specify a grantee\
+            \ is only supported in the following Amazon Web Services Regions:\n\n\
+            \    * US East (N. Virginia)\n\n    * US West (N. California)\n\n    *\
+            \ US West (Oregon)\n\n    * Asia Pacific (Singapore)\n\n    * Asia Pacific\
+            \ (Sydney)\n\n    * Asia Pacific (Tokyo)\n\n    * Europe (Ireland)\n\n\
+            \    * South America (São Paulo)\n\nFor a list of all the Amazon S3 supported\
+            \ Regions and endpoints, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)\
+            \ in the Amazon Web Services General Reference.\n\nFor example, the following\
+            \ `x-amz-grant-read` header grants the Amazon Web Services accounts identified\
+            \ by account IDs permissions to read object data and its metadata:\n\n\
+            `x-amz-grant-read: id=\"11112222333\", id=\"444455556666\" `\n\n  * This\
+            \ functionality is not supported for directory buckets.\n\n  * This functionality\
+            \ is not supported for Amazon S3 on Outposts."
+        GrantReadACP:
+          $ref: '#/components/schemas/GrantReadACP'
+          description: "Specify access permissions explicitly to allows grantee to\
+            \ read the object ACL.\n\nBy default, all objects are private. Only the\
+            \ owner has full access control. When uploading an object, you can use\
+            \ this header to explicitly grant access permissions to specific Amazon\
+            \ Web Services accounts or groups. This header maps to specific permissions\
+            \ that Amazon S3 supports in an ACL. For more information, see [Access\
+            \ Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)\
+            \ in the _Amazon S3 User Guide_.\n\nYou specify each grantee as a type=value\
+            \ pair, where the type is one of the following:\n\n  * `id` – if the value\
+            \ specified is the canonical user ID of an Amazon Web Services account\n\
+            \n  * `uri` – if you are granting permissions to a predefined group\n\n\
+            \  * `emailAddress` – if the value specified is the email address of an\
+            \ Amazon Web Services account\n\nUsing email addresses to specify a grantee\
+            \ is only supported in the following Amazon Web Services Regions:\n\n\
+            \    * US East (N. Virginia)\n\n    * US West (N. California)\n\n    *\
+            \ US West (Oregon)\n\n    * Asia Pacific (Singapore)\n\n    * Asia Pacific\
+            \ (Sydney)\n\n    * Asia Pacific (Tokyo)\n\n    * Europe (Ireland)\n\n\
+            \    * South America (São Paulo)\n\nFor a list of all the Amazon S3 supported\
+            \ Regions and endpoints, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)\
+            \ in the Amazon Web Services General Reference.\n\nFor example, the following\
+            \ `x-amz-grant-read` header grants the Amazon Web Services accounts identified\
+            \ by account IDs permissions to read object data and its metadata:\n\n\
+            `x-amz-grant-read: id=\"11112222333\", id=\"444455556666\" `\n\n  * This\
+            \ functionality is not supported for directory buckets.\n\n  * This functionality\
+            \ is not supported for Amazon S3 on Outposts."
+        GrantWriteACP:
+          $ref: '#/components/schemas/GrantWriteACP'
+          description: "Specify access permissions explicitly to allows grantee to\
+            \ allow grantee to write the ACL for the applicable object.\n\nBy default,\
+            \ all objects are private. Only the owner has full access control. When\
+            \ uploading an object, you can use this header to explicitly grant access\
+            \ permissions to specific Amazon Web Services accounts or groups. This\
+            \ header maps to specific permissions that Amazon S3 supports in an ACL.\
+            \ For more information, see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)\
+            \ in the _Amazon S3 User Guide_.\n\nYou specify each grantee as a type=value\
+            \ pair, where the type is one of the following:\n\n  * `id` – if the value\
+            \ specified is the canonical user ID of an Amazon Web Services account\n\
+            \n  * `uri` – if you are granting permissions to a predefined group\n\n\
+            \  * `emailAddress` – if the value specified is the email address of an\
+            \ Amazon Web Services account\n\nUsing email addresses to specify a grantee\
+            \ is only supported in the following Amazon Web Services Regions:\n\n\
+            \    * US East (N. Virginia)\n\n    * US West (N. California)\n\n    *\
+            \ US West (Oregon)\n\n    * Asia Pacific (Singapore)\n\n    * Asia Pacific\
+            \ (Sydney)\n\n    * Asia Pacific (Tokyo)\n\n    * Europe (Ireland)\n\n\
+            \    * South America (São Paulo)\n\nFor a list of all the Amazon S3 supported\
+            \ Regions and endpoints, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)\
+            \ in the Amazon Web Services General Reference.\n\nFor example, the following\
+            \ `x-amz-grant-read` header grants the Amazon Web Services accounts identified\
+            \ by account IDs permissions to read object data and its metadata:\n\n\
+            `x-amz-grant-read: id=\"11112222333\", id=\"444455556666\" `\n\n  * This\
+            \ functionality is not supported for directory buckets.\n\n  * This functionality\
+            \ is not supported for Amazon S3 on Outposts."
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the multipart upload is to be initiated.
+        Metadata:
+          $ref: '#/components/schemas/Metadata'
+          description: A map of metadata to store with the object in S3.
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: "The server-side encryption algorithm used when you store this\
+            \ object in Amazon S3 or Amazon FSx.\n\n  * **Directory buckets** \\-\
+            \ For directory buckets, there are only two supported options for server-side\
+            \ encryption: server-side encryption with Amazon S3 managed keys (SSE-S3)\
+            \ (`AES256`) and server-side encryption with KMS keys (SSE-KMS) (`aws:kms`).\
+            \ We recommend that the bucket's default encryption uses the desired encryption\
+            \ configuration and you don't override the bucket default encryption in\
+            \ your `CreateSession` requests or `PUT` object requests. Then, new objects\
+            \ are automatically encrypted with the desired encryption settings. For\
+            \ more information, see [Protecting data with server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-serv-side-encryption.html)\
+            \ in the _Amazon S3 User Guide_. For more information about the encryption\
+            \ overriding behaviors in directory buckets, see [Specifying server-side\
+            \ encryption with KMS for new object uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-specifying-kms-encryption.html).\
+            \ \n\nIn the Zonal endpoint API calls (except [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html)\
+            \ and [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html))\
+            \ using the REST API, the encryption request headers must match the encryption\
+            \ settings that are specified in the `CreateSession` request. You can't\
+            \ override the values of the encryption settings (`x-amz-server-side-encryption`,\
+            \ `x-amz-server-side-encryption-aws-kms-key-id`, `x-amz-server-side-encryption-context`,\
+            \ and `x-amz-server-side-encryption-bucket-key-enabled`) that are specified\
+            \ in the `CreateSession` request. You don't need to explicitly specify\
+            \ these encryption settings values in Zonal endpoint API calls, and Amazon\
+            \ S3 will use the encryption settings values from the `CreateSession`\
+            \ request to protect new objects in the directory bucket.\n\nWhen you\
+            \ use the CLI or the Amazon Web Services SDKs, for `CreateSession`, the\
+            \ session token refreshes automatically to avoid service interruptions\
+            \ when a session expires. The CLI or the Amazon Web Services SDKs use\
+            \ the bucket's default encryption configuration for the `CreateSession`\
+            \ request. It's not supported to override the encryption settings values\
+            \ in the `CreateSession` request. So in the Zonal endpoint API calls (except\
+            \ [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html)\
+            \ and [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html)),\
+            \ the encryption request headers must match the default encryption configuration\
+            \ of the directory bucket.\n\n  * **S3 access points for Amazon FSx**\
+            \ \\- When accessing data stored in Amazon FSx file systems using S3 access\
+            \ points, the only valid server side encryption option is `aws:fsx`. All\
+            \ Amazon FSx file systems have encryption configured by default and are\
+            \ encrypted at rest. Data is automatically encrypted before being written\
+            \ to the file system, and automatically decrypted as it is read. These\
+            \ processes are handled transparently by Amazon FSx."
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: "By default, Amazon S3 uses the STANDARD Storage Class to store\
+            \ newly created objects. The STANDARD storage class provides high durability\
+            \ and high availability. Depending on performance needs, you can specify\
+            \ a different Storage Class. For more information, see [Storage Classes](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)\
+            \ in the _Amazon S3 User Guide_.\n\n  * Directory buckets only support\
+            \ `EXPRESS_ONEZONE` (the S3 Express One Zone storage class) in Availability\
+            \ Zones and `ONEZONE_IA` (the S3 One Zone-Infrequent Access storage class)\
+            \ in Dedicated Local Zones.\n\n  * Amazon S3 on Outposts only uses the\
+            \ OUTPOSTS Storage Class."
+        WebsiteRedirectLocation:
+          $ref: '#/components/schemas/WebsiteRedirectLocation'
+          description: 'If the bucket is configured as a website, redirects requests
+            for this object to another object in the same bucket or to an external
+            URL. Amazon S3 stores the value of this header in the object metadata.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when encrypting the object
+            (for example, AES256).
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use in encrypting data. This value is used to store the object and
+            then it is discarded; Amazon S3 does not store the encryption key. The
+            key must be appropriate for use with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm`
+            header.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the customer-provided
+            encryption key according to RFC 1321. Amazon S3 uses this header for a
+            message integrity check to ensure that the encryption key was transmitted
+            without error.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: 'Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to
+            use for object encryption. If the KMS key doesn''t exist in the same account
+            that''s issuing the command, you must use the full Key ARN not the Key
+            ID.
+
+
+            **General purpose buckets** \- If you specify `x-amz-server-side-encryption`
+            with `aws:kms` or `aws:kms:dsse`, this header specifies the ID (Key ID,
+            Key ARN, or Key Alias) of the KMS key to use. If you specify `x-amz-server-side-encryption:aws:kms`
+            or `x-amz-server-side-encryption:aws:kms:dsse`, but do not provide `x-amz-server-side-encryption-aws-kms-key-id`,
+            Amazon S3 uses the Amazon Web Services managed key (`aws/s3`) to protect
+            the data.
+
+
+            **Directory buckets** \- To encrypt data using SSE-KMS, it''s recommended
+            to specify the `x-amz-server-side-encryption` header to `aws:kms`. Then,
+            the `x-amz-server-side-encryption-aws-kms-key-id` header implicitly uses
+            the bucket''s default KMS customer managed key ID. If you want to explicitly
+            set the ` x-amz-server-side-encryption-aws-kms-key-id` header, it must
+            match the bucket''s default customer managed key (using key ID or ARN,
+            not alias). Your SSE-KMS configuration can only support 1 [customer managed
+            key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+            per directory bucket''s lifetime. The [Amazon Web Services managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)
+            (`aws/s3`) isn''t supported. Incorrect key specification results in an
+            HTTP `400 Bad Request` error.'
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: 'Specifies the Amazon Web Services KMS Encryption Context to
+            use for object encryption. The value of this header is a Base64 encoded
+            string of a UTF-8 encoded JSON, which contains the encryption context
+            as key-value pairs.
+
+
+            **Directory buckets** \- You can optionally provide an explicit encryption
+            context value. The value must match the default encryption context - the
+            bucket Amazon Resource Name (ARN). An additional encryption context value
+            is not supported.'
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: 'Specifies whether Amazon S3 should use an S3 Bucket Key for
+            object encryption with server-side encryption using Key Management Service
+            (KMS) keys (SSE-KMS).
+
+
+            **General purpose buckets** \- Setting this header to `true` causes Amazon
+            S3 to use an S3 Bucket Key for object encryption with SSE-KMS. Also, specifying
+            this header with a PUT action doesn''t affect bucket-level settings for
+            S3 Bucket Key.
+
+
+            **Directory buckets** \- S3 Bucket Keys are always enabled for `GET` and
+            `PUT` operations in a directory bucket and can’t be disabled. S3 Bucket
+            Keys aren''t supported, when you copy SSE-KMS encrypted objects from general
+            purpose buckets to directory buckets, from directory buckets to general
+            purpose buckets, or between directory buckets, through [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html),
+            [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html),
+            [the Copy operation in Batch Operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-Batch-Ops),
+            or [the import jobs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-import-job).
+            In this case, Amazon S3 makes a call to KMS every time a copy request
+            is made for a KMS-encrypted object.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        Tagging:
+          $ref: '#/components/schemas/TaggingHeader'
+          description: 'The tag-set for the object. The tag-set must be encoded as
+            URL Query parameters.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockMode:
+          $ref: '#/components/schemas/ObjectLockMode'
+          description: 'Specifies the Object Lock mode that you want to apply to the
+            uploaded object.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockRetainUntilDate:
+          $ref: '#/components/schemas/ObjectLockRetainUntilDate'
+          description: 'Specifies the date and time when you want the Object Lock
+            to expire.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockLegalHoldStatus:
+          $ref: '#/components/schemas/ObjectLockLegalHoldStatus'
+          description: 'Specifies whether you want to apply a legal hold to the uploaded
+            object.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: Indicates the algorithm that you want Amazon S3 to use to create
+            the checksum for the object. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: Indicates the checksum type that you want Amazon S3 to use
+            to calculate the object’s checksum value. For more information, see [Checking
+            object integrity in the Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+      required:
+      - Bucket
+      - Key
+    CreateSessionOutput:
+      type: object
+      properties:
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store objects
+            in the directory bucket.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If you specify `x-amz-server-side-encryption` with `aws:kms`,
+            this header indicates the ID of the KMS symmetric encryption customer
+            managed key that was used for object encryption.
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: If present, indicates the Amazon Web Services KMS Encryption
+            Context to use for object encryption. The value of this header is a Base64
+            encoded string of a UTF-8 encoded JSON, which contains the encryption
+            context as key-value pairs. This value is stored as object metadata and
+            automatically gets passed on to Amazon Web Services KMS for future `GetObject`
+            operations on this object.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether to use an S3 Bucket Key for server-side encryption
+            with KMS keys (SSE-KMS).
+        Credentials:
+          $ref: '#/components/schemas/SessionCredentials'
+          description: The established temporary security credentials for the created
+            session.
+      required:
+      - Credentials
+    CreateSessionRequest:
+      type: object
+      properties:
+        SessionMode:
+          $ref: '#/components/schemas/SessionMode'
+          description: 'Specifies the mode of the session that will be created, either
+            `ReadWrite` or `ReadOnly`. By default, a `ReadWrite` session is created.
+            A `ReadWrite` session is capable of executing all the Zonal endpoint API
+            operations on a directory bucket. A `ReadOnly` session is constrained
+            to execute the following Zonal endpoint API operations: `GetObject`, `HeadObject`,
+            `ListObjectsV2`, `GetObjectAttributes`, `ListParts`, and `ListMultipartUploads`.'
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket that you create a session for.
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm to use when you store
+            objects in the directory bucket.
+
+
+            For directory buckets, there are only two supported options for server-side
+            encryption: server-side encryption with Amazon S3 managed keys (SSE-S3)
+            (`AES256`) and server-side encryption with KMS keys (SSE-KMS) (`aws:kms`).
+            By default, Amazon S3 encrypts data with SSE-S3. For more information,
+            see [Protecting data with server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **S3 access points for Amazon FSx** \- When accessing data stored in Amazon
+            FSx file systems using S3 access points, the only valid server side encryption
+            option is `aws:fsx`. All Amazon FSx file systems have encryption configured
+            by default and are encrypted at rest. Data is automatically encrypted
+            before being written to the file system, and automatically decrypted as
+            it is read. These processes are handled transparently by Amazon FSx.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: 'If you specify `x-amz-server-side-encryption` with `aws:kms`,
+            you must specify the ` x-amz-server-side-encryption-aws-kms-key-id` header
+            with the ID (Key ID or Key ARN) of the KMS symmetric encryption customer
+            managed key to use. Otherwise, you get an HTTP `400 Bad Request` error.
+            Only use the key ID or key ARN. The key alias format of the KMS key isn''t
+            supported. Also, if the KMS key doesn''t exist in the same account that''t
+            issuing the command, you must use the full Key ARN not the Key ID.
+
+
+            Your SSE-KMS configuration can only support 1 [customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+            per directory bucket''s lifetime. The [Amazon Web Services managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)
+            (`aws/s3`) isn''t supported.'
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: 'Specifies the Amazon Web Services KMS Encryption Context as
+            an additional encryption context to use for object encryption. The value
+            of this header is a Base64 encoded string of a UTF-8 encoded JSON, which
+            contains the encryption context as key-value pairs. This value is stored
+            as object metadata and automatically gets passed on to Amazon Web Services
+            KMS for future `GetObject` operations on this object.
+
+
+            **General purpose buckets** \- This value must be explicitly added during
+            `CopyObject` operations if you want an additional encryption context for
+            your object. For more information, see [Encryption context](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context)
+            in the _Amazon S3 User Guide_.
+
+
+            **Directory buckets** \- You can optionally provide an explicit encryption
+            context value. The value must match the default encryption context - the
+            bucket Amazon Resource Name (ARN). An additional encryption context value
+            is not supported.'
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: 'Specifies whether Amazon S3 should use an S3 Bucket Key for
+            object encryption with server-side encryption using KMS keys (SSE-KMS).
+
+
+            S3 Bucket Keys are always enabled for `GET` and `PUT` operations in a
+            directory bucket and can’t be disabled. S3 Bucket Keys aren''t supported,
+            when you copy SSE-KMS encrypted objects from general purpose buckets to
+            directory buckets, from directory buckets to general purpose buckets,
+            or between directory buckets, through [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html),
+            [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html),
+            [the Copy operation in Batch Operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-Batch-Ops),
+            or [the import jobs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-import-job).
+            In this case, Amazon S3 makes a call to KMS every time a copy request
+            is made for a KMS-encrypted object.'
+      required:
+      - Bucket
+    CreationDate:
+      type: string
+      format: date-time
+    DataRedundancy:
+      type: string
+      enum:
+      - SingleAvailabilityZone
+      - SingleLocalZone
+    Date:
+      type: string
+      format: date-time
+    Days:
+      type: integer
+    DaysAfterInitiation:
+      type: integer
+    DefaultRetention:
+      type: object
+      properties:
+        Mode:
+          $ref: '#/components/schemas/ObjectLockRetentionMode'
+          description: The default Object Lock retention mode you want to apply to
+            new objects placed in the specified bucket. Must be used with either `Days`
+            or `Years`.
+        Days:
+          $ref: '#/components/schemas/Days'
+          description: The number of days that you want to specify for the default
+            retention period. Must be used with `Mode`.
+        Years:
+          $ref: '#/components/schemas/Years'
+          description: The number of years that you want to specify for the default
+            retention period. Must be used with `Mode`.
+      description: "The container element for optionally specifying the default Object\
+        \ Lock retention settings for new objects placed in the specified bucket.\n\
+        \n  * The `DefaultRetention` settings require both a mode and a period.\n\n\
+        \  * The `DefaultRetention` period can be either `Days` or `Years` but you\
+        \ must select one. You cannot specify `Days` and `Years` at the same time."
+    Delete:
+      type: object
+      properties:
+        Objects:
+          $ref: '#/components/schemas/ObjectIdentifierList'
+          description: 'The object to delete.
+
+
+            **Directory buckets** \- For directory buckets, an object that''s composed
+            entirely of whitespace characters is not supported by the `DeleteObjects`
+            API operation. The request will receive a `400 Bad Request` error and
+            none of the objects in the request will be deleted.'
+        Quiet:
+          $ref: '#/components/schemas/Quiet'
+          description: Element to enable quiet mode for the request. When you add
+            this element, you must set its value to `true`.
+      required:
+      - Objects
+      description: Container for the objects to delete.
+    DeleteBucketAnalyticsConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket from which an analytics configuration
+            is deleted.
+        Id:
+          $ref: '#/components/schemas/AnalyticsId'
+          description: The ID that identifies the analytics configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    DeleteBucketCorsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: Specifies the bucket whose `cors` configuration is being deleted.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    DeleteBucketEncryptionRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket containing the server-side encryption
+            configuration to delete.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            For directory buckets, this header is not supported in this API operation.
+            If you specify this header, the request fails with the HTTP status code
+            `501 Not Implemented`.'
+      required:
+      - Bucket
+    DeleteBucketIntelligentTieringConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose configuration you want
+            to modify or retrieve.
+        Id:
+          $ref: '#/components/schemas/IntelligentTieringId'
+          description: The ID used to identify the S3 Intelligent-Tiering configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    DeleteBucketInventoryConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket containing the inventory configuration
+            to delete.
+        Id:
+          $ref: '#/components/schemas/InventoryId'
+          description: The ID used to identify the inventory configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    DeleteBucketLifecycleRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name of the lifecycle to delete.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+      required:
+      - Bucket
+    DeleteBucketMetadataConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that you want to remove the metadata
+            configuration from.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected bucket owner of the general purpose bucket that
+            you want to remove the metadata table configuration from.
+      required:
+      - Bucket
+    DeleteBucketMetadataTableConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that you want to remove the metadata
+            table configuration from.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected bucket owner of the general purpose bucket that
+            you want to remove the metadata table configuration from.
+      required:
+      - Bucket
+    DeleteBucketMetricsConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket containing the metrics configuration
+            to delete.
+        Id:
+          $ref: '#/components/schemas/MetricsId'
+          description: The ID used to identify the metrics configuration. The ID has
+            a 64 character limit and can only contain letters, numbers, periods, dashes,
+            and underscores.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    DeleteBucketOwnershipControlsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The Amazon S3 bucket whose `OwnershipControls` you want to
+            delete.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    DeleteBucketPolicyRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            For directory buckets, this header is not supported in this API operation.
+            If you specify this header, the request fails with the HTTP status code
+            `501 Not Implemented`.'
+      required:
+      - Bucket
+    DeleteBucketReplicationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    DeleteBucketRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'Specifies the bucket being deleted.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            For directory buckets, this header is not supported in this API operation.
+            If you specify this header, the request fails with the HTTP status code
+            `501 Not Implemented`.'
+      required:
+      - Bucket
+    DeleteBucketTaggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket that has the tag set to be removed.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    DeleteBucketWebsiteRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name for which you want to remove the website configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    DeleteMarker:
+      type: boolean
+    DeleteMarkerEntry:
+      type: object
+      properties:
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: The account that created the delete marker.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The object key.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: Version ID of an object.
+        IsLatest:
+          $ref: '#/components/schemas/IsLatest'
+          description: Specifies whether the object is (true) or is not (false) the
+            latest version of an object.
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Date and time when the object was last modified.
+      description: Information about the delete marker.
+    DeleteMarkerReplication:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/DeleteMarkerReplicationStatus'
+          description: 'Indicates whether to replicate delete markers.
+
+
+            Indicates whether to replicate delete markers.'
+      description: 'Specifies whether Amazon S3 replicates delete markers. If you
+        specify a `Filter` in your replication configuration, you must also include
+        a `DeleteMarkerReplication` element. If your `Filter` includes a `Tag` element,
+        the `DeleteMarkerReplication` `Status` must be set to Disabled, because Amazon
+        S3 does not support replicating delete markers for tag-based rules. For an
+        example configuration, see [Basic Rule Configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-config-min-rule-config).
+
+
+        For more information about delete marker replication, see [Basic Rule Configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/delete-marker-replication.html).
+
+
+        If you are using an earlier version of the replication configuration, Amazon
+        S3 handles replication of delete markers differently. For more information,
+        see [Backward Compatibility](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations).'
+    DeleteMarkerReplicationStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    DeleteMarkerVersionId:
+      type: string
+    DeleteMarkers:
+      type: array
+      items:
+        $ref: '#/components/schemas/DeleteMarkerEntry'
+    DeleteObjectOutput:
+      type: object
+      properties:
+        DeleteMarker:
+          $ref: '#/components/schemas/DeleteMarker'
+          description: 'Indicates whether the specified object version that was permanently
+            deleted was (true) or was not (false) a delete marker before deletion.
+            In a simple DELETE, this header indicates whether (true) or not (false)
+            the current version of the object is a delete marker. To learn more about
+            delete markers, see [Working with delete markers](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html).
+
+
+            This functionality is not supported for directory buckets.'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Returns the version ID of the delete marker created as a result
+            of the DELETE operation.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    DeleteObjectRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name of the bucket containing the object.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Key name of the object to delete.
+        MFA:
+          $ref: '#/components/schemas/MFA'
+          description: 'The concatenation of the authentication device''s serial number,
+            a space, and the value that is displayed on your authentication device.
+            Required to permanently delete a versioned object if versioning is configured
+            with MFA delete enabled.
+
+
+            This functionality is not supported for directory buckets.'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID used to reference a specific version of the object.
+
+
+            For directory buckets in this API operation, only the `null` value of
+            the version ID is supported.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        BypassGovernanceRetention:
+          $ref: '#/components/schemas/BypassGovernanceRetention'
+          description: 'Indicates whether S3 Object Lock should bypass Governance-mode
+            restrictions to process this operation. To use this header, you must have
+            the `s3:BypassGovernanceRetention` permission.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        IfMatch:
+          $ref: '#/components/schemas/IfMatch'
+          description: 'Deletes the object if the ETag (entity tag) value provided
+            during the delete operation matches the ETag of the object in S3. If the
+            ETag values do not match, the operation returns a `412 Precondition Failed`
+            error.
+
+
+            Expects the ETag value as a string. `If-Match` does accept a string value
+            of an ''*'' (asterisk) character to denote a match of any ETag.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232).'
+        IfMatchLastModifiedTime:
+          $ref: '#/components/schemas/IfMatchLastModifiedTime'
+          description: 'If present, the object is deleted only if its modification
+            times matches the provided `Timestamp`. If the `Timestamp` values do not
+            match, the operation returns a `412 Precondition Failed` error. If the
+            `Timestamp` matches or if the object doesn’t exist, the operation returns
+            a `204 Success (No Content)` response.
+
+
+            This functionality is only supported for directory buckets.'
+        IfMatchSize:
+          $ref: '#/components/schemas/IfMatchSize'
+          description: 'If present, the object is deleted only if its size matches
+            the provided size in bytes. If the `Size` value does not match, the operation
+            returns a `412 Precondition Failed` error. If the `Size` matches or if
+            the object doesn’t exist, the operation returns a `204 Success (No Content)`
+            response.
+
+
+            This functionality is only supported for directory buckets.
+
+
+            You can use the `If-Match`, `x-amz-if-match-last-modified-time` and `x-amz-if-match-size`
+            conditional headers in conjunction with each-other or individually.'
+      required:
+      - Bucket
+      - Key
+    DeleteObjectTaggingOutput:
+      type: object
+      properties:
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The versionId of the object the tag-set was removed from.
+    DeleteObjectTaggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the objects from which to remove
+            the tags.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The key that identifies the object in the bucket from which
+            to remove all tags.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The versionId of the object that the tag-set will be removed
+            from.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    DeleteObjectsOutput:
+      type: object
+      properties:
+        Deleted:
+          $ref: '#/components/schemas/DeletedObjects'
+          description: Container element for a successful delete. It identifies the
+            object that was successfully deleted.
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        Errors:
+          $ref: '#/components/schemas/Errors'
+          description: Container for a failed delete action that describes the object
+            that Amazon S3 attempted to delete and the error it encountered.
+    DeleteObjectsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the objects to delete.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Delete:
+          $ref: '#/components/schemas/Delete'
+          description: Container for the request.
+        MFA:
+          $ref: '#/components/schemas/MFA'
+          description: 'The concatenation of the authentication device''s serial number,
+            a space, and the value that is displayed on your authentication device.
+            Required to permanently delete a versioned object if versioning is configured
+            with MFA delete enabled.
+
+
+            When performing the `DeleteObjects` operation on an MFA delete enabled
+            bucket, which attempts to delete the specified versioned objects, you
+            must include an MFA token. If you don''t provide an MFA token, the entire
+            request will fail, even if there are non-versioned objects that you are
+            trying to delete. If you provide an invalid token, whether there are versioned
+            object keys in the request or not, the entire Multi-Object Delete request
+            will fail. For information about MFA Delete, see [ MFA Delete](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html#MultiFactorAuthenticationDelete)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        BypassGovernanceRetention:
+          $ref: '#/components/schemas/BypassGovernanceRetention'
+          description: 'Specifies whether you want to delete this object even if it
+            has a Governance-type Object Lock in place. To use this header, you must
+            have the `s3:BypassGovernanceRetention` permission.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: "Indicates the algorithm used to create the checksum for the\
+            \ object when you use the SDK. This header will not provide any additional\
+            \ functionality if you don't use the SDK. When you send this header, there\
+            \ must be a corresponding `x-amz-checksum-_algorithm_ ` or `x-amz-trailer`\
+            \ header sent. Otherwise, Amazon S3 fails the request with the HTTP status\
+            \ code `400 Bad Request`.\n\nFor the `x-amz-checksum-_algorithm_ ` header,\
+            \ replace ` _algorithm_ ` with the supported algorithm from the following\
+            \ list:\n\n  * `CRC32`\n\n  * `CRC32C`\n\n  * `CRC64NVME`\n\n  * `SHA1`\n\
+            \n  * `SHA256`\n\nFor more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)\
+            \ in the _Amazon S3 User Guide_.\n\nIf the individual checksum value you\
+            \ provide through `x-amz-checksum-_algorithm_ ` doesn't match the checksum\
+            \ algorithm you set through `x-amz-sdk-checksum-algorithm`, Amazon S3\
+            \ fails the request with a `BadDigest` error.\n\nIf you provide an individual\
+            \ checksum, Amazon S3 ignores any provided `ChecksumAlgorithm` parameter."
+      required:
+      - Bucket
+      - Delete
+    DeletePublicAccessBlockRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The Amazon S3 bucket whose `PublicAccessBlock` configuration
+            you want to delete.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    DeletedObject:
+      type: object
+      properties:
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The name of the deleted object.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'The version ID of the deleted object.
+
+
+            This functionality is not supported for directory buckets.'
+        DeleteMarker:
+          $ref: '#/components/schemas/DeleteMarker'
+          description: 'Indicates whether the specified object version that was permanently
+            deleted was (true) or was not (false) a delete marker before deletion.
+            In a simple DELETE, this header indicates whether (true) or not (false)
+            the current version of the object is a delete marker. To learn more about
+            delete markers, see [Working with delete markers](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html).
+
+
+            This functionality is not supported for directory buckets.'
+        DeleteMarkerVersionId:
+          $ref: '#/components/schemas/DeleteMarkerVersionId'
+          description: 'The version ID of the delete marker created as a result of
+            the DELETE operation. If you delete a specific object version, the value
+            returned by this header is the version ID of the object version deleted.
+
+
+            This functionality is not supported for directory buckets.'
+      description: Information about the deleted object.
+    DeletedObjects:
+      type: array
+      items:
+        $ref: '#/components/schemas/DeletedObject'
+    Delimiter:
+      type: string
+    Description:
+      type: string
+    Destination:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The Amazon Resource Name (ARN) of the bucket where you want
+            Amazon S3 to store the results.
+        Account:
+          $ref: '#/components/schemas/AccountId'
+          description: 'Destination bucket owner account ID. In a cross-account scenario,
+            if you direct Amazon S3 to change replica ownership to the Amazon Web
+            Services account that owns the destination bucket by specifying the `AccessControlTranslation`
+            property, this is the account ID of the destination bucket owner. For
+            more information, see [Replication Additional Configuration: Changing
+            the Replica Owner](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-change-owner.html)
+            in the _Amazon S3 User Guide_.'
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: 'The storage class to use when replicating objects, such as
+            S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage
+            class of the source object to create the object replica.
+
+
+            For valid values, see the `StorageClass` element of the [PUT Bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html)
+            action in the _Amazon S3 API Reference_.
+
+
+            `FSX_OPENZFS` is not an accepted value when replicating objects.'
+        AccessControlTranslation:
+          $ref: '#/components/schemas/AccessControlTranslation'
+          description: Specify this only in a cross-account scenario (where source
+            and destination bucket owners are not the same), and you want to change
+            replica ownership to the Amazon Web Services account that owns the destination
+            bucket. If this is not specified in the replication configuration, the
+            replicas are owned by same Amazon Web Services account that owns the source
+            object.
+        EncryptionConfiguration:
+          $ref: '#/components/schemas/EncryptionConfiguration'
+          description: A container that provides information about encryption. If
+            `SourceSelectionCriteria` is specified, you must specify this element.
+        ReplicationTime:
+          $ref: '#/components/schemas/ReplicationTime'
+          description: A container specifying S3 Replication Time Control (S3 RTC),
+            including whether S3 RTC is enabled and the time when all objects and
+            operations on objects must be replicated. Must be specified together with
+            a `Metrics` block.
+        Metrics:
+          $ref: '#/components/schemas/Metrics'
+          description: A container specifying replication metrics-related settings
+            enabling replication metrics and events.
+      required:
+      - Bucket
+      description: Specifies information about where to publish analysis or configuration
+        results for an Amazon S3 bucket and S3 Replication Time Control (S3 RTC).
+    DestinationResult:
+      type: object
+      properties:
+        TableBucketType:
+          $ref: '#/components/schemas/S3TablesBucketType'
+          description: The type of the table bucket where the metadata configuration
+            is stored. The `aws` value indicates an Amazon Web Services managed table
+            bucket, and the `customer` value indicates a customer-managed table bucket.
+            V2 metadata configurations are stored in Amazon Web Services managed table
+            buckets, and V1 metadata configurations are stored in customer-managed
+            table buckets.
+        TableBucketArn:
+          $ref: '#/components/schemas/S3TablesBucketArn'
+          description: The Amazon Resource Name (ARN) of the table bucket where the
+            metadata configuration is stored.
+        TableNamespace:
+          $ref: '#/components/schemas/S3TablesNamespace'
+          description: The namespace in the table bucket where the metadata tables
+            for a metadata configuration are stored.
+      description: The destination information for the S3 Metadata configuration.
+    DirectoryBucketToken:
+      type: string
+      minLength: 0
+      maxLength: 1024
+    DisplayName:
+      type: string
+    ETag:
+      type: string
+    EmailAddress:
+      type: string
+    EnableRequestProgress:
+      type: boolean
+    EncodingType:
+      type: string
+      enum:
+      - url
+      description: "<p>Encoding type used by Amazon S3 to encode the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html\"\
+        >object keys</a> in the response. Responses are\n      encoded only in UTF-8.\
+        \ An object key can contain any Unicode character. However, the XML 1.0 parser\n\
+        \      can't parse certain characters, such as characters with an ASCII value\
+        \ from 0 to 10. For characters that\n      aren't supported in XML 1.0, you\
+        \ can add this parameter to request that Amazon S3 encode the keys in the\n\
+        \      response. For more information about characters to avoid in object\
+        \ key names, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-guidelines\"\
+        >Object key\n        naming guidelines</a>.</p>\n         <note>\n       \
+        \     <p>When using the URL encoding type, non-ASCII characters that are used\
+        \ in an object's key name will\n        be percent-encoded according to UTF-8\
+        \ code values. For example, the object\n          <code>test_file(3).png</code>\
+        \ will appear as <code>test_file%283%29.png</code>.</p>\n         </note>"
+    Encryption:
+      type: object
+      properties:
+        EncryptionType:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: The server-side encryption algorithm used when storing job
+            results in Amazon S3 (for example, AES256, `aws:kms`).
+        KMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If the encryption type is `aws:kms`, this optional value specifies
+            the ID of the symmetric encryption customer managed key to use for encryption
+            of job results. Amazon S3 only supports symmetric encryption KMS keys.
+            For more information, see [Asymmetric keys in KMS](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+            in the _Amazon Web Services Key Management Service Developer Guide_.
+        KMSContext:
+          $ref: '#/components/schemas/KMSContext'
+          description: If the encryption type is `aws:kms`, this optional value can
+            be used to specify the encryption context for the restore results.
+      required:
+      - EncryptionType
+      description: Contains the type of server-side encryption used.
+    EncryptionConfiguration:
+      type: object
+      properties:
+        ReplicaKmsKeyID:
+          $ref: '#/components/schemas/ReplicaKmsKeyID'
+          description: Specifies the ID (Key ARN or Alias ARN) of the customer managed
+            Amazon Web Services KMS key stored in Amazon Web Services Key Management
+            Service (KMS) for the destination bucket. Amazon S3 uses this key to encrypt
+            replica objects. Amazon S3 only supports symmetric encryption KMS keys.
+            For more information, see [Asymmetric keys in Amazon Web Services KMS](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+            in the _Amazon Web Services Key Management Service Developer Guide_.
+      description: 'Specifies encryption-related information for an Amazon S3 bucket
+        that is a destination for replicated objects.
+
+
+        If you''re specifying a customer managed KMS key, we recommend using a fully
+        qualified KMS key ARN. If you use a KMS key alias instead, then KMS resolves
+        the key within the requester’s account. This behavior can result in data that''s
+        encrypted with a KMS key that belongs to the requester, and not the bucket
+        owner.'
+    EncryptionType:
+      type: string
+      enum:
+      - NONE
+      - SSE-C
+    EncryptionTypeList:
+      type: array
+      items:
+        $ref: '#/components/schemas/EncryptionType'
+    EncryptionTypeMismatch:
+      type: object
+      properties: {}
+      description: The existing object was created with a different encryption type.
+        Subsequent write requests must include the appropriate encryption parameters
+        in the request or while creating the session.
+    End:
+      type: integer
+      format: int64
+    EndEvent:
+      type: object
+      properties: {}
+      description: A message that indicates the request is complete and no more messages
+        will be sent. You should not assume that the request is complete until the
+        client receives an `EndEvent`.
+    Error:
+      type: object
+      properties:
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The error key.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'The version ID of the error.
+
+
+            This functionality is not supported for directory buckets.'
+        Code:
+          $ref: '#/components/schemas/Code'
+          description: "The error code is a string that uniquely identifies an error\
+            \ condition. It is meant to be read and understood by programs that detect\
+            \ and handle errors by type. The following is a list of Amazon S3 error\
+            \ codes. For more information, see [Error responses](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html).\n\
+            \n  *     * _Code:_ AccessDenied \n\n    * _Description:_ Access Denied\n\
+            \n    * _HTTP Status Code:_ 403 Forbidden\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ AccountProblem\n\n    * _Description:_ There\
+            \ is a problem with your Amazon Web Services account that prevents the\
+            \ action from completing successfully. Contact Amazon Web Services Support\
+            \ for further assistance.\n\n    * _HTTP Status Code:_ 403 Forbidden\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ AllAccessDisabled\n\
+            \n    * _Description:_ All access to this Amazon S3 resource has been\
+            \ disabled. Contact Amazon Web Services Support for further assistance.\n\
+            \n    * _HTTP Status Code:_ 403 Forbidden\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ AmbiguousGrantByEmailAddress\n\n    * _Description:_\
+            \ The email address you provided is associated with more than one account.\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Client\n\n  *     * _Code:_ AuthorizationHeaderMalformed\n\n\
+            \    * _Description:_ The authorization header you provided is invalid.\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _HTTP Status Code:_\
+            \ N/A\n\n  *     * _Code:_ BadDigest\n\n    * _Description:_ The Content-MD5\
+            \ you specified did not match what we received.\n\n    * _HTTP Status\
+            \ Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n\
+            \  *     * _Code:_ BucketAlreadyExists\n\n    * _Description:_ The requested\
+            \ bucket name is not available. The bucket namespace is shared by all\
+            \ users of the system. Please select a different name and try again.\n\
+            \n    * _HTTP Status Code:_ 409 Conflict\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ BucketAlreadyOwnedByYou\n\n    * _Description:_\
+            \ The bucket you tried to create already exists, and you own it. Amazon\
+            \ S3 returns this error in all Amazon Web Services Regions except in the\
+            \ North Virginia Region. For legacy compatibility, if you re-create an\
+            \ existing bucket that you already own in the North Virginia Region, Amazon\
+            \ S3 returns 200 OK and resets the bucket access control lists (ACLs).\n\
+            \n    * _Code:_ 409 Conflict (in all Regions except the North Virginia\
+            \ Region) \n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ BucketNotEmpty\n\n    * _Description:_ The bucket you tried to delete\
+            \ is not empty.\n\n    * _HTTP Status Code:_ 409 Conflict\n\n    * _SOAP\
+            \ Fault Code Prefix:_ Client\n\n  *     * _Code:_ CredentialsNotSupported\n\
+            \n    * _Description:_ This request does not support credentials.\n\n\
+            \    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ CrossLocationLoggingProhibited\n\n    *\
+            \ _Description:_ Cross-location logging not allowed. Buckets in one geographic\
+            \ location cannot log information to a bucket in another location.\n\n\
+            \    * _HTTP Status Code:_ 403 Forbidden\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ EntityTooSmall\n\n    * _Description:_ Your\
+            \ proposed upload is smaller than the minimum allowed object size.\n\n\
+            \    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ EntityTooLarge\n\n    * _Description:_ Your\
+            \ proposed upload exceeds the maximum allowed object size.\n\n    * _HTTP\
+            \ Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\
+            \n  *     * _Code:_ ExpiredToken\n\n    * _Description:_ The provided\
+            \ token has expired.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n\
+            \    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ IllegalVersioningConfigurationException\
+            \ \n\n    * _Description:_ Indicates that the versioning configuration\
+            \ specified in the request is invalid.\n\n    * _HTTP Status Code:_ 400\
+            \ Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ IncompleteBody\n\n    * _Description:_ You did not provide the number\
+            \ of bytes specified by the Content-Length HTTP header\n\n    * _HTTP\
+            \ Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\
+            \n  *     * _Code:_ IncorrectNumberOfFilesInPostRequest\n\n    * _Description:_\
+            \ POST requires exactly one file upload per request.\n\n    * _HTTP Status\
+            \ Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n\
+            \  *     * _Code:_ InlineDataTooLarge\n\n    * _Description:_ Inline data\
+            \ exceeds the maximum allowed size.\n\n    * _HTTP Status Code:_ 400 Bad\
+            \ Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ InternalError\n\n    * _Description:_ We encountered an internal error.\
+            \ Please try again.\n\n    * _HTTP Status Code:_ 500 Internal Server Error\n\
+            \n    * _SOAP Fault Code Prefix:_ Server\n\n  *     * _Code:_ InvalidAccessKeyId\n\
+            \n    * _Description:_ The Amazon Web Services access key ID you provided\
+            \ does not exist in our records.\n\n    * _HTTP Status Code:_ 403 Forbidden\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidAddressingHeader\n\
+            \n    * _Description:_ You must specify the Anonymous role.\n\n    * _HTTP\
+            \ Status Code:_ N/A\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  * \
+            \    * _Code:_ InvalidArgument\n\n    * _Description:_ Invalid Argument\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Client\n\n  *     * _Code:_ InvalidBucketName\n\n    * _Description:_\
+            \ The specified bucket is not valid.\n\n    * _HTTP Status Code:_ 400\
+            \ Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ InvalidBucketState\n\n    * _Description:_ The request is not valid\
+            \ with the current state of the bucket.\n\n    * _HTTP Status Code:_ 409\
+            \ Conflict\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ InvalidDigest\n\n    * _Description:_ The Content-MD5 you specified\
+            \ is not valid.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    *\
+            \ _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidEncryptionAlgorithmError\n\
+            \n    * _Description:_ The encryption request you specified is not valid.\
+            \ The valid value is AES256.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidLocationConstraint\n\
+            \n    * _Description:_ The specified location constraint is not valid.\
+            \ For more information about Regions, see [How to Select a Region for\
+            \ Your Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro).\
+            \ \n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Client\n\n  *     * _Code:_ InvalidObjectState\n\n    * _Description:_\
+            \ The action is not valid for the current state of the object.\n\n   \
+            \ * _HTTP Status Code:_ 403 Forbidden\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ InvalidPart\n\n    * _Description:_ One\
+            \ or more of the specified parts could not be found. The part might not\
+            \ have been uploaded, or the specified entity tag might not have matched\
+            \ the part's entity tag.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidPartOrder\n\
+            \n    * _Description:_ The list of parts was not in ascending order. Parts\
+            \ list must be specified in order by part number.\n\n    * _HTTP Status\
+            \ Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n\
+            \  *     * _Code:_ InvalidPayer\n\n    * _Description:_ All access to\
+            \ this object has been disabled. Please contact Amazon Web Services Support\
+            \ for further assistance.\n\n    * _HTTP Status Code:_ 403 Forbidden\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidPolicyDocument\n\
+            \n    * _Description:_ The content of the form does not meet the conditions\
+            \ specified in the policy document.\n\n    * _HTTP Status Code:_ 400 Bad\
+            \ Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ InvalidRange\n\n    * _Description:_ The requested range cannot be satisfied.\n\
+            \n    * _HTTP Status Code:_ 416 Requested Range Not Satisfiable\n\n  \
+            \  * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidRequest\n\
+            \n    * _Description:_ Please use `AWS4-HMAC-SHA256`.\n\n    * _HTTP Status\
+            \ Code:_ 400 Bad Request\n\n    * _Code:_ N/A\n\n  *     * _Code:_ InvalidRequest\n\
+            \n    * _Description:_ SOAP requests must be made over an HTTPS connection.\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Client\n\n  *     * _Code:_ InvalidRequest\n\n    * _Description:_\
+            \ Amazon S3 Transfer Acceleration is not supported for buckets with non-DNS\
+            \ compliant names.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n  \
+            \  * _Code:_ N/A\n\n  *     * _Code:_ InvalidRequest\n\n    * _Description:_\
+            \ Amazon S3 Transfer Acceleration is not supported for buckets with periods\
+            \ (.) in their names.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n\
+            \    * _Code:_ N/A\n\n  *     * _Code:_ InvalidRequest\n\n    * _Description:_\
+            \ Amazon S3 Transfer Accelerate endpoint only supports virtual style requests.\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _Code:_ N/A\n\n \
+            \ *     * _Code:_ InvalidRequest\n\n    * _Description:_ Amazon S3 Transfer\
+            \ Accelerate is not configured on this bucket.\n\n    * _HTTP Status Code:_\
+            \ 400 Bad Request\n\n    * _Code:_ N/A\n\n  *     * _Code:_ InvalidRequest\n\
+            \n    * _Description:_ Amazon S3 Transfer Accelerate is disabled on this\
+            \ bucket.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _Code:_\
+            \ N/A\n\n  *     * _Code:_ InvalidRequest\n\n    * _Description:_ Amazon\
+            \ S3 Transfer Acceleration is not supported on this bucket. Contact Amazon\
+            \ Web Services Support for more information.\n\n    * _HTTP Status Code:_\
+            \ 400 Bad Request\n\n    * _Code:_ N/A\n\n  *     * _Code:_ InvalidRequest\n\
+            \n    * _Description:_ Amazon S3 Transfer Acceleration cannot be enabled\
+            \ on this bucket. Contact Amazon Web Services Support for more information.\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _Code:_ N/A\n\n \
+            \ *     * _Code:_ InvalidSecurity\n\n    * _Description:_ The provided\
+            \ security credentials are not valid.\n\n    * _HTTP Status Code:_ 403\
+            \ Forbidden\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ InvalidSOAPRequest\n\n    * _Description:_ The SOAP request body is\
+            \ invalid.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP\
+            \ Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidStorageClass\n\
+            \n    * _Description:_ The storage class you specified is not valid.\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Client\n\n  *     * _Code:_ InvalidTargetBucketForLogging\n\
+            \n    * _Description:_ The target bucket for logging does not exist, is\
+            \ not owned by you, or does not have the appropriate grants for the log-delivery\
+            \ group. \n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP\
+            \ Fault Code Prefix:_ Client\n\n  *     * _Code:_ InvalidToken\n\n   \
+            \ * _Description:_ The provided token is malformed or otherwise invalid.\n\
+            \n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Client\n\n  *     * _Code:_ InvalidURI\n\n    * _Description:_\
+            \ Couldn't parse the specified URI.\n\n    * _HTTP Status Code:_ 400 Bad\
+            \ Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ KeyTooLongError\n\n    * _Description:_ Your key is too long.\n\n  \
+            \  * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ MalformedACLError\n\n    * _Description:_\
+            \ The XML you provided was not well-formed or did not validate against\
+            \ our published schema.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ MalformedPOSTRequest\
+            \ \n\n    * _Description:_ The body of your POST request is not well-formed\
+            \ multipart/form-data.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n\
+            \    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ MalformedXML\n\
+            \n    * _Description:_ This happens when the user sends malformed XML\
+            \ (XML that doesn't conform to the published XSD) for the configuration.\
+            \ The error message is, \"The XML you provided was not well-formed or\
+            \ did not validate against our published schema.\" \n\n    * _HTTP Status\
+            \ Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n\
+            \  *     * _Code:_ MaxMessageLengthExceeded\n\n    * _Description:_ Your\
+            \ request was too big.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n\
+            \    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ MaxPostPreDataLengthExceededError\n\
+            \n    * _Description:_ Your POST request fields preceding the upload file\
+            \ were too large.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n   \
+            \ * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ MetadataTooLarge\n\
+            \n    * _Description:_ Your metadata headers exceed the maximum allowed\
+            \ metadata size.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    *\
+            \ _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ MethodNotAllowed\n\
+            \n    * _Description:_ The specified method is not allowed against this\
+            \ resource.\n\n    * _HTTP Status Code:_ 405 Method Not Allowed\n\n  \
+            \  * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ MissingAttachment\n\
+            \n    * _Description:_ A SOAP attachment was expected, but none were found.\n\
+            \n    * _HTTP Status Code:_ N/A\n\n    * _SOAP Fault Code Prefix:_ Client\n\
+            \n  *     * _Code:_ MissingContentLength\n\n    * _Description:_ You must\
+            \ provide the Content-Length HTTP header.\n\n    * _HTTP Status Code:_\
+            \ 411 Length Required\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *\
+            \     * _Code:_ MissingRequestBodyError\n\n    * _Description:_ This happens\
+            \ when the user sends an empty XML document as a request. The error message\
+            \ is, \"Request body is empty.\" \n\n    * _HTTP Status Code:_ 400 Bad\
+            \ Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ MissingSecurityElement\n\n    * _Description:_ The SOAP 1.1 request\
+            \ is missing a security element.\n\n    * _HTTP Status Code:_ 400 Bad\
+            \ Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ MissingSecurityHeader\n\n    * _Description:_ Your request is missing\
+            \ a required header.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n\
+            \    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ NoLoggingStatusForKey\n\
+            \n    * _Description:_ There is no such thing as a logging status subresource\
+            \ for a key.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP\
+            \ Fault Code Prefix:_ Client\n\n  *     * _Code:_ NoSuchBucket\n\n   \
+            \ * _Description:_ The specified bucket does not exist.\n\n    * _HTTP\
+            \ Status Code:_ 404 Not Found\n\n    * _SOAP Fault Code Prefix:_ Client\n\
+            \n  *     * _Code:_ NoSuchBucketPolicy\n\n    * _Description:_ The specified\
+            \ bucket does not have a bucket policy.\n\n    * _HTTP Status Code:_ 404\
+            \ Not Found\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ NoSuchKey\n\n    * _Description:_ The specified key does not exist.\n\
+            \n    * _HTTP Status Code:_ 404 Not Found\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ NoSuchLifecycleConfiguration\n\n    * _Description:_\
+            \ The lifecycle configuration does not exist. \n\n    * _HTTP Status Code:_\
+            \ 404 Not Found\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     *\
+            \ _Code:_ NoSuchUpload\n\n    * _Description:_ The specified multipart\
+            \ upload does not exist. The upload ID might be invalid, or the multipart\
+            \ upload might have been aborted or completed.\n\n    * _HTTP Status Code:_\
+            \ 404 Not Found\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     *\
+            \ _Code:_ NoSuchVersion \n\n    * _Description:_ Indicates that the version\
+            \ ID specified in the request does not match an existing version.\n\n\
+            \    * _HTTP Status Code:_ 404 Not Found\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ NotImplemented\n\n    * _Description:_ A\
+            \ header you provided implies functionality that is not implemented.\n\
+            \n    * _HTTP Status Code:_ 501 Not Implemented\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Server\n\n  *     * _Code:_ NotSignedUp\n\n    * _Description:_\
+            \ Your account is not signed up for the Amazon S3 service. You must sign\
+            \ up before you can use Amazon S3. You can sign up at the following URL:\
+            \ [Amazon S3](http://aws.amazon.com/s3)\n\n    * _HTTP Status Code:_ 403\
+            \ Forbidden\n\n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_\
+            \ OperationAborted\n\n    * _Description:_ A conflicting conditional action\
+            \ is currently in progress against this resource. Try again.\n\n    *\
+            \ _HTTP Status Code:_ 409 Conflict\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ PermanentRedirect\n\n    * _Description:_\
+            \ The bucket you are attempting to access must be addressed using the\
+            \ specified endpoint. Send all future requests to this endpoint.\n\n \
+            \   * _HTTP Status Code:_ 301 Moved Permanently\n\n    * _SOAP Fault Code\
+            \ Prefix:_ Client\n\n  *     * _Code:_ PreconditionFailed\n\n    * _Description:_\
+            \ At least one of the preconditions you specified did not hold.\n\n  \
+            \  * _HTTP Status Code:_ 412 Precondition Failed\n\n    * _SOAP Fault\
+            \ Code Prefix:_ Client\n\n  *     * _Code:_ Redirect\n\n    * _Description:_\
+            \ Temporary redirect.\n\n    * _HTTP Status Code:_ 307 Moved Temporarily\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ RestoreAlreadyInProgress\n\
+            \n    * _Description:_ Object restore is already in progress.\n\n    *\
+            \ _HTTP Status Code:_ 409 Conflict\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ RequestIsNotMultiPartContent\n\n    * _Description:_\
+            \ Bucket POST must be of the enclosure-type multipart/form-data.\n\n \
+            \   * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ RequestTimeout\n\n    * _Description:_ Your\
+            \ socket connection to the server was not read from or written to within\
+            \ the timeout period.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n\
+            \    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ RequestTimeTooSkewed\n\
+            \n    * _Description:_ The difference between the request time and the\
+            \ server's time is too large.\n\n    * _HTTP Status Code:_ 403 Forbidden\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ RequestTorrentOfBucketError\n\
+            \n    * _Description:_ Requesting the torrent file of a bucket is not\
+            \ permitted.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP\
+            \ Fault Code Prefix:_ Client\n\n  *     * _Code:_ SignatureDoesNotMatch\n\
+            \n    * _Description:_ The request signature we calculated does not match\
+            \ the signature you provided. Check your Amazon Web Services secret access\
+            \ key and signing method. For more information, see [REST Authentication](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)\
+            \ and [SOAP Authentication](https://docs.aws.amazon.com/AmazonS3/latest/dev/SOAPAuthentication.html)\
+            \ for details.\n\n    * _HTTP Status Code:_ 403 Forbidden\n\n    * _SOAP\
+            \ Fault Code Prefix:_ Client\n\n  *     * _Code:_ ServiceUnavailable\n\
+            \n    * _Description:_ Service is unable to handle request.\n\n    * _HTTP\
+            \ Status Code:_ 503 Service Unavailable\n\n    * _SOAP Fault Code Prefix:_\
+            \ Server\n\n  *     * _Code:_ SlowDown\n\n    * _Description:_ Reduce\
+            \ your request rate.\n\n    * _HTTP Status Code:_ 503 Slow Down\n\n  \
+            \  * _SOAP Fault Code Prefix:_ Server\n\n  *     * _Code:_ TemporaryRedirect\n\
+            \n    * _Description:_ You are being redirected to the bucket while DNS\
+            \ updates.\n\n    * _HTTP Status Code:_ 307 Moved Temporarily\n\n    *\
+            \ _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ TokenRefreshRequired\n\
+            \n    * _Description:_ The provided token must be refreshed.\n\n    *\
+            \ _HTTP Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_\
+            \ Client\n\n  *     * _Code:_ TooManyBuckets\n\n    * _Description:_ You\
+            \ have attempted to create more buckets than allowed.\n\n    * _HTTP Status\
+            \ Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client\n\n\
+            \  *     * _Code:_ UnexpectedContent\n\n    * _Description:_ This request\
+            \ does not support content.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\
+            \n    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ UnresolvableGrantByEmailAddress\n\
+            \n    * _Description:_ The email address you provided does not match any\
+            \ account on record.\n\n    * _HTTP Status Code:_ 400 Bad Request\n\n\
+            \    * _SOAP Fault Code Prefix:_ Client\n\n  *     * _Code:_ UserKeyMustBeSpecified\n\
+            \n    * _Description:_ The bucket POST must contain the specified field\
+            \ name. If it is specified, check the order of the fields.\n\n    * _HTTP\
+            \ Status Code:_ 400 Bad Request\n\n    * _SOAP Fault Code Prefix:_ Client"
+        Message:
+          $ref: '#/components/schemas/Message'
+          description: The error message contains a generic description of the error
+            condition in English. It is intended for a human audience. Simple programs
+            display the message directly to the end user if they encounter an error
+            condition they don't know how or don't care to handle. Sophisticated programs
+            with more exhaustive error handling and proper internationalization are
+            more likely to ignore the error message.
+      description: Container for all error elements.
+    ErrorCode:
+      type: string
+    ErrorDetails:
+      type: object
+      properties:
+        ErrorCode:
+          $ref: '#/components/schemas/ErrorCode'
+          description: "If the V1 `CreateBucketMetadataTableConfiguration` request\
+            \ succeeds, but S3 Metadata was unable to create the table, this structure\
+            \ contains the error code. The possible error codes and error messages\
+            \ are as follows:\n\n  * `AccessDeniedCreatingResources` \\- You don't\
+            \ have sufficient permissions to create the required resources. Make sure\
+            \ that you have `s3tables:CreateNamespace`, `s3tables:CreateTable`, `s3tables:GetTable`\
+            \ and `s3tables:PutTablePolicy` permissions, and then try again. To create\
+            \ a new metadata table, you must delete the metadata configuration for\
+            \ this bucket, and then create a new metadata configuration. \n\n  * `AccessDeniedWritingToTable`\
+            \ \\- Unable to write to the metadata table because of missing resource\
+            \ permissions. To fix the resource policy, Amazon S3 needs to create a\
+            \ new metadata table. To create a new metadata table, you must delete\
+            \ the metadata configuration for this bucket, and then create a new metadata\
+            \ configuration.\n\n  * `DestinationTableNotFound` \\- The destination\
+            \ table doesn't exist. To create a new metadata table, you must delete\
+            \ the metadata configuration for this bucket, and then create a new metadata\
+            \ configuration.\n\n  * `ServerInternalError` \\- An internal error has\
+            \ occurred. To create a new metadata table, you must delete the metadata\
+            \ configuration for this bucket, and then create a new metadata configuration.\n\
+            \n  * `TableAlreadyExists` \\- The table that you specified already exists\
+            \ in the table bucket's namespace. Specify a different table name. To\
+            \ create a new metadata table, you must delete the metadata configuration\
+            \ for this bucket, and then create a new metadata configuration.\n\n \
+            \ * `TableBucketNotFound` \\- The table bucket that you specified doesn't\
+            \ exist in this Amazon Web Services Region and account. Create or choose\
+            \ a different table bucket. To create a new metadata table, you must delete\
+            \ the metadata configuration for this bucket, and then create a new metadata\
+            \ configuration.\n\nIf the V2 `CreateBucketMetadataConfiguration` request\
+            \ succeeds, but S3 Metadata was unable to create the table, this structure\
+            \ contains the error code. The possible error codes and error messages\
+            \ are as follows:\n\n  * `AccessDeniedCreatingResources` \\- You don't\
+            \ have sufficient permissions to create the required resources. Make sure\
+            \ that you have `s3tables:CreateTableBucket`, `s3tables:CreateNamespace`,\
+            \ `s3tables:CreateTable`, `s3tables:GetTable`, `s3tables:PutTablePolicy`,\
+            \ `kms:DescribeKey`, and `s3tables:PutTableEncryption` permissions. Additionally,\
+            \ ensure that the KMS key used to encrypt the table still exists, is active\
+            \ and has a resource policy granting access to the S3 service principals\
+            \ '`maintenance.s3tables.amazonaws.com`' and '`metadata.s3.amazonaws.com`'.\
+            \ To create a new metadata table, you must delete the metadata configuration\
+            \ for this bucket, and then create a new metadata configuration. \n\n\
+            \  * `AccessDeniedWritingToTable` \\- Unable to write to the metadata\
+            \ table because of missing resource permissions. To fix the resource policy,\
+            \ Amazon S3 needs to create a new metadata table. To create a new metadata\
+            \ table, you must delete the metadata configuration for this bucket, and\
+            \ then create a new metadata configuration.\n\n  * `DestinationTableNotFound`\
+            \ \\- The destination table doesn't exist. To create a new metadata table,\
+            \ you must delete the metadata configuration for this bucket, and then\
+            \ create a new metadata configuration.\n\n  * `ServerInternalError` \\\
+            - An internal error has occurred. To create a new metadata table, you\
+            \ must delete the metadata configuration for this bucket, and then create\
+            \ a new metadata configuration.\n\n  * `JournalTableAlreadyExists` \\\
+            - A journal table already exists in the Amazon Web Services managed table\
+            \ bucket's namespace. Delete the journal table, and then try again. To\
+            \ create a new metadata table, you must delete the metadata configuration\
+            \ for this bucket, and then create a new metadata configuration.\n\n \
+            \ * `InventoryTableAlreadyExists` \\- An inventory table already exists\
+            \ in the Amazon Web Services managed table bucket's namespace. Delete\
+            \ the inventory table, and then try again. To create a new metadata table,\
+            \ you must delete the metadata configuration for this bucket, and then\
+            \ create a new metadata configuration.\n\n  * `JournalTableNotAvailable`\
+            \ \\- The journal table that the inventory table relies on has a `FAILED`\
+            \ status. An inventory table requires a journal table with an `ACTIVE`\
+            \ status. To create a new journal or inventory table, you must delete\
+            \ the metadata configuration for this bucket, along with any journal or\
+            \ inventory tables, and then create a new metadata configuration.\n\n\
+            \  * `NoSuchBucket` \\- The specified general purpose bucket does not\
+            \ exist."
+        ErrorMessage:
+          $ref: '#/components/schemas/ErrorMessage'
+          description: "If the V1 `CreateBucketMetadataTableConfiguration` request\
+            \ succeeds, but S3 Metadata was unable to create the table, this structure\
+            \ contains the error message. The possible error codes and error messages\
+            \ are as follows:\n\n  * `AccessDeniedCreatingResources` \\- You don't\
+            \ have sufficient permissions to create the required resources. Make sure\
+            \ that you have `s3tables:CreateNamespace`, `s3tables:CreateTable`, `s3tables:GetTable`\
+            \ and `s3tables:PutTablePolicy` permissions, and then try again. To create\
+            \ a new metadata table, you must delete the metadata configuration for\
+            \ this bucket, and then create a new metadata configuration. \n\n  * `AccessDeniedWritingToTable`\
+            \ \\- Unable to write to the metadata table because of missing resource\
+            \ permissions. To fix the resource policy, Amazon S3 needs to create a\
+            \ new metadata table. To create a new metadata table, you must delete\
+            \ the metadata configuration for this bucket, and then create a new metadata\
+            \ configuration.\n\n  * `DestinationTableNotFound` \\- The destination\
+            \ table doesn't exist. To create a new metadata table, you must delete\
+            \ the metadata configuration for this bucket, and then create a new metadata\
+            \ configuration.\n\n  * `ServerInternalError` \\- An internal error has\
+            \ occurred. To create a new metadata table, you must delete the metadata\
+            \ configuration for this bucket, and then create a new metadata configuration.\n\
+            \n  * `TableAlreadyExists` \\- The table that you specified already exists\
+            \ in the table bucket's namespace. Specify a different table name. To\
+            \ create a new metadata table, you must delete the metadata configuration\
+            \ for this bucket, and then create a new metadata configuration.\n\n \
+            \ * `TableBucketNotFound` \\- The table bucket that you specified doesn't\
+            \ exist in this Amazon Web Services Region and account. Create or choose\
+            \ a different table bucket. To create a new metadata table, you must delete\
+            \ the metadata configuration for this bucket, and then create a new metadata\
+            \ configuration.\n\nIf the V2 `CreateBucketMetadataConfiguration` request\
+            \ succeeds, but S3 Metadata was unable to create the table, this structure\
+            \ contains the error code. The possible error codes and error messages\
+            \ are as follows:\n\n  * `AccessDeniedCreatingResources` \\- You don't\
+            \ have sufficient permissions to create the required resources. Make sure\
+            \ that you have `s3tables:CreateTableBucket`, `s3tables:CreateNamespace`,\
+            \ `s3tables:CreateTable`, `s3tables:GetTable`, `s3tables:PutTablePolicy`,\
+            \ `kms:DescribeKey`, and `s3tables:PutTableEncryption` permissions. Additionally,\
+            \ ensure that the KMS key used to encrypt the table still exists, is active\
+            \ and has a resource policy granting access to the S3 service principals\
+            \ '`maintenance.s3tables.amazonaws.com`' and '`metadata.s3.amazonaws.com`'.\
+            \ To create a new metadata table, you must delete the metadata configuration\
+            \ for this bucket, and then create a new metadata configuration. \n\n\
+            \  * `AccessDeniedWritingToTable` \\- Unable to write to the metadata\
+            \ table because of missing resource permissions. To fix the resource policy,\
+            \ Amazon S3 needs to create a new metadata table. To create a new metadata\
+            \ table, you must delete the metadata configuration for this bucket, and\
+            \ then create a new metadata configuration.\n\n  * `DestinationTableNotFound`\
+            \ \\- The destination table doesn't exist. To create a new metadata table,\
+            \ you must delete the metadata configuration for this bucket, and then\
+            \ create a new metadata configuration.\n\n  * `ServerInternalError` \\\
+            - An internal error has occurred. To create a new metadata table, you\
+            \ must delete the metadata configuration for this bucket, and then create\
+            \ a new metadata configuration.\n\n  * `JournalTableAlreadyExists` \\\
+            - A journal table already exists in the Amazon Web Services managed table\
+            \ bucket's namespace. Delete the journal table, and then try again. To\
+            \ create a new metadata table, you must delete the metadata configuration\
+            \ for this bucket, and then create a new metadata configuration.\n\n \
+            \ * `InventoryTableAlreadyExists` \\- An inventory table already exists\
+            \ in the Amazon Web Services managed table bucket's namespace. Delete\
+            \ the inventory table, and then try again. To create a new metadata table,\
+            \ you must delete the metadata configuration for this bucket, and then\
+            \ create a new metadata configuration.\n\n  * `JournalTableNotAvailable`\
+            \ \\- The journal table that the inventory table relies on has a `FAILED`\
+            \ status. An inventory table requires a journal table with an `ACTIVE`\
+            \ status. To create a new journal or inventory table, you must delete\
+            \ the metadata configuration for this bucket, along with any journal or\
+            \ inventory tables, and then create a new metadata configuration.\n\n\
+            \  * `NoSuchBucket` \\- The specified general purpose bucket does not\
+            \ exist."
+      description: 'If an S3 Metadata V1 `CreateBucketMetadataTableConfiguration`
+        or V2 `CreateBucketMetadataConfiguration` request succeeds, but S3 Metadata
+        was unable to create the table, this structure contains the error code and
+        error message.
+
+
+        If you created your S3 Metadata configuration before July 15, 2025, we recommend
+        that you delete and re-create your configuration by using [CreateBucketMetadataConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html)
+        so that you can expire journal table records and create a live inventory table.'
+    ErrorDocument:
+      type: object
+      properties:
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: 'The object key name to use when a 4XX class error occurs.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+      required:
+      - Key
+      description: The error information.
+    ErrorMessage:
+      type: string
+    Errors:
+      type: array
+      items:
+        $ref: '#/components/schemas/Error'
+    Event:
+      type: string
+      enum:
+      - s3:ReducedRedundancyLostObject
+      - s3:ObjectCreated:*
+      - s3:ObjectCreated:Put
+      - s3:ObjectCreated:Post
+      - s3:ObjectCreated:Copy
+      - s3:ObjectCreated:CompleteMultipartUpload
+      - s3:ObjectRemoved:*
+      - s3:ObjectRemoved:Delete
+      - s3:ObjectRemoved:DeleteMarkerCreated
+      - s3:ObjectRestore:*
+      - s3:ObjectRestore:Post
+      - s3:ObjectRestore:Completed
+      - s3:Replication:*
+      - s3:Replication:OperationFailedReplication
+      - s3:Replication:OperationNotTracked
+      - s3:Replication:OperationMissedThreshold
+      - s3:Replication:OperationReplicatedAfterThreshold
+      - s3:ObjectRestore:Delete
+      - s3:LifecycleTransition
+      - s3:IntelligentTiering
+      - s3:ObjectAcl:Put
+      - s3:LifecycleExpiration:*
+      - s3:LifecycleExpiration:Delete
+      - s3:LifecycleExpiration:DeleteMarkerCreated
+      - s3:ObjectTagging:*
+      - s3:ObjectTagging:Put
+      - s3:ObjectTagging:Delete
+      description: <p>The bucket event for which to send notifications.</p>
+    EventBridgeConfiguration:
+      type: object
+      properties: {}
+      description: A container for specifying the configuration for Amazon EventBridge.
+    EventList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Event'
+    ExistingObjectReplication:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/ExistingObjectReplicationStatus'
+          description: Specifies whether Amazon S3 replicates existing source bucket
+            objects.
+      required:
+      - Status
+      description: 'Optional configuration to replicate existing source bucket objects.
+
+
+        This parameter is no longer supported. To replicate existing objects, see
+        [Replicating existing objects with S3 Batch Replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-batch-replication-batch.html)
+        in the _Amazon S3 User Guide_.'
+    ExistingObjectReplicationStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    Expiration:
+      type: string
+    ExpirationState:
+      type: string
+      enum:
+      - ENABLED
+      - DISABLED
+    ExpirationStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    ExpiredObjectDeleteMarker:
+      type: boolean
+    Expires:
+      type: string
+    ExposeHeader:
+      type: string
+    ExposeHeaders:
+      type: array
+      items:
+        $ref: '#/components/schemas/ExposeHeader'
+    Expression:
+      type: string
+    ExpressionType:
+      type: string
+      enum:
+      - SQL
+    FetchOwner:
+      type: boolean
+    FieldDelimiter:
+      type: string
+    FileHeaderInfo:
+      type: string
+      enum:
+      - USE
+      - IGNORE
+      - NONE
+    FilterRule:
+      type: object
+      properties:
+        Name:
+          $ref: '#/components/schemas/FilterRuleName'
+          description: The object key name prefix or suffix identifying one or more
+            objects to which the filtering rule applies. The maximum length is 1,024
+            characters. Overlapping prefixes and suffixes are not supported. For more
+            information, see [Configuring Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+            in the _Amazon S3 User Guide_.
+        Value:
+          $ref: '#/components/schemas/FilterRuleValue'
+          description: The value that the filter searches for in object key names.
+      description: Specifies the Amazon S3 object key name to filter on. An object
+        key name is the name assigned to an object in your Amazon S3 bucket. You specify
+        whether to filter on the suffix or prefix of the object key name. A prefix
+        is a specific string of characters at the beginning of an object key name,
+        which you can use to organize objects. For example, you can start the key
+        names of related objects with a prefix, such as `2023-` or `engineering/`.
+        Then, you can use `FilterRule` to find objects in a bucket with key names
+        that have the same prefix. A suffix is similar to a prefix, but it is at the
+        end of the object key name instead of at the beginning.
+    FilterRuleList:
+      type: array
+      items:
+        $ref: '#/components/schemas/FilterRule'
+      description: <p>A list of containers for the key-value pair that defines the
+        criteria for the filter rule.</p>
+    FilterRuleName:
+      type: string
+      enum:
+      - prefix
+      - suffix
+    FilterRuleValue:
+      type: string
+    GetBucketAbacOutput:
+      type: object
+      properties:
+        AbacStatus:
+          $ref: '#/components/schemas/AbacStatus'
+          description: The ABAC status of the general purpose bucket.
+    GetBucketAbacRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the general purpose bucket.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The Amazon Web Services account ID of the general purpose bucket's
+            owner.
+      required:
+      - Bucket
+    GetBucketAccelerateConfigurationOutput:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/BucketAccelerateStatus'
+          description: The accelerate configuration of the bucket.
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    GetBucketAccelerateConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which the accelerate configuration
+            is retrieved.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+      required:
+      - Bucket
+    GetBucketAclOutput:
+      type: object
+      properties:
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: Container for the bucket owner's ID.
+        Grants:
+          $ref: '#/components/schemas/Grants'
+          description: A list of grants.
+    GetBucketAclRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'Specifies the S3 bucket whose ACL is being requested.
+
+
+            When you use this API operation with an access point, provide the alias
+            of the access point in place of the bucket name.
+
+
+            When you use this API operation with an Object Lambda access point, provide
+            the alias of the Object Lambda access point in place of the bucket name.
+            If the Object Lambda access point alias in a request is not valid, the
+            error code `InvalidAccessPointAliasError` is returned. For more information
+            about `InvalidAccessPointAliasError`, see [List of Error Codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketAnalyticsConfigurationOutput:
+      type: object
+      properties:
+        AnalyticsConfiguration:
+          $ref: '#/components/schemas/AnalyticsConfiguration'
+          description: The configuration and any analyses for the analytics filter.
+    GetBucketAnalyticsConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket from which an analytics configuration
+            is retrieved.
+        Id:
+          $ref: '#/components/schemas/AnalyticsId'
+          description: The ID that identifies the analytics configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    GetBucketCorsOutput:
+      type: object
+      properties:
+        CORSRules:
+          $ref: '#/components/schemas/CORSRules'
+          description: A set of origins and methods (cross-origin access that you
+            want to allow). You can add up to 100 rules to the configuration.
+    GetBucketCorsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name for which to get the cors configuration.
+
+
+            When you use this API operation with an access point, provide the alias
+            of the access point in place of the bucket name.
+
+
+            When you use this API operation with an Object Lambda access point, provide
+            the alias of the Object Lambda access point in place of the bucket name.
+            If the Object Lambda access point alias in a request is not valid, the
+            error code `InvalidAccessPointAliasError` is returned. For more information
+            about `InvalidAccessPointAliasError`, see [List of Error Codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketEncryptionOutput:
+      type: object
+      properties:
+        ServerSideEncryptionConfiguration:
+          $ref: '#/components/schemas/ServerSideEncryptionConfiguration'
+    GetBucketEncryptionRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket from which the server-side encryption
+            configuration is retrieved.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            For directory buckets, this header is not supported in this API operation.
+            If you specify this header, the request fails with the HTTP status code
+            `501 Not Implemented`.'
+      required:
+      - Bucket
+    GetBucketIntelligentTieringConfigurationOutput:
+      type: object
+      properties:
+        IntelligentTieringConfiguration:
+          $ref: '#/components/schemas/IntelligentTieringConfiguration'
+          description: Container for S3 Intelligent-Tiering configuration.
+    GetBucketIntelligentTieringConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose configuration you want
+            to modify or retrieve.
+        Id:
+          $ref: '#/components/schemas/IntelligentTieringId'
+          description: The ID used to identify the S3 Intelligent-Tiering configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    GetBucketInventoryConfigurationOutput:
+      type: object
+      properties:
+        InventoryConfiguration:
+          $ref: '#/components/schemas/InventoryConfiguration'
+          description: Specifies the inventory configuration.
+    GetBucketInventoryConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket containing the inventory configuration
+            to retrieve.
+        Id:
+          $ref: '#/components/schemas/InventoryId'
+          description: The ID used to identify the inventory configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    GetBucketLifecycleConfigurationOutput:
+      type: object
+      properties:
+        Rules:
+          $ref: '#/components/schemas/LifecycleRules'
+          description: Container for a lifecycle rule.
+        TransitionDefaultMinimumObjectSize:
+          $ref: '#/components/schemas/TransitionDefaultMinimumObjectSize'
+          description: "Indicates which default minimum object size behavior is applied\
+            \ to the lifecycle configuration.\n\nThis parameter applies to general\
+            \ purpose buckets only. It isn't supported for directory bucket lifecycle\
+            \ configurations.\n\n  * `all_storage_classes_128K` \\- Objects smaller\
+            \ than 128 KB will not transition to any storage class by default.\n\n\
+            \  * `varies_by_storage_class` \\- Objects smaller than 128 KB will transition\
+            \ to Glacier Flexible Retrieval or Glacier Deep Archive storage classes.\
+            \ By default, all other storage classes will prevent transitions smaller\
+            \ than 128 KB. \n\nTo customize the minimum object size for any transition\
+            \ you can add a filter that specifies a custom `ObjectSizeGreaterThan`\
+            \ or `ObjectSizeLessThan` in the body of your transition rule. Custom\
+            \ filters always take precedence over the default transition behavior."
+    GetBucketLifecycleConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which to get the lifecycle information.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+      required:
+      - Bucket
+    GetBucketLocationOutput:
+      type: object
+      properties:
+        LocationConstraint:
+          $ref: '#/components/schemas/BucketLocationConstraint'
+          description: 'Specifies the Region where the bucket resides. For a list
+            of all the Amazon S3 supported location constraints by Region, see [Regions
+            and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+
+
+            Buckets in Region `us-east-1` have a LocationConstraint of `null`. Buckets
+            with a LocationConstraint of `EU` reside in `eu-west-1`.'
+    GetBucketLocationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket for which to get the location.
+
+
+            When you use this API operation with an access point, provide the alias
+            of the access point in place of the bucket name.
+
+
+            When you use this API operation with an Object Lambda access point, provide
+            the alias of the Object Lambda access point in place of the bucket name.
+            If the Object Lambda access point alias in a request is not valid, the
+            error code `InvalidAccessPointAliasError` is returned. For more information
+            about `InvalidAccessPointAliasError`, see [List of Error Codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketLoggingOutput:
+      type: object
+      properties:
+        LoggingEnabled:
+          $ref: '#/components/schemas/LoggingEnabled'
+    GetBucketLoggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name for which to get the logging information.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketMetadataConfigurationOutput:
+      type: object
+      properties:
+        GetBucketMetadataConfigurationResult:
+          $ref: '#/components/schemas/GetBucketMetadataConfigurationResult'
+          description: The metadata configuration for the general purpose bucket.
+    GetBucketMetadataConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that corresponds to the metadata
+            configuration that you want to retrieve.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected owner of the general purpose bucket that you want
+            to retrieve the metadata table configuration for.
+      required:
+      - Bucket
+    GetBucketMetadataConfigurationResult:
+      type: object
+      properties:
+        MetadataConfigurationResult:
+          $ref: '#/components/schemas/MetadataConfigurationResult'
+          description: The metadata configuration for a general purpose bucket.
+      required:
+      - MetadataConfigurationResult
+      description: The S3 Metadata configuration for a general purpose bucket.
+    GetBucketMetadataTableConfigurationOutput:
+      type: object
+      properties:
+        GetBucketMetadataTableConfigurationResult:
+          $ref: '#/components/schemas/GetBucketMetadataTableConfigurationResult'
+          description: The metadata table configuration for the general purpose bucket.
+    GetBucketMetadataTableConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that corresponds to the metadata
+            table configuration that you want to retrieve.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected owner of the general purpose bucket that you want
+            to retrieve the metadata table configuration for.
+      required:
+      - Bucket
+    GetBucketMetadataTableConfigurationResult:
+      type: object
+      properties:
+        MetadataTableConfigurationResult:
+          $ref: '#/components/schemas/MetadataTableConfigurationResult'
+          description: The V1 S3 Metadata configuration for a general purpose bucket.
+        Status:
+          $ref: '#/components/schemas/MetadataTableStatus'
+          description: "The status of the metadata table. The status values are:\n\
+            \n  * `CREATING` \\- The metadata table is in the process of being created\
+            \ in the specified table bucket.\n\n  * `ACTIVE` \\- The metadata table\
+            \ has been created successfully, and records are being delivered to the\
+            \ table. \n\n  * `FAILED` \\- Amazon S3 is unable to create the metadata\
+            \ table, or Amazon S3 is unable to deliver records. See `ErrorDetails`\
+            \ for details."
+        Error:
+          $ref: '#/components/schemas/ErrorDetails'
+          description: If the `CreateBucketMetadataTableConfiguration` request succeeds,
+            but S3 Metadata was unable to create the table, this structure contains
+            the error code and error message.
+      required:
+      - MetadataTableConfigurationResult
+      - Status
+      description: 'The V1 S3 Metadata configuration for a general purpose bucket.
+
+
+        If you created your S3 Metadata configuration before July 15, 2025, we recommend
+        that you delete and re-create your configuration by using [CreateBucketMetadataConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html)
+        so that you can expire journal table records and create a live inventory table.'
+    GetBucketMetricsConfigurationOutput:
+      type: object
+      properties:
+        MetricsConfiguration:
+          $ref: '#/components/schemas/MetricsConfiguration'
+          description: Specifies the metrics configuration.
+    GetBucketMetricsConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket containing the metrics configuration
+            to retrieve.
+        Id:
+          $ref: '#/components/schemas/MetricsId'
+          description: The ID used to identify the metrics configuration. The ID has
+            a 64 character limit and can only contain letters, numbers, periods, dashes,
+            and underscores.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+    GetBucketNotificationConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket for which to get the notification configuration.
+
+
+            When you use this API operation with an access point, provide the alias
+            of the access point in place of the bucket name.
+
+
+            When you use this API operation with an Object Lambda access point, provide
+            the alias of the Object Lambda access point in place of the bucket name.
+            If the Object Lambda access point alias in a request is not valid, the
+            error code `InvalidAccessPointAliasError` is returned. For more information
+            about `InvalidAccessPointAliasError`, see [List of Error Codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketOwnershipControlsOutput:
+      type: object
+      properties:
+        OwnershipControls:
+          $ref: '#/components/schemas/OwnershipControls'
+          description: The `OwnershipControls` (BucketOwnerEnforced, BucketOwnerPreferred,
+            or ObjectWriter) currently in effect for this Amazon S3 bucket.
+    GetBucketOwnershipControlsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose `OwnershipControls`
+            you want to retrieve.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketPolicyOutput:
+      type: object
+      properties:
+        Policy:
+          $ref: '#/components/schemas/Policy'
+          description: The bucket policy as a JSON document.
+    GetBucketPolicyRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name to get the bucket policy for.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_
+
+
+            **Access points** \- When you use this API operation with an access point,
+            provide the alias of the access point in place of the bucket name.
+
+
+            **Object Lambda access points** \- When you use this API operation with
+            an Object Lambda access point, provide the alias of the Object Lambda
+            access point in place of the bucket name. If the Object Lambda access
+            point alias in a request is not valid, the error code `InvalidAccessPointAliasError`
+            is returned. For more information about `InvalidAccessPointAliasError`,
+            see [List of Error Codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).
+
+
+            Object Lambda access points are not supported by directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            For directory buckets, this header is not supported in this API operation.
+            If you specify this header, the request fails with the HTTP status code
+            `501 Not Implemented`.'
+      required:
+      - Bucket
+    GetBucketPolicyStatusOutput:
+      type: object
+      properties:
+        PolicyStatus:
+          $ref: '#/components/schemas/PolicyStatus'
+          description: The policy status for the specified bucket.
+    GetBucketPolicyStatusRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose policy status you want
+            to retrieve.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketReplicationOutput:
+      type: object
+      properties:
+        ReplicationConfiguration:
+          $ref: '#/components/schemas/ReplicationConfiguration'
+    GetBucketReplicationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name for which to get the replication information.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketRequestPaymentOutput:
+      type: object
+      properties:
+        Payer:
+          $ref: '#/components/schemas/Payer'
+          description: Specifies who pays for the download and request fees.
+    GetBucketRequestPaymentRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which to get the payment request
+            configuration
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketTaggingOutput:
+      type: object
+      properties:
+        TagSet:
+          $ref: '#/components/schemas/TagSet'
+          description: Contains the tag set.
+      required:
+      - TagSet
+    GetBucketTaggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which to get the tagging information.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketVersioningOutput:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/BucketVersioningStatus'
+          description: The versioning state of the bucket.
+        MFADelete:
+          $ref: '#/components/schemas/MFADeleteStatus'
+          description: Specifies whether MFA delete is enabled in the bucket versioning
+            configuration. This element is only returned if the bucket has been configured
+            with MFA delete. If the bucket has never been so configured, this element
+            is not returned.
+    GetBucketVersioningRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which to get the versioning information.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetBucketWebsiteOutput:
+      type: object
+      properties:
+        RedirectAllRequestsTo:
+          $ref: '#/components/schemas/RedirectAllRequestsTo'
+          description: Specifies the redirect behavior of all requests to a website
+            endpoint of an Amazon S3 bucket.
+        IndexDocument:
+          $ref: '#/components/schemas/IndexDocument'
+          description: The name of the index document for the website (for example
+            `index.html`).
+        ErrorDocument:
+          $ref: '#/components/schemas/ErrorDocument'
+          description: The object key name of the website error document to use for
+            4XX class errors.
+        RoutingRules:
+          $ref: '#/components/schemas/RoutingRules'
+          description: Rules that define when a redirect is applied and the redirect
+            behavior.
+    GetBucketWebsiteRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name for which to get the website configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetObjectAclOutput:
+      type: object
+      properties:
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: Container for the bucket owner's ID.
+        Grants:
+          $ref: '#/components/schemas/Grants'
+          description: A list of grants.
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    GetObjectAclRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name that contains the object for which to get
+            the ACL information.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The key of the object for which to get the ACL information.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID used to reference a specific version of the object.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    GetObjectAttributesOutput:
+      type: object
+      properties:
+        DeleteMarker:
+          $ref: '#/components/schemas/DeleteMarker'
+          description: 'Specifies whether the object retrieved was (`true`) or was
+            not (`false`) a delete marker. If `false`, this response header does not
+            appear in the response. To learn more about delete markers, see [Working
+            with delete markers](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html).
+
+
+            This functionality is not supported for directory buckets.'
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Date and time when the object was last modified.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'The version ID of the object.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: An ETag is an opaque identifier assigned by a web server to
+            a specific version of a resource found at a URL.
+        Checksum:
+          $ref: '#/components/schemas/Checksum'
+          description: The checksum or digest of the object.
+        ObjectParts:
+          $ref: '#/components/schemas/GetObjectAttributesParts'
+          description: A collection of parts associated with a multipart upload.
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: 'Provides the storage class information of the object. Amazon
+            S3 returns this header for all objects except for S3 Standard storage
+            class objects.
+
+
+            For more information, see [Storage Classes](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html).
+
+
+            **Directory buckets** \- Directory buckets only support `EXPRESS_ONEZONE`
+            (the S3 Express One Zone storage class) in Availability Zones and `ONEZONE_IA`
+            (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.'
+        ObjectSize:
+          $ref: '#/components/schemas/ObjectSize'
+          description: The size of the object in bytes.
+    GetObjectAttributesParts:
+      type: object
+      properties:
+        TotalPartsCount:
+          $ref: '#/components/schemas/PartsCount'
+          description: The total number of parts.
+        PartNumberMarker:
+          $ref: '#/components/schemas/PartNumberMarker'
+          description: The marker for the current part.
+        NextPartNumberMarker:
+          $ref: '#/components/schemas/NextPartNumberMarker'
+          description: When a list is truncated, this element specifies the last part
+            in the list, as well as the value to use for the `PartNumberMarker` request
+            parameter in a subsequent request.
+        MaxParts:
+          $ref: '#/components/schemas/MaxParts'
+          description: The maximum number of parts allowed in the response.
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Indicates whether the returned list of parts is truncated.
+            A value of `true` indicates that the list was truncated. A list can be
+            truncated if the number of parts exceeds the limit returned in the `MaxParts`
+            element.
+        Parts:
+          $ref: '#/components/schemas/PartsList'
+          description: "A container for elements related to a particular part. A response\
+            \ can contain zero or more `Parts` elements.\n\n  * **General purpose\
+            \ buckets** \\- For `GetObjectAttributes`, if an additional checksum (including\
+            \ `x-amz-checksum-crc32`, `x-amz-checksum-crc32c`, `x-amz-checksum-sha1`,\
+            \ or `x-amz-checksum-sha256`) isn't applied to the object specified in\
+            \ the request, the response doesn't return the `Part` element.\n\n  *\
+            \ **Directory buckets** \\- For `GetObjectAttributes`, regardless of whether\
+            \ an additional checksum is applied to the object specified in the request,\
+            \ the response returns the `Part` element."
+      description: A collection of parts associated with a multipart upload.
+    GetObjectAttributesRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket that contains the object.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The object key.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'The version ID used to reference a specific version of the
+            object.
+
+
+            S3 Versioning isn''t enabled and supported for directory buckets. For
+            this API operation, only the `null` value of the version ID is supported
+            by directory buckets. You can only specify `null` to the `versionId` query
+            parameter in the request.'
+        MaxParts:
+          $ref: '#/components/schemas/MaxParts'
+          description: Sets the maximum number of parts to return. For more information,
+            see [Uploading and copying objects using multipart upload in Amazon S3
+            ](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html)
+            in the _Amazon Simple Storage Service user guide_.
+        PartNumberMarker:
+          $ref: '#/components/schemas/PartNumberMarker'
+          description: Specifies the part after which listing should begin. Only parts
+            with higher part numbers will be listed. For more information, see [Uploading
+            and copying objects using multipart upload in Amazon S3 ](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html)
+            in the _Amazon Simple Storage Service user guide_.
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when encrypting the object
+            (for example, AES256).
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use in encrypting data. This value is used to store the object and
+            then it is discarded; Amazon S3 does not store the encryption key. The
+            key must be appropriate for use with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm`
+            header.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        ObjectAttributes:
+          $ref: '#/components/schemas/ObjectAttributesList'
+          description: Specifies the fields at the root level that you want returned
+            in the response. Fields that you do not specify are not returned.
+      required:
+      - Bucket
+      - Key
+      - ObjectAttributes
+    GetObjectLegalHoldOutput:
+      type: object
+      properties:
+        LegalHold:
+          $ref: '#/components/schemas/ObjectLockLegalHold'
+          description: The current legal hold status for the specified object.
+    GetObjectLegalHoldRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the object whose legal hold status
+            you want to retrieve.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The key name for the object whose legal hold status you want
+            to retrieve.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The version ID of the object whose legal hold status you want
+            to retrieve.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    GetObjectLockConfigurationOutput:
+      type: object
+      properties:
+        ObjectLockConfiguration:
+          $ref: '#/components/schemas/ObjectLockConfiguration'
+          description: The specified bucket's Object Lock configuration.
+    GetObjectLockConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket whose Object Lock configuration you want to retrieve.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GetObjectOutput:
+      type: object
+      properties:
+        Body:
+          $ref: '#/components/schemas/StreamingBlob'
+          description: Object data.
+        DeleteMarker:
+          $ref: '#/components/schemas/DeleteMarker'
+          description: "Indicates whether the object retrieved was (true) or was not\
+            \ (false) a Delete Marker. If false, this response header does not appear\
+            \ in the response.\n\n  * If the current version of the object is a delete\
+            \ marker, Amazon S3 behaves as if the object was deleted and includes\
+            \ `x-amz-delete-marker: true` in the response.\n\n  * If the specified\
+            \ version in the request is a delete marker, the response returns a `405\
+            \ Method Not Allowed` error and the `Last-Modified: timestamp` response\
+            \ header."
+        AcceptRanges:
+          $ref: '#/components/schemas/AcceptRanges'
+          description: Indicates that a range of bytes was specified in the request.
+        Expiration:
+          $ref: '#/components/schemas/Expiration'
+          description: 'If the object expiration is configured (see [ `PutBucketLifecycleConfiguration`
+            ](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html)),
+            the response includes this header. It includes the `expiry-date` and `rule-id`
+            key-value pairs providing object expiration information. The value of
+            the `rule-id` is URL-encoded.
+
+
+            Object expiration information is not returned in directory buckets and
+            this header returns the value "`NotImplemented`" in all responses for
+            directory buckets.'
+        Restore:
+          $ref: '#/components/schemas/Restore'
+          description: 'Provides information about object restoration action and expiration
+            time of the restored object copy.
+
+
+            This functionality is not supported for directory buckets. Directory buckets
+            only support `EXPRESS_ONEZONE` (the S3 Express One Zone storage class)
+            in Availability Zones and `ONEZONE_IA` (the S3 One Zone-Infrequent Access
+            storage class) in Dedicated Local Zones.'
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: 'Date and time when the object was last modified.
+
+
+            **General purpose buckets** \- When you specify a `versionId` of the object
+            in your request, if the specified version in the request is a delete marker,
+            the response returns a `405 Method Not Allowed` error and the `Last-Modified:
+            timestamp` response header.'
+        ContentLength:
+          $ref: '#/components/schemas/ContentLength'
+          description: Size of the body in bytes.
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: An entity tag (ETag) is an opaque identifier assigned by a
+            web server to a specific version of a resource found at a URL.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32` checksum of the object.
+            This checksum is only present if the object was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the object.
+            For more information, see [Checking object integrity in the Amazon S3
+            User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` digest of the object. This
+            checksum is only present if the checksum was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` digest of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type, which determines how part-level checksums
+            are combined to create an object-level checksum for multipart objects.
+            You can use this header response to verify that the checksum type that
+            is received is the same checksum type that was specified in the `CreateMultipartUpload`
+            request. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        MissingMeta:
+          $ref: '#/components/schemas/MissingMeta'
+          description: 'This is set to the number of metadata entries not returned
+            in the headers that are prefixed with `x-amz-meta-`. This can happen if
+            you create metadata using an API like SOAP that supports more flexible
+            metadata than the REST API. For example, using SOAP, you can create metadata
+            whose values are not legal HTTP headers.
+
+
+            This functionality is not supported for directory buckets.'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID of the object.
+
+
+            This functionality is not supported for directory buckets.'
+        CacheControl:
+          $ref: '#/components/schemas/CacheControl'
+          description: Specifies caching behavior along the request/reply chain.
+        ContentDisposition:
+          $ref: '#/components/schemas/ContentDisposition'
+          description: Specifies presentational information for the object.
+        ContentEncoding:
+          $ref: '#/components/schemas/ContentEncoding'
+          description: Indicates what content encodings have been applied to the object
+            and thus what decoding mechanisms must be applied to obtain the media-type
+            referenced by the Content-Type header field.
+        ContentLanguage:
+          $ref: '#/components/schemas/ContentLanguage'
+          description: The language the content is in.
+        ContentRange:
+          $ref: '#/components/schemas/ContentRange'
+          description: The portion of the object returned in the response.
+        ContentType:
+          $ref: '#/components/schemas/ContentType'
+          description: A standard MIME type describing the format of the object data.
+        Expires:
+          $ref: '#/components/schemas/Expires'
+          description: The date and time at which the object is no longer cacheable.
+        WebsiteRedirectLocation:
+          $ref: '#/components/schemas/WebsiteRedirectLocation'
+          description: 'If the bucket is configured as a website, redirects requests
+            for this object to another object in the same bucket or to an external
+            URL. Amazon S3 stores the value of this header in the object metadata.
+
+
+            This functionality is not supported for directory buckets.'
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store this
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        Metadata:
+          $ref: '#/components/schemas/Metadata'
+          description: A map of metadata to store with the object in S3.
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to confirm the
+            encryption algorithm that''s used.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to provide the
+            round-trip message integrity verification of the customer-provided encryption
+            key.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the object uses an S3 Bucket Key for server-side
+            encryption with Key Management Service (KMS) keys (SSE-KMS).
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: 'Provides storage class information of the object. Amazon S3
+            returns this header for all objects except for S3 Standard storage class
+            objects.
+
+
+            **Directory buckets** \- Directory buckets only support `EXPRESS_ONEZONE`
+            (the S3 Express One Zone storage class) in Availability Zones and `ONEZONE_IA`
+            (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        ReplicationStatus:
+          $ref: '#/components/schemas/ReplicationStatus'
+          description: 'Amazon S3 can return this if your request involves a bucket
+            that is either a source or destination in a replication rule.
+
+
+            This functionality is not supported for directory buckets.'
+        PartsCount:
+          $ref: '#/components/schemas/PartsCount'
+          description: The count of parts this object has. This value is only returned
+            if you specify `partNumber` in your request and the object was uploaded
+            as a multipart upload.
+        TagCount:
+          $ref: '#/components/schemas/TagCount'
+          description: 'The number of tags, if any, on the object, when you have the
+            relevant permission to read object tags.
+
+
+            You can use [GetObjectTagging](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html)
+            to retrieve the tag set associated with an object.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockMode:
+          $ref: '#/components/schemas/ObjectLockMode'
+          description: 'The Object Lock mode that''s currently in place for this object.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockRetainUntilDate:
+          $ref: '#/components/schemas/ObjectLockRetainUntilDate'
+          description: 'The date and time when this object''s Object Lock will expire.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockLegalHoldStatus:
+          $ref: '#/components/schemas/ObjectLockLegalHoldStatus'
+          description: 'Indicates whether this object has an active legal hold. This
+            field is only returned if you have permission to view an object''s legal
+            hold status.
+
+
+            This functionality is not supported for directory buckets.'
+    GetObjectRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the object.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Object Lambda access points** \- When you use this action with an Object
+            Lambda access point, you must direct requests to the Object Lambda access
+            point hostname. The Object Lambda access point hostname takes the form
+            _AccessPointName_ -_AccountId_.s3-object-lambda._Region_.amazonaws.com.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        IfMatch:
+          $ref: '#/components/schemas/IfMatch'
+          description: 'Return the object only if its entity tag (ETag) is the same
+            as the one specified in this header; otherwise, return a `412 Precondition
+            Failed` error.
+
+
+            If both of the `If-Match` and `If-Unmodified-Since` headers are present
+            in the request as follows: `If-Match` condition evaluates to `true`, and;
+            `If-Unmodified-Since` condition evaluates to `false`; then, S3 returns
+            `200 OK` and the data requested.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232).'
+        IfModifiedSince:
+          $ref: '#/components/schemas/IfModifiedSince'
+          description: 'Return the object only if it has been modified since the specified
+            time; otherwise, return a `304 Not Modified` error.
+
+
+            If both of the `If-None-Match` and `If-Modified-Since` headers are present
+            in the request as follows:` If-None-Match` condition evaluates to `false`,
+            and; `If-Modified-Since` condition evaluates to `true`; then, S3 returns
+            `304 Not Modified` status code.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232).'
+        IfNoneMatch:
+          $ref: '#/components/schemas/IfNoneMatch'
+          description: 'Return the object only if its entity tag (ETag) is different
+            from the one specified in this header; otherwise, return a `304 Not Modified`
+            error.
+
+
+            If both of the `If-None-Match` and `If-Modified-Since` headers are present
+            in the request as follows:` If-None-Match` condition evaluates to `false`,
+            and; `If-Modified-Since` condition evaluates to `true`; then, S3 returns
+            `304 Not Modified` HTTP status code.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232).'
+        IfUnmodifiedSince:
+          $ref: '#/components/schemas/IfUnmodifiedSince'
+          description: 'Return the object only if it has not been modified since the
+            specified time; otherwise, return a `412 Precondition Failed` error.
+
+
+            If both of the `If-Match` and `If-Unmodified-Since` headers are present
+            in the request as follows: `If-Match` condition evaluates to `true`, and;
+            `If-Unmodified-Since` condition evaluates to `false`; then, S3 returns
+            `200 OK` and the data requested.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232).'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Key of the object to get.
+        Range:
+          $ref: '#/components/schemas/Range'
+          description: 'Downloads the specified byte range of an object. For more
+            information about the HTTP Range header, see <https://www.rfc-editor.org/rfc/rfc9110.html#name-range>.
+
+
+            Amazon S3 doesn''t support retrieving multiple ranges of data per `GET`
+            request.'
+        ResponseCacheControl:
+          $ref: '#/components/schemas/ResponseCacheControl'
+          description: Sets the `Cache-Control` header of the response.
+        ResponseContentDisposition:
+          $ref: '#/components/schemas/ResponseContentDisposition'
+          description: Sets the `Content-Disposition` header of the response.
+        ResponseContentEncoding:
+          $ref: '#/components/schemas/ResponseContentEncoding'
+          description: Sets the `Content-Encoding` header of the response.
+        ResponseContentLanguage:
+          $ref: '#/components/schemas/ResponseContentLanguage'
+          description: Sets the `Content-Language` header of the response.
+        ResponseContentType:
+          $ref: '#/components/schemas/ResponseContentType'
+          description: Sets the `Content-Type` header of the response.
+        ResponseExpires:
+          $ref: '#/components/schemas/ResponseExpires'
+          description: Sets the `Expires` header of the response.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: "Version ID used to reference a specific version of the object.\n\
+            \nBy default, the `GetObject` operation returns the current version of\
+            \ an object. To return a different version, use the `versionId` subresource.\n\
+            \n  * If you include a `versionId` in your request header, you must have\
+            \ the `s3:GetObjectVersion` permission to access a specific version of\
+            \ an object. The `s3:GetObject` permission is not required in this scenario.\n\
+            \n  * If you request the current version of an object without a specific\
+            \ `versionId` in the request header, only the `s3:GetObject` permission\
+            \ is required. The `s3:GetObjectVersion` permission is not required in\
+            \ this scenario.\n\n  * **Directory buckets** \\- S3 Versioning isn't\
+            \ enabled and supported for directory buckets. For this API operation,\
+            \ only the `null` value of the version ID is supported by directory buckets.\
+            \ You can only specify `null` to the `versionId` query parameter in the\
+            \ request.\n\nFor more information about versioning, see [PutBucketVersioning](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html)."
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: "Specifies the algorithm to use when decrypting the object\
+            \ (for example, `AES256`).\n\nIf you encrypt an object by using server-side\
+            \ encryption with customer-provided encryption keys (SSE-C) when you store\
+            \ the object in Amazon S3, then when you GET the object, you must use\
+            \ the following headers:\n\n  * `x-amz-server-side-encryption-customer-algorithm`\n\
+            \n  * `x-amz-server-side-encryption-customer-key`\n\n  * `x-amz-server-side-encryption-customer-key-MD5`\n\
+            \nFor more information about SSE-C, see [Server-Side Encryption (Using\
+            \ Customer-Provided Encryption Keys)](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)\
+            \ in the _Amazon S3 User Guide_.\n\nThis functionality is not supported\
+            \ for directory buckets."
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: "Specifies the customer-provided encryption key that you originally\
+            \ provided for Amazon S3 to encrypt the data before storing it. This value\
+            \ is used to decrypt the object when recovering it and must match the\
+            \ one used when storing the data. The key must be appropriate for use\
+            \ with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm`\
+            \ header.\n\nIf you encrypt an object by using server-side encryption\
+            \ with customer-provided encryption keys (SSE-C) when you store the object\
+            \ in Amazon S3, then when you GET the object, you must use the following\
+            \ headers:\n\n  * `x-amz-server-side-encryption-customer-algorithm`\n\n\
+            \  * `x-amz-server-side-encryption-customer-key`\n\n  * `x-amz-server-side-encryption-customer-key-MD5`\n\
+            \nFor more information about SSE-C, see [Server-Side Encryption (Using\
+            \ Customer-Provided Encryption Keys)](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)\
+            \ in the _Amazon S3 User Guide_.\n\nThis functionality is not supported\
+            \ for directory buckets."
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: "Specifies the 128-bit MD5 digest of the customer-provided\
+            \ encryption key according to RFC 1321. Amazon S3 uses this header for\
+            \ a message integrity check to ensure that the encryption key was transmitted\
+            \ without error.\n\nIf you encrypt an object by using server-side encryption\
+            \ with customer-provided encryption keys (SSE-C) when you store the object\
+            \ in Amazon S3, then when you GET the object, you must use the following\
+            \ headers:\n\n  * `x-amz-server-side-encryption-customer-algorithm`\n\n\
+            \  * `x-amz-server-side-encryption-customer-key`\n\n  * `x-amz-server-side-encryption-customer-key-MD5`\n\
+            \nFor more information about SSE-C, see [Server-Side Encryption (Using\
+            \ Customer-Provided Encryption Keys)](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)\
+            \ in the _Amazon S3 User Guide_.\n\nThis functionality is not supported\
+            \ for directory buckets."
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        PartNumber:
+          $ref: '#/components/schemas/PartNumber'
+          description: Part number of the object being read. This is a positive integer
+            between 1 and 10,000. Effectively performs a 'ranged' GET request for
+            the part specified. Useful for downloading just a part of an object.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        ChecksumMode:
+          $ref: '#/components/schemas/ChecksumMode'
+          description: To retrieve the checksum, this mode must be enabled.
+      required:
+      - Bucket
+      - Key
+    GetObjectResponseStatusCode:
+      type: integer
+    GetObjectRetentionOutput:
+      type: object
+      properties:
+        Retention:
+          $ref: '#/components/schemas/ObjectLockRetention'
+          description: The container element for an object's retention settings.
+    GetObjectRetentionRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the object whose retention settings
+            you want to retrieve.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The key name for the object whose retention settings you want
+            to retrieve.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The version ID for the object whose retention settings you
+            want to retrieve.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    GetObjectTaggingOutput:
+      type: object
+      properties:
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The versionId of the object for which you got the tagging information.
+        TagSet:
+          $ref: '#/components/schemas/TagSet'
+          description: Contains the tag set.
+      required:
+      - TagSet
+    GetObjectTaggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the object for which to get the
+            tagging information.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which to get the tagging information.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The versionId of the object for which to get the tagging information.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+      required:
+      - Bucket
+      - Key
+    GetObjectTorrentOutput:
+      type: object
+      properties:
+        Body:
+          $ref: '#/components/schemas/StreamingBlob'
+          description: A Bencoded dictionary as defined by the BitTorrent specification
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    GetObjectTorrentRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket containing the object for which to get
+            the torrent files.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The object key for which to get the information.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    GetPublicAccessBlockOutput:
+      type: object
+      properties:
+        PublicAccessBlockConfiguration:
+          $ref: '#/components/schemas/PublicAccessBlockConfiguration'
+          description: The `PublicAccessBlock` configuration currently in effect for
+            this Amazon S3 bucket.
+    GetPublicAccessBlockRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose `PublicAccessBlock`
+            configuration you want to retrieve.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    GlacierJobParameters:
+      type: object
+      properties:
+        Tier:
+          $ref: '#/components/schemas/Tier'
+          description: Retrieval tier at which the restore will be processed.
+      required:
+      - Tier
+      description: Container for S3 Glacier job parameters.
+    Grant:
+      type: object
+      properties:
+        Grantee:
+          $ref: '#/components/schemas/Grantee'
+          description: The person being granted permissions.
+        Permission:
+          $ref: '#/components/schemas/Permission'
+          description: Specifies the permission given to the grantee.
+      description: Container for grant information.
+    GrantFullControl:
+      type: string
+    GrantRead:
+      type: string
+    GrantReadACP:
+      type: string
+    GrantWrite:
+      type: string
+    GrantWriteACP:
+      type: string
+    Grantee:
+      type: object
+      properties:
+        DisplayName:
+          $ref: '#/components/schemas/DisplayName'
+          description: ''
+        EmailAddress:
+          $ref: '#/components/schemas/EmailAddress'
+          description: ''
+        ID:
+          $ref: '#/components/schemas/ID'
+          description: The canonical user ID of the grantee.
+        URI:
+          $ref: '#/components/schemas/URI'
+          description: URI of the grantee group.
+        Type:
+          $ref: '#/components/schemas/Type'
+          description: Type of grantee
+      required:
+      - Type
+      description: Container for the person being granted permissions.
+    Grants:
+      type: array
+      items:
+        $ref: '#/components/schemas/Grant'
+    HeadBucketOutput:
+      type: object
+      properties:
+        BucketArn:
+          $ref: '#/components/schemas/S3RegionalOrS3ExpressBucketArnString'
+          description: 'The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely
+            identify Amazon Web Services resources across all of Amazon Web Services.
+
+
+            This parameter is only supported for S3 directory buckets. For more information,
+            see [Using tags with directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html).'
+        BucketLocationType:
+          $ref: '#/components/schemas/LocationType'
+          description: 'The type of location where the bucket is created.
+
+
+            This functionality is only supported by directory buckets.'
+        BucketLocationName:
+          $ref: '#/components/schemas/BucketLocationName'
+          description: 'The name of the location where the bucket will be created.
+
+
+            For directory buckets, the Zone ID of the Availability Zone or the Local
+            Zone where the bucket is created. An example Zone ID value for an Availability
+            Zone is `usw2-az1`.
+
+
+            This functionality is only supported by directory buckets.'
+        BucketRegion:
+          $ref: '#/components/schemas/Region'
+          description: The Region that the bucket is located.
+        AccessPointAlias:
+          $ref: '#/components/schemas/AccessPointAlias'
+          description: 'Indicates whether the bucket name used in the request is an
+            access point alias.
+
+
+            For directory buckets, the value of this field is `false`.'
+    HeadBucketRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Object Lambda access points** \- When you use this API operation with
+            an Object Lambda access point, provide the alias of the Object Lambda
+            access point in place of the bucket name. If the Object Lambda access
+            point alias in a request is not valid, the error code `InvalidAccessPointAliasError`
+            is returned. For more information about `InvalidAccessPointAliasError`,
+            see [List of Error Codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    HeadObjectOutput:
+      type: object
+      properties:
+        DeleteMarker:
+          $ref: '#/components/schemas/DeleteMarker'
+          description: 'Specifies whether the object retrieved was (true) or was not
+            (false) a Delete Marker. If false, this response header does not appear
+            in the response.
+
+
+            This functionality is not supported for directory buckets.'
+        AcceptRanges:
+          $ref: '#/components/schemas/AcceptRanges'
+          description: Indicates that a range of bytes was specified.
+        Expiration:
+          $ref: '#/components/schemas/Expiration'
+          description: 'If the object expiration is configured (see [ `PutBucketLifecycleConfiguration`
+            ](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html)),
+            the response includes this header. It includes the `expiry-date` and `rule-id`
+            key-value pairs providing object expiration information. The value of
+            the `rule-id` is URL-encoded.
+
+
+            Object expiration information is not returned in directory buckets and
+            this header returns the value "`NotImplemented`" in all responses for
+            directory buckets.'
+        Restore:
+          $ref: '#/components/schemas/Restore'
+          description: 'If the object is an archived object (an object whose storage
+            class is GLACIER), the response includes this header if either the archive
+            restoration is in progress (see [RestoreObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html)
+            or an archive copy is already restored.
+
+
+            If an archive copy is already restored, the header value indicates when
+            Amazon S3 is scheduled to delete the object copy. For example:
+
+
+            `x-amz-restore: ongoing-request="false", expiry-date="Fri, 21 Dec 2012
+            00:00:00 GMT"`
+
+
+            If the object restoration is in progress, the header returns the value
+            `ongoing-request="true"`.
+
+
+            For more information about archiving objects, see [Transitioning Objects:
+            General Considerations](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-transition-general-considerations).
+
+
+            This functionality is not supported for directory buckets. Directory buckets
+            only support `EXPRESS_ONEZONE` (the S3 Express One Zone storage class)
+            in Availability Zones and `ONEZONE_IA` (the S3 One Zone-Infrequent Access
+            storage class) in Dedicated Local Zones.'
+        ArchiveStatus:
+          $ref: '#/components/schemas/ArchiveStatus'
+          description: 'The archive state of the head object.
+
+
+            This functionality is not supported for directory buckets.'
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Date and time when the object was last modified.
+        ContentLength:
+          $ref: '#/components/schemas/ContentLength'
+          description: Size of the body in bytes.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32 checksum` of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the object.
+            For more information, see [Checking object integrity in the Amazon S3
+            User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` digest of the object. This
+            checksum is only present if the checksum was uploaded with the object.
+            When you use the API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` digest of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type, which determines how part-level checksums
+            are combined to create an object-level checksum for multipart objects.
+            You can use this header response to verify that the checksum type that
+            is received is the same checksum type that was specified in `CreateMultipartUpload`
+            request. For more information, see [Checking object integrity in the Amazon
+            S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: An entity tag (ETag) is an opaque identifier assigned by a
+            web server to a specific version of a resource found at a URL.
+        MissingMeta:
+          $ref: '#/components/schemas/MissingMeta'
+          description: 'This is set to the number of metadata entries not returned
+            in `x-amz-meta` headers. This can happen if you create metadata using
+            an API like SOAP that supports more flexible metadata than the REST API.
+            For example, using SOAP, you can create metadata whose values are not
+            legal HTTP headers.
+
+
+            This functionality is not supported for directory buckets.'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID of the object.
+
+
+            This functionality is not supported for directory buckets.'
+        CacheControl:
+          $ref: '#/components/schemas/CacheControl'
+          description: Specifies caching behavior along the request/reply chain.
+        ContentDisposition:
+          $ref: '#/components/schemas/ContentDisposition'
+          description: Specifies presentational information for the object.
+        ContentEncoding:
+          $ref: '#/components/schemas/ContentEncoding'
+          description: Indicates what content encodings have been applied to the object
+            and thus what decoding mechanisms must be applied to obtain the media-type
+            referenced by the Content-Type header field.
+        ContentLanguage:
+          $ref: '#/components/schemas/ContentLanguage'
+          description: The language the content is in.
+        ContentType:
+          $ref: '#/components/schemas/ContentType'
+          description: A standard MIME type describing the format of the object data.
+        ContentRange:
+          $ref: '#/components/schemas/ContentRange'
+          description: The portion of the object returned in the response for a `GET`
+            request.
+        Expires:
+          $ref: '#/components/schemas/Expires'
+          description: The date and time at which the object is no longer cacheable.
+        WebsiteRedirectLocation:
+          $ref: '#/components/schemas/WebsiteRedirectLocation'
+          description: 'If the bucket is configured as a website, redirects requests
+            for this object to another object in the same bucket or to an external
+            URL. Amazon S3 stores the value of this header in the object metadata.
+
+
+            This functionality is not supported for directory buckets.'
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store this
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        Metadata:
+          $ref: '#/components/schemas/Metadata'
+          description: A map of metadata to store with the object in S3.
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to confirm the
+            encryption algorithm that''s used.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to provide the
+            round-trip message integrity verification of the customer-provided encryption
+            key.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the object uses an S3 Bucket Key for server-side
+            encryption with Key Management Service (KMS) keys (SSE-KMS).
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: 'Provides storage class information of the object. Amazon S3
+            returns this header for all objects except for S3 Standard storage class
+            objects.
+
+
+            For more information, see [Storage Classes](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html).
+
+
+            **Directory buckets** \- Directory buckets only support `EXPRESS_ONEZONE`
+            (the S3 Express One Zone storage class) in Availability Zones and `ONEZONE_IA`
+            (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        ReplicationStatus:
+          $ref: '#/components/schemas/ReplicationStatus'
+          description: "Amazon S3 can return this header if your request involves\
+            \ a bucket that is either a source or a destination in a replication rule.\n\
+            \nIn replication, you have a source bucket on which you configure replication\
+            \ and destination bucket or buckets where Amazon S3 stores object replicas.\
+            \ When you request an object (`GetObject`) or object metadata (`HeadObject`)\
+            \ from these buckets, Amazon S3 will return the `x-amz-replication-status`\
+            \ header in the response as follows:\n\n  * **If requesting an object\
+            \ from the source bucket** , Amazon S3 will return the `x-amz-replication-status`\
+            \ header if the object in your request is eligible for replication.\n\n\
+            For example, suppose that in your replication configuration, you specify\
+            \ object prefix `TaxDocs` requesting Amazon S3 to replicate objects with\
+            \ key prefix `TaxDocs`. Any objects you upload with this key name prefix,\
+            \ for example `TaxDocs/document1.pdf`, are eligible for replication. For\
+            \ any object request with this key name prefix, Amazon S3 will return\
+            \ the `x-amz-replication-status` header with value PENDING, COMPLETED\
+            \ or FAILED indicating object replication status.\n\n  * **If requesting\
+            \ an object from a destination bucket** , Amazon S3 will return the `x-amz-replication-status`\
+            \ header with value REPLICA if the object in your request is a replica\
+            \ that Amazon S3 created and there is no replica modification replication\
+            \ in progress.\n\n  * **When replicating objects to multiple destination\
+            \ buckets** , the `x-amz-replication-status` header acts differently.\
+            \ The header of the source object will only return a value of COMPLETED\
+            \ when replication is successful to all destinations. The header will\
+            \ remain at value PENDING until replication has completed for all destinations.\
+            \ If one or more destinations fails replication the header will return\
+            \ FAILED. \n\nFor more information, see [Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html).\n\
+            \nThis functionality is not supported for directory buckets."
+        PartsCount:
+          $ref: '#/components/schemas/PartsCount'
+          description: The count of parts this object has. This value is only returned
+            if you specify `partNumber` in your request and the object was uploaded
+            as a multipart upload.
+        TagCount:
+          $ref: '#/components/schemas/TagCount'
+          description: 'The number of tags, if any, on the object, when you have the
+            relevant permission to read object tags.
+
+
+            You can use [GetObjectTagging](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html)
+            to retrieve the tag set associated with an object.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockMode:
+          $ref: '#/components/schemas/ObjectLockMode'
+          description: 'The Object Lock mode, if any, that''s in effect for this object.
+            This header is only returned if the requester has the `s3:GetObjectRetention`
+            permission. For more information about S3 Object Lock, see [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html).
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockRetainUntilDate:
+          $ref: '#/components/schemas/ObjectLockRetainUntilDate'
+          description: 'The date and time when the Object Lock retention period expires.
+            This header is only returned if the requester has the `s3:GetObjectRetention`
+            permission.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockLegalHoldStatus:
+          $ref: '#/components/schemas/ObjectLockLegalHoldStatus'
+          description: 'Specifies whether a legal hold is in effect for this object.
+            This header is only returned if the requester has the `s3:GetObjectLegalHold`
+            permission. This header is not returned if the specified version of this
+            object has never had a legal hold applied. For more information about
+            S3 Object Lock, see [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html).
+
+
+            This functionality is not supported for directory buckets.'
+    HeadObjectRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket that contains the object.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        IfMatch:
+          $ref: '#/components/schemas/IfMatch'
+          description: "Return the object only if its entity tag (ETag) is the same\
+            \ as the one specified; otherwise, return a 412 (precondition failed)\
+            \ error.\n\nIf both of the `If-Match` and `If-Unmodified-Since` headers\
+            \ are present in the request as follows:\n\n  * `If-Match` condition evaluates\
+            \ to `true`, and;\n\n  * `If-Unmodified-Since` condition evaluates to\
+            \ `false`;\n\nThen Amazon S3 returns `200 OK` and the data requested.\n\
+            \nFor more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232)."
+        IfModifiedSince:
+          $ref: '#/components/schemas/IfModifiedSince'
+          description: "Return the object only if it has been modified since the specified\
+            \ time; otherwise, return a 304 (not modified) error.\n\nIf both of the\
+            \ `If-None-Match` and `If-Modified-Since` headers are present in the request\
+            \ as follows:\n\n  * `If-None-Match` condition evaluates to `false`, and;\n\
+            \n  * `If-Modified-Since` condition evaluates to `true`;\n\nThen Amazon\
+            \ S3 returns the `304 Not Modified` response code.\n\nFor more information\
+            \ about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232)."
+        IfNoneMatch:
+          $ref: '#/components/schemas/IfNoneMatch'
+          description: "Return the object only if its entity tag (ETag) is different\
+            \ from the one specified; otherwise, return a 304 (not modified) error.\n\
+            \nIf both of the `If-None-Match` and `If-Modified-Since` headers are present\
+            \ in the request as follows:\n\n  * `If-None-Match` condition evaluates\
+            \ to `false`, and;\n\n  * `If-Modified-Since` condition evaluates to `true`;\n\
+            \nThen Amazon S3 returns the `304 Not Modified` response code.\n\nFor\
+            \ more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232)."
+        IfUnmodifiedSince:
+          $ref: '#/components/schemas/IfUnmodifiedSince'
+          description: "Return the object only if it has not been modified since the\
+            \ specified time; otherwise, return a 412 (precondition failed) error.\n\
+            \nIf both of the `If-Match` and `If-Unmodified-Since` headers are present\
+            \ in the request as follows:\n\n  * `If-Match` condition evaluates to\
+            \ `true`, and;\n\n  * `If-Unmodified-Since` condition evaluates to `false`;\n\
+            \nThen Amazon S3 returns `200 OK` and the data requested.\n\nFor more\
+            \ information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232)."
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The object key.
+        Range:
+          $ref: '#/components/schemas/Range'
+          description: HeadObject returns only the metadata for an object. If the
+            Range is satisfiable, only the `ContentLength` is affected in the response.
+            If the Range is not satisfiable, S3 returns a `416 - Requested Range Not
+            Satisfiable` error.
+        ResponseCacheControl:
+          $ref: '#/components/schemas/ResponseCacheControl'
+          description: Sets the `Cache-Control` header of the response.
+        ResponseContentDisposition:
+          $ref: '#/components/schemas/ResponseContentDisposition'
+          description: Sets the `Content-Disposition` header of the response.
+        ResponseContentEncoding:
+          $ref: '#/components/schemas/ResponseContentEncoding'
+          description: Sets the `Content-Encoding` header of the response.
+        ResponseContentLanguage:
+          $ref: '#/components/schemas/ResponseContentLanguage'
+          description: Sets the `Content-Language` header of the response.
+        ResponseContentType:
+          $ref: '#/components/schemas/ResponseContentType'
+          description: Sets the `Content-Type` header of the response.
+        ResponseExpires:
+          $ref: '#/components/schemas/ResponseExpires'
+          description: Sets the `Expires` header of the response.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID used to reference a specific version of the object.
+
+
+            For directory buckets in this API operation, only the `null` value of
+            the version ID is supported.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when encrypting the object
+            (for example, AES256).
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use in encrypting data. This value is used to store the object and
+            then it is discarded; Amazon S3 does not store the encryption key. The
+            key must be appropriate for use with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm`
+            header.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        PartNumber:
+          $ref: '#/components/schemas/PartNumber'
+          description: Part number of the object being read. This is a positive integer
+            between 1 and 10,000. Effectively performs a 'ranged' HEAD request for
+            the part specified. Useful querying about the size of the part and the
+            number of parts in this object.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        ChecksumMode:
+          $ref: '#/components/schemas/ChecksumMode'
+          description: 'To retrieve the checksum, this parameter must be enabled.
+
+
+            **General purpose buckets** \- If you enable checksum mode and the object
+            is uploaded with a [checksum](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Checksum.html)
+            and encrypted with an Key Management Service (KMS) key, you must have
+            permission to use the `kms:Decrypt` action to retrieve the checksum.
+
+
+            **Directory buckets** \- If you enable `ChecksumMode` and the object is
+            encrypted with Amazon Web Services Key Management Service (Amazon Web
+            Services KMS), you must also have the `kms:GenerateDataKey` and `kms:Decrypt`
+            permissions in IAM identity-based policies and KMS key policies for the
+            KMS key to retrieve the checksum of the object.'
+      required:
+      - Bucket
+      - Key
+    HostName:
+      type: string
+    HttpErrorCodeReturnedEquals:
+      type: string
+    HttpRedirectCode:
+      type: string
+    ID:
+      type: string
+    IdempotencyParameterMismatch:
+      type: object
+      properties: {}
+      description: 'Parameters on this idempotent request are inconsistent with parameters
+        used in previous request(s).
+
+
+        For a list of error codes and more information on Amazon S3 errors, see [Error
+        codes](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList).
+
+
+        Idempotency ensures that an API request completes no more than one time. With
+        an idempotent request, if the original request completes successfully, any
+        subsequent retries complete successfully without performing any further actions.'
+    IfMatch:
+      type: string
+    IfMatchInitiatedTime:
+      type: string
+      format: date-time
+    IfMatchLastModifiedTime:
+      type: string
+      format: date-time
+    IfMatchSize:
+      type: integer
+      format: int64
+    IfModifiedSince:
+      type: string
+      format: date-time
+    IfNoneMatch:
+      type: string
+    IfUnmodifiedSince:
+      type: string
+      format: date-time
+    IndexDocument:
+      type: object
+      properties:
+        Suffix:
+          $ref: '#/components/schemas/Suffix'
+          description: 'A suffix that is appended to a request that is for a directory
+            on the website endpoint. (For example, if the suffix is `index.html` and
+            you make a request to `samplebucket/images/`, the data that is returned
+            will be for the object with the key name `images/index.html`.) The suffix
+            must not be empty and must not include a slash character.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+      required:
+      - Suffix
+      description: Container for the `Suffix` element.
+    Initiated:
+      type: string
+      format: date-time
+    Initiator:
+      type: object
+      properties:
+        ID:
+          $ref: '#/components/schemas/ID'
+          description: 'If the principal is an Amazon Web Services account, it provides
+            the Canonical User ID. If the principal is an IAM User, it provides a
+            user ARN value.
+
+
+            **Directory buckets** \- If the principal is an Amazon Web Services account,
+            it provides the Amazon Web Services account ID. If the principal is an
+            IAM User, it provides a user ARN value.'
+        DisplayName:
+          $ref: '#/components/schemas/DisplayName'
+          description: This functionality is not supported for directory buckets.
+      description: Container element that identifies who initiated the multipart upload.
+    InputSerialization:
+      type: object
+      properties:
+        CSV:
+          $ref: '#/components/schemas/CSVInput'
+          description: Describes the serialization of a CSV-encoded object.
+        CompressionType:
+          $ref: '#/components/schemas/CompressionType'
+          description: 'Specifies object''s compression format. Valid values: NONE,
+            GZIP, BZIP2. Default Value: NONE.'
+        JSON:
+          $ref: '#/components/schemas/JSONInput'
+          description: Specifies JSON as object's input serialization format.
+        Parquet:
+          $ref: '#/components/schemas/ParquetInput'
+          description: Specifies Parquet as object's input serialization format.
+      description: Describes the serialization format of the object.
+    IntelligentTieringAccessTier:
+      type: string
+      enum:
+      - ARCHIVE_ACCESS
+      - DEEP_ARCHIVE_ACCESS
+    IntelligentTieringAndOperator:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: An object key name prefix that identifies the subset of objects
+            to which the configuration applies.
+        Tags:
+          $ref: '#/components/schemas/TagSet'
+          description: All of these tags must exist in the object's tag set in order
+            for the configuration to apply.
+      description: A container for specifying S3 Intelligent-Tiering filters. The
+        filters determine the subset of objects to which the rule applies.
+    IntelligentTieringConfiguration:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/IntelligentTieringId'
+          description: The ID used to identify the S3 Intelligent-Tiering configuration.
+        Filter:
+          $ref: '#/components/schemas/IntelligentTieringFilter'
+          description: Specifies a bucket filter. The configuration only includes
+            objects that meet the filter's criteria.
+        Status:
+          $ref: '#/components/schemas/IntelligentTieringStatus'
+          description: Specifies the status of the configuration.
+        Tierings:
+          $ref: '#/components/schemas/TieringList'
+          description: Specifies the S3 Intelligent-Tiering storage class tier of
+            the configuration.
+      required:
+      - Id
+      - Status
+      - Tierings
+      description: 'Specifies the S3 Intelligent-Tiering configuration for an Amazon
+        S3 bucket.
+
+
+        For information about the S3 Intelligent-Tiering storage class, see [Storage
+        class for automatically optimizing frequently and infrequently accessed objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access).'
+    IntelligentTieringConfigurationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/IntelligentTieringConfiguration'
+    IntelligentTieringDays:
+      type: integer
+    IntelligentTieringFilter:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'An object key name prefix that identifies the subset of objects
+            to which the rule applies.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+        Tag:
+          $ref: '#/components/schemas/Tag'
+        And:
+          $ref: '#/components/schemas/IntelligentTieringAndOperator'
+          description: A conjunction (logical AND) of predicates, which is used in
+            evaluating a metrics filter. The operator must have at least two predicates,
+            and an object must match all of the predicates in order for the filter
+            to apply.
+      description: The `Filter` is used to identify objects that the S3 Intelligent-Tiering
+        configuration applies to.
+    IntelligentTieringId:
+      type: string
+    IntelligentTieringStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    InvalidObjectState:
+      type: object
+      properties:
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+        AccessTier:
+          $ref: '#/components/schemas/IntelligentTieringAccessTier'
+      description: 'Object is archived and inaccessible until restored.
+
+
+        If the object you are retrieving is stored in the S3 Glacier Flexible Retrieval
+        storage class, the S3 Glacier Deep Archive storage class, the S3 Intelligent-Tiering
+        Archive Access tier, or the S3 Intelligent-Tiering Deep Archive Access tier,
+        before you can retrieve the object you must first restore a copy using [RestoreObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html).
+        Otherwise, this operation returns an `InvalidObjectState` error. For information
+        about restoring archived objects, see [Restoring Archived Objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html)
+        in the _Amazon S3 User Guide_.'
+    InvalidRequest:
+      type: object
+      properties: {}
+      description: "You may receive this error in multiple cases. Depending on the\
+        \ reason for the error, you may receive one of the messages below:\n\n  *\
+        \ Cannot specify both a write offset value and user-defined object metadata\
+        \ for existing objects.\n\n  * Checksum Type mismatch occurred, expected checksum\
+        \ Type: sha1, actual checksum Type: crc32c.\n\n  * Request body cannot be\
+        \ empty when 'write offset' is specified."
+    InvalidWriteOffset:
+      type: object
+      properties: {}
+      description: The write offset value that you specified does not match the current
+        object size.
+    InventoryConfiguration:
+      type: object
+      properties:
+        Destination:
+          $ref: '#/components/schemas/InventoryDestination'
+          description: Contains information about where to publish the inventory results.
+        IsEnabled:
+          $ref: '#/components/schemas/IsEnabled'
+          description: Specifies whether the inventory is enabled or disabled. If
+            set to `True`, an inventory list is generated. If set to `False`, no inventory
+            list is generated.
+        Filter:
+          $ref: '#/components/schemas/InventoryFilter'
+          description: Specifies an inventory filter. The inventory only includes
+            objects that meet the filter's criteria.
+        Id:
+          $ref: '#/components/schemas/InventoryId'
+          description: The ID used to identify the inventory configuration.
+        IncludedObjectVersions:
+          $ref: '#/components/schemas/InventoryIncludedObjectVersions'
+          description: Object versions to include in the inventory list. If set to
+            `All`, the list includes all the object versions, which adds the version-related
+            fields `VersionId`, `IsLatest`, and `DeleteMarker` to the list. If set
+            to `Current`, the list does not contain these version-related fields.
+        OptionalFields:
+          $ref: '#/components/schemas/InventoryOptionalFields'
+          description: Contains the optional fields that are included in the inventory
+            results.
+        Schedule:
+          $ref: '#/components/schemas/InventorySchedule'
+          description: Specifies the schedule for generating inventory results.
+      required:
+      - Destination
+      - IsEnabled
+      - Id
+      - IncludedObjectVersions
+      - Schedule
+      description: Specifies the S3 Inventory configuration for an Amazon S3 bucket.
+        For more information, see [GET Bucket inventory](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETInventoryConfig.html)
+        in the _Amazon S3 API Reference_.
+    InventoryConfigurationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/InventoryConfiguration'
+    InventoryConfigurationState:
+      type: string
+      enum:
+      - ENABLED
+      - DISABLED
+    InventoryDestination:
+      type: object
+      properties:
+        S3BucketDestination:
+          $ref: '#/components/schemas/InventoryS3BucketDestination'
+          description: Contains the bucket name, file format, bucket owner (optional),
+            and prefix (optional) where inventory results are published.
+      required:
+      - S3BucketDestination
+      description: Specifies the S3 Inventory configuration for an Amazon S3 bucket.
+    InventoryEncryption:
+      type: object
+      properties:
+        SSES3:
+          $ref: '#/components/schemas/SSES3'
+          description: Specifies the use of SSE-S3 to encrypt delivered inventory
+            reports.
+        SSEKMS:
+          $ref: '#/components/schemas/SSEKMS'
+          description: Specifies the use of SSE-KMS to encrypt delivered inventory
+            reports.
+      description: Contains the type of server-side encryption used to encrypt the
+        S3 Inventory results.
+    InventoryFilter:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: The prefix that an object must have to be included in the inventory
+            results.
+      required:
+      - Prefix
+      description: Specifies an S3 Inventory filter. The inventory only includes objects
+        that meet the filter's criteria.
+    InventoryFormat:
+      type: string
+      enum:
+      - CSV
+      - ORC
+      - Parquet
+    InventoryFrequency:
+      type: string
+      enum:
+      - Daily
+      - Weekly
+    InventoryId:
+      type: string
+    InventoryIncludedObjectVersions:
+      type: string
+      enum:
+      - All
+      - Current
+    InventoryOptionalField:
+      type: string
+      enum:
+      - Size
+      - LastModifiedDate
+      - StorageClass
+      - ETag
+      - IsMultipartUploaded
+      - ReplicationStatus
+      - EncryptionStatus
+      - ObjectLockRetainUntilDate
+      - ObjectLockMode
+      - ObjectLockLegalHoldStatus
+      - IntelligentTieringAccessTier
+      - BucketKeyStatus
+      - ChecksumAlgorithm
+      - ObjectAccessControlList
+      - ObjectOwner
+    InventoryOptionalFields:
+      type: array
+      items:
+        $ref: '#/components/schemas/InventoryOptionalField'
+    InventoryS3BucketDestination:
+      type: object
+      properties:
+        AccountId:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID that owns the destination S3 bucket. If no
+            account ID is provided, the owner is not validated before exporting data.
+
+
+            Although this value is optional, we strongly recommend that you set it
+            to help prevent problems if the destination bucket ownership changes.'
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The Amazon Resource Name (ARN) of the bucket where inventory
+            results will be published.
+        Format:
+          $ref: '#/components/schemas/InventoryFormat'
+          description: Specifies the output format of the inventory results.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: The prefix that is prepended to all inventory results.
+        Encryption:
+          $ref: '#/components/schemas/InventoryEncryption'
+          description: Contains the type of server-side encryption used to encrypt
+            the inventory results.
+      required:
+      - Bucket
+      - Format
+      description: Contains the bucket name, file format, bucket owner (optional),
+        and prefix (optional) where S3 Inventory results are published.
+    InventorySchedule:
+      type: object
+      properties:
+        Frequency:
+          $ref: '#/components/schemas/InventoryFrequency'
+          description: Specifies how frequently inventory results are produced.
+      required:
+      - Frequency
+      description: Specifies the schedule for generating S3 Inventory results.
+    InventoryTableConfiguration:
+      type: object
+      properties:
+        ConfigurationState:
+          $ref: '#/components/schemas/InventoryConfigurationState'
+          description: The configuration state of the inventory table, indicating
+            whether the inventory table is enabled or disabled.
+        EncryptionConfiguration:
+          $ref: '#/components/schemas/MetadataTableEncryptionConfiguration'
+          description: The encryption configuration for the inventory table.
+      required:
+      - ConfigurationState
+      description: The inventory table configuration for an S3 Metadata configuration.
+    InventoryTableConfigurationResult:
+      type: object
+      properties:
+        ConfigurationState:
+          $ref: '#/components/schemas/InventoryConfigurationState'
+          description: The configuration state of the inventory table, indicating
+            whether the inventory table is enabled or disabled.
+        TableStatus:
+          $ref: '#/components/schemas/MetadataTableStatus'
+          description: "The status of the inventory table. The status values are:\n\
+            \n  * `CREATING` \\- The inventory table is in the process of being created\
+            \ in the specified Amazon Web Services managed table bucket.\n\n  * `BACKFILLING`\
+            \ \\- The inventory table is in the process of being backfilled. When\
+            \ you enable the inventory table for your metadata configuration, the\
+            \ table goes through a process known as backfilling, during which Amazon\
+            \ S3 scans your general purpose bucket to retrieve the initial metadata\
+            \ for all objects in the bucket. Depending on the number of objects in\
+            \ your bucket, this process can take several hours. When the backfilling\
+            \ process is finished, the status of your inventory table changes from\
+            \ `BACKFILLING` to `ACTIVE`. After backfilling is completed, updates to\
+            \ your objects are reflected in the inventory table within one hour.\n\
+            \n  * `ACTIVE` \\- The inventory table has been created successfully,\
+            \ and records are being delivered to the table. \n\n  * `FAILED` \\- Amazon\
+            \ S3 is unable to create the inventory table, or Amazon S3 is unable to\
+            \ deliver records."
+        Error:
+          $ref: '#/components/schemas/ErrorDetails'
+        TableName:
+          $ref: '#/components/schemas/S3TablesName'
+          description: The name of the inventory table.
+        TableArn:
+          $ref: '#/components/schemas/S3TablesArn'
+          description: The Amazon Resource Name (ARN) for the inventory table.
+      required:
+      - ConfigurationState
+      description: The inventory table configuration for an S3 Metadata configuration.
+    InventoryTableConfigurationUpdates:
+      type: object
+      properties:
+        ConfigurationState:
+          $ref: '#/components/schemas/InventoryConfigurationState'
+          description: The configuration state of the inventory table, indicating
+            whether the inventory table is enabled or disabled.
+        EncryptionConfiguration:
+          $ref: '#/components/schemas/MetadataTableEncryptionConfiguration'
+          description: The encryption configuration for the inventory table.
+      required:
+      - ConfigurationState
+      description: The specified updates to the S3 Metadata inventory table configuration.
+    IsEnabled:
+      type: boolean
+    IsLatest:
+      type: boolean
+    IsPublic:
+      type: boolean
+    IsRestoreInProgress:
+      type: boolean
+    IsTruncated:
+      type: boolean
+    JSONInput:
+      type: object
+      properties:
+        Type:
+          $ref: '#/components/schemas/JSONType'
+          description: 'The type of JSON. Valid values: Document, Lines.'
+      description: Specifies JSON as object's input serialization format.
+    JSONOutput:
+      type: object
+      properties:
+        RecordDelimiter:
+          $ref: '#/components/schemas/RecordDelimiter'
+          description: The value used to separate individual records in the output.
+            If no value is specified, Amazon S3 uses a newline character ('\n').
+      description: Specifies JSON as request's output serialization format.
+    JSONType:
+      type: string
+      enum:
+      - DOCUMENT
+      - LINES
+    JournalTableConfiguration:
+      type: object
+      properties:
+        RecordExpiration:
+          $ref: '#/components/schemas/RecordExpiration'
+          description: The journal table record expiration settings for the journal
+            table.
+        EncryptionConfiguration:
+          $ref: '#/components/schemas/MetadataTableEncryptionConfiguration'
+          description: The encryption configuration for the journal table.
+      required:
+      - RecordExpiration
+      description: The journal table configuration for an S3 Metadata configuration.
+    JournalTableConfigurationResult:
+      type: object
+      properties:
+        TableStatus:
+          $ref: '#/components/schemas/MetadataTableStatus'
+          description: "The status of the journal table. The status values are:\n\n\
+            \  * `CREATING` \\- The journal table is in the process of being created\
+            \ in the specified table bucket.\n\n  * `ACTIVE` \\- The journal table\
+            \ has been created successfully, and records are being delivered to the\
+            \ table. \n\n  * `FAILED` \\- Amazon S3 is unable to create the journal\
+            \ table, or Amazon S3 is unable to deliver records."
+        Error:
+          $ref: '#/components/schemas/ErrorDetails'
+        TableName:
+          $ref: '#/components/schemas/S3TablesName'
+          description: The name of the journal table.
+        TableArn:
+          $ref: '#/components/schemas/S3TablesArn'
+          description: The Amazon Resource Name (ARN) for the journal table.
+        RecordExpiration:
+          $ref: '#/components/schemas/RecordExpiration'
+          description: The journal table record expiration settings for the journal
+            table.
+      required:
+      - TableStatus
+      - TableName
+      - RecordExpiration
+      description: The journal table configuration for the S3 Metadata configuration.
+    JournalTableConfigurationUpdates:
+      type: object
+      properties:
+        RecordExpiration:
+          $ref: '#/components/schemas/RecordExpiration'
+          description: The journal table record expiration settings for the journal
+            table.
+      required:
+      - RecordExpiration
+      description: The specified updates to the S3 Metadata journal table configuration.
+    KMSContext:
+      type: string
+    KeyCount:
+      type: integer
+    KeyMarker:
+      type: string
+    KeyPrefixEquals:
+      type: string
+    KmsKeyArn:
+      type: string
+    LambdaFunctionArn:
+      type: string
+    LambdaFunctionConfiguration:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/NotificationId'
+        LambdaFunctionArn:
+          $ref: '#/components/schemas/LambdaFunctionArn'
+          description: The Amazon Resource Name (ARN) of the Lambda function that
+            Amazon S3 invokes when the specified event type occurs.
+        Events:
+          $ref: '#/components/schemas/EventList'
+          description: The Amazon S3 bucket event for which to invoke the Lambda function.
+            For more information, see [Supported Event Types](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+            in the _Amazon S3 User Guide_.
+        Filter:
+          $ref: '#/components/schemas/NotificationConfigurationFilter'
+      required:
+      - LambdaFunctionArn
+      - Events
+      description: A container for specifying the configuration for Lambda notifications.
+    LambdaFunctionConfigurationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/LambdaFunctionConfiguration'
+    LastModified:
+      type: string
+      format: date-time
+    LastModifiedTime:
+      type: string
+      format: date-time
+    LifecycleExpiration:
+      type: object
+      properties:
+        Date:
+          $ref: '#/components/schemas/Date'
+          description: 'Indicates at what date the object is to be moved or deleted.
+            The date value must conform to the ISO 8601 format. The time is always
+            midnight UTC.
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+        Days:
+          $ref: '#/components/schemas/Days'
+          description: Indicates the lifetime, in days, of the objects that are subject
+            to the rule. The value must be a non-zero positive integer.
+        ExpiredObjectDeleteMarker:
+          $ref: '#/components/schemas/ExpiredObjectDeleteMarker'
+          description: 'Indicates whether Amazon S3 will remove a delete marker with
+            no noncurrent versions. If set to true, the delete marker will be expired;
+            if set to false the policy takes no action. This cannot be specified with
+            Days or Date in a Lifecycle Expiration Policy.
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+      description: 'Container for the expiration for the lifecycle of the object.
+
+
+        For more information see, [Managing your storage lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+        in the _Amazon S3 User Guide_.'
+    LifecycleRule:
+      type: object
+      properties:
+        Expiration:
+          $ref: '#/components/schemas/LifecycleExpiration'
+          description: Specifies the expiration for the lifecycle of the object in
+            the form of date, days and, whether the object has a delete marker.
+        ID:
+          $ref: '#/components/schemas/ID'
+          description: Unique identifier for the rule. The value cannot be longer
+            than 255 characters.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'The general purpose bucket prefix that identifies one or more
+            objects to which the rule applies. We recommend using `Filter` instead
+            of `Prefix` for new PUTs. Previous configurations where a prefix is defined
+            will continue to operate as before.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+        Filter:
+          $ref: '#/components/schemas/LifecycleRuleFilter'
+          description: 'The `Filter` is used to identify objects that a Lifecycle
+            Rule applies to. A `Filter` must have exactly one of `Prefix`, `Tag`,
+            `ObjectSizeGreaterThan`, `ObjectSizeLessThan`, or `And` specified. `Filter`
+            is required if the `LifecycleRule` does not contain a `Prefix` element.
+
+
+            For more information about `Tag` filters, see [Adding filters to Lifecycle
+            rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-filters.html)
+            in the _Amazon S3 User Guide_.
+
+
+            `Tag` filters are not supported for directory buckets.'
+        Status:
+          $ref: '#/components/schemas/ExpirationStatus'
+          description: If 'Enabled', the rule is currently being applied. If 'Disabled',
+            the rule is not currently being applied.
+        Transitions:
+          $ref: '#/components/schemas/TransitionList'
+          description: 'Specifies when an Amazon S3 object transitions to a specified
+            storage class.
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+        NoncurrentVersionTransitions:
+          $ref: '#/components/schemas/NoncurrentVersionTransitionList'
+          description: 'Specifies the transition rule for the lifecycle rule that
+            describes when noncurrent objects transition to a specific storage class.
+            If your bucket is versioning-enabled (or versioning is suspended), you
+            can set this action to request that Amazon S3 transition noncurrent object
+            versions to a specific storage class at a set period in the object''s
+            lifetime.
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+        NoncurrentVersionExpiration:
+          $ref: '#/components/schemas/NoncurrentVersionExpiration'
+        AbortIncompleteMultipartUpload:
+          $ref: '#/components/schemas/AbortIncompleteMultipartUpload'
+      required:
+      - Status
+      description: 'A lifecycle rule for individual objects in an Amazon S3 bucket.
+
+
+        For more information see, [Managing your storage lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+        in the _Amazon S3 User Guide_.'
+    LifecycleRuleAndOperator:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: Prefix identifying one or more objects to which the rule applies.
+        Tags:
+          $ref: '#/components/schemas/TagSet'
+          description: All of these tags must exist in the object's tag set in order
+            for the rule to apply.
+        ObjectSizeGreaterThan:
+          $ref: '#/components/schemas/ObjectSizeGreaterThanBytes'
+          description: Minimum object size to which the rule applies.
+        ObjectSizeLessThan:
+          $ref: '#/components/schemas/ObjectSizeLessThanBytes'
+          description: Maximum object size to which the rule applies.
+      description: This is used in a Lifecycle Rule Filter to apply a logical AND
+        to two or more predicates. The Lifecycle Rule will apply to any object matching
+        all of the predicates configured inside the And operator.
+    LifecycleRuleFilter:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'Prefix identifying one or more objects to which the rule applies.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+        Tag:
+          $ref: '#/components/schemas/Tag'
+          description: 'This tag must exist in the object''s tag set in order for
+            the rule to apply.
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+        ObjectSizeGreaterThan:
+          $ref: '#/components/schemas/ObjectSizeGreaterThanBytes'
+          description: Minimum object size to which the rule applies.
+        ObjectSizeLessThan:
+          $ref: '#/components/schemas/ObjectSizeLessThanBytes'
+          description: Maximum object size to which the rule applies.
+        And:
+          $ref: '#/components/schemas/LifecycleRuleAndOperator'
+      description: The `Filter` is used to identify objects that a Lifecycle Rule
+        applies to. A `Filter` can have exactly one of `Prefix`, `Tag`, `ObjectSizeGreaterThan`,
+        `ObjectSizeLessThan`, or `And` specified. If the `Filter` element is left
+        empty, the Lifecycle Rule applies to all objects in the bucket.
+    LifecycleRules:
+      type: array
+      items:
+        $ref: '#/components/schemas/LifecycleRule'
+    ListBucketAnalyticsConfigurationsOutput:
+      type: object
+      properties:
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Indicates whether the returned list of analytics configurations
+            is complete. A value of true indicates that the list is not complete and
+            the NextContinuationToken will be provided for a subsequent request.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: The marker that is used as a starting point for this analytics
+            configuration list response. This value is present if it was sent in the
+            request.
+        NextContinuationToken:
+          $ref: '#/components/schemas/NextToken'
+          description: '`NextContinuationToken` is sent when `isTruncated` is true,
+            which indicates that there are more analytics configurations to list.
+            The next request must include this `NextContinuationToken`. The token
+            is obfuscated and is not a usable value.'
+        AnalyticsConfigurationList:
+          $ref: '#/components/schemas/AnalyticsConfigurationList'
+          description: The list of analytics configurations for a bucket.
+    ListBucketAnalyticsConfigurationsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket from which analytics configurations
+            are retrieved.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: The `ContinuationToken` that represents a placeholder from
+            where this request should begin.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    ListBucketIntelligentTieringConfigurationsOutput:
+      type: object
+      properties:
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Indicates whether the returned list of analytics configurations
+            is complete. A value of `true` indicates that the list is not complete
+            and the `NextContinuationToken` will be provided for a subsequent request.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: The `ContinuationToken` that represents a placeholder from
+            where this request should begin.
+        NextContinuationToken:
+          $ref: '#/components/schemas/NextToken'
+          description: The marker used to continue this inventory configuration listing.
+            Use the `NextContinuationToken` from this response to continue the listing
+            in a subsequent request. The continuation token is an opaque value that
+            Amazon S3 understands.
+        IntelligentTieringConfigurationList:
+          $ref: '#/components/schemas/IntelligentTieringConfigurationList'
+          description: The list of S3 Intelligent-Tiering configurations for a bucket.
+    ListBucketIntelligentTieringConfigurationsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose configuration you want
+            to modify or retrieve.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: The `ContinuationToken` that represents a placeholder from
+            where this request should begin.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    ListBucketInventoryConfigurationsOutput:
+      type: object
+      properties:
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: If sent in the request, the marker that is used as a starting
+            point for this inventory configuration list response.
+        InventoryConfigurationList:
+          $ref: '#/components/schemas/InventoryConfigurationList'
+          description: The list of inventory configurations for a bucket.
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Tells whether the returned list of inventory configurations
+            is complete. A value of true indicates that the list is not complete and
+            the NextContinuationToken is provided for a subsequent request.
+        NextContinuationToken:
+          $ref: '#/components/schemas/NextToken'
+          description: The marker used to continue this inventory configuration listing.
+            Use the `NextContinuationToken` from this response to continue the listing
+            in a subsequent request. The continuation token is an opaque value that
+            Amazon S3 understands.
+    ListBucketInventoryConfigurationsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket containing the inventory configurations
+            to retrieve.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: The marker used to continue an inventory configuration listing
+            that has been truncated. Use the `NextContinuationToken` from a previously
+            truncated list response to continue the listing. The continuation token
+            is an opaque value that Amazon S3 understands.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    ListBucketMetricsConfigurationsOutput:
+      type: object
+      properties:
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Indicates whether the returned list of metrics configurations
+            is complete. A value of true indicates that the list is not complete and
+            the NextContinuationToken will be provided for a subsequent request.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: The marker that is used as a starting point for this metrics
+            configuration list response. This value is present if it was sent in the
+            request.
+        NextContinuationToken:
+          $ref: '#/components/schemas/NextToken'
+          description: The marker used to continue a metrics configuration listing
+            that has been truncated. Use the `NextContinuationToken` from a previously
+            truncated list response to continue the listing. The continuation token
+            is an opaque value that Amazon S3 understands.
+        MetricsConfigurationList:
+          $ref: '#/components/schemas/MetricsConfigurationList'
+          description: The list of metrics configurations for a bucket.
+    ListBucketMetricsConfigurationsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket containing the metrics configurations
+            to retrieve.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: The marker that is used to continue a metrics configuration
+            listing that has been truncated. Use the `NextContinuationToken` from
+            a previously truncated list response to continue the listing. The continuation
+            token is an opaque value that Amazon S3 understands.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    ListBucketsOutput:
+      type: object
+      properties:
+        Buckets:
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Bucket"
+              - xml:
+                  name: Bucket
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: The owner of the buckets listed.
+        ContinuationToken:
+          $ref: '#/components/schemas/NextToken'
+          description: '`ContinuationToken` is included in the response when there
+            are more buckets that can be listed with pagination. The next `ListBuckets`
+            request to Amazon S3 can be continued with this `ContinuationToken`. `ContinuationToken`
+            is obfuscated and is not a real bucket.'
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'If `Prefix` was sent with the request, it is included in the
+            response.
+
+
+            All bucket names in the response begin with the specified bucket name
+            prefix.'
+    ListBucketsRequest:
+      type: object
+      properties:
+        MaxBuckets:
+          $ref: '#/components/schemas/MaxBuckets'
+          description: Maximum number of buckets to be returned in response. When
+            the number is more than the count of buckets that are owned by an Amazon
+            Web Services account, return all the buckets in response.
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: '`ContinuationToken` indicates to Amazon S3 that the list is
+            being continued on this bucket with a token. `ContinuationToken` is obfuscated
+            and is not a real key. You can use this `ContinuationToken` for pagination
+            of the list results.
+
+
+            Length Constraints: Minimum length of 0. Maximum length of 1024.
+
+
+            Required: No.
+
+
+            If you specify the `bucket-region`, `prefix`, or `continuation-token`
+            query parameters without using `max-buckets` to set the maximum number
+            of buckets returned in the response, Amazon S3 applies a default page
+            size of 10,000 and provides a continuation token if there are more buckets.'
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: Limits the response to bucket names that begin with the specified
+            bucket name prefix.
+        BucketRegion:
+          $ref: '#/components/schemas/BucketRegion'
+          description: 'Limits the response to buckets that are located in the specified
+            Amazon Web Services Region. The Amazon Web Services Region must be expressed
+            according to the Amazon Web Services Region code, such as `us-west-2`
+            for the US West (Oregon) Region. For a list of the valid values for all
+            of the Amazon Web Services Regions, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
+
+
+            Requests made to a Regional endpoint that is different from the `bucket-region`
+            parameter are not supported. For example, if you want to limit the response
+            to your buckets in Region `us-west-2`, the request must be made to an
+            endpoint in Region `us-west-2`.'
+    ListDirectoryBucketsOutput:
+      type: object
+      properties:
+        Buckets:
+          $ref: '#/components/schemas/Buckets'
+          description: The list of buckets owned by the requester.
+        ContinuationToken:
+          $ref: '#/components/schemas/DirectoryBucketToken'
+          description: If `ContinuationToken` was sent with the request, it is included
+            in the response. You can use the returned `ContinuationToken` for pagination
+            of the list response.
+    ListDirectoryBucketsRequest:
+      type: object
+      properties:
+        ContinuationToken:
+          $ref: '#/components/schemas/DirectoryBucketToken'
+          description: '`ContinuationToken` indicates to Amazon S3 that the list is
+            being continued on buckets in this account with a token. `ContinuationToken`
+            is obfuscated and is not a real bucket name. You can use this `ContinuationToken`
+            for the pagination of the list results.'
+        MaxDirectoryBuckets:
+          $ref: '#/components/schemas/MaxDirectoryBuckets'
+          description: Maximum number of buckets to be returned in response. When
+            the number is more than the count of buckets that are owned by an Amazon
+            Web Services account, return all the buckets in response.
+    ListMultipartUploadsOutput:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket to which the multipart upload was initiated.
+            Does not return the access point ARN or access point alias if used.
+        KeyMarker:
+          $ref: '#/components/schemas/KeyMarker'
+          description: The key at or after which the listing began.
+        UploadIdMarker:
+          $ref: '#/components/schemas/UploadIdMarker'
+          description: 'Together with key-marker, specifies the multipart upload after
+            which listing should begin. If key-marker is not specified, the upload-id-marker
+            parameter is ignored. Otherwise, any multipart uploads for a key equal
+            to the key-marker might be included in the list only if they have an upload
+            ID lexicographically greater than the specified `upload-id-marker`.
+
+
+            This functionality is not supported for directory buckets.'
+        NextKeyMarker:
+          $ref: '#/components/schemas/NextKeyMarker'
+          description: When a list is truncated, this element specifies the value
+            that should be used for the key-marker request parameter in a subsequent
+            request.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'When a prefix is provided in the request, this field contains
+            the specified prefix. The result contains only keys starting with the
+            specified prefix.
+
+
+            **Directory buckets** \- For directory buckets, only prefixes that end
+            in a delimiter (`/`) are supported.'
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: 'Contains the delimiter you specified in the request. If you
+            don''t specify a delimiter in your request, this element is absent from
+            the response.
+
+
+            **Directory buckets** \- For directory buckets, `/` is the only supported
+            delimiter.'
+        NextUploadIdMarker:
+          $ref: '#/components/schemas/NextUploadIdMarker'
+          description: 'When a list is truncated, this element specifies the value
+            that should be used for the `upload-id-marker` request parameter in a
+            subsequent request.
+
+
+            This functionality is not supported for directory buckets.'
+        MaxUploads:
+          $ref: '#/components/schemas/MaxUploads'
+          description: Maximum number of multipart uploads that could have been included
+            in the response.
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Indicates whether the returned list of multipart uploads is
+            truncated. A value of true indicates that the list was truncated. The
+            list can be truncated if the number of multipart uploads exceeds the limit
+            allowed or specified by max uploads.
+        Uploads:
+          $ref: '#/components/schemas/MultipartUploadList'
+          description: Container for elements related to a particular multipart upload.
+            A response can contain zero or more `Upload` elements.
+        CommonPrefixes:
+          $ref: '#/components/schemas/CommonPrefixList'
+          description: 'If you specify a delimiter in the request, then the result
+            returns each distinct key prefix containing the delimiter in a `CommonPrefixes`
+            element. The distinct key prefixes are returned in the `Prefix` child
+            element.
+
+
+            **Directory buckets** \- For directory buckets, only prefixes that end
+            in a delimiter (`/`) are supported.'
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+          description: 'Encoding type used by Amazon S3 to encode object keys in the
+            response.
+
+
+            If you specify the `encoding-type` request parameter, Amazon S3 includes
+            this element in the response, and returns encoded key name values in the
+            following response elements:
+
+
+            `Delimiter`, `KeyMarker`, `Prefix`, `NextKeyMarker`, `Key`.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    ListMultipartUploadsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket to which the multipart upload was initiated.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: 'Character you use to group keys.
+
+
+            All keys that contain the same string between the prefix, if specified,
+            and the first occurrence of the delimiter after the prefix are grouped
+            under a single result element, `CommonPrefixes`. If you don''t specify
+            the prefix parameter, then the substring starts at the beginning of the
+            key. The keys that are grouped under `CommonPrefixes` result element are
+            not returned elsewhere in the response.
+
+
+            `CommonPrefixes` is filtered out from results if it is not lexicographically
+            greater than the key-marker.
+
+
+            **Directory buckets** \- For directory buckets, `/` is the only supported
+            delimiter.'
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+        KeyMarker:
+          $ref: '#/components/schemas/KeyMarker'
+          description: "Specifies the multipart upload after which listing should\
+            \ begin.\n\n  * **General purpose buckets** \\- For general purpose buckets,\
+            \ `key-marker` is an object key. Together with `upload-id-marker`, this\
+            \ parameter specifies the multipart upload after which listing should\
+            \ begin.\n\nIf `upload-id-marker` is not specified, only the keys lexicographically\
+            \ greater than the specified `key-marker` will be included in the list.\n\
+            \nIf `upload-id-marker` is specified, any multipart uploads for a key\
+            \ equal to the `key-marker` might also be included, provided those multipart\
+            \ uploads have upload IDs lexicographically greater than the specified\
+            \ `upload-id-marker`.\n\n  * **Directory buckets** \\- For directory buckets,\
+            \ `key-marker` is obfuscated and isn't a real object key. The `upload-id-marker`\
+            \ parameter isn't supported by directory buckets. To list the additional\
+            \ multipart uploads, you only need to set the value of `key-marker` to\
+            \ the `NextKeyMarker` value from the previous response. \n\nIn the `ListMultipartUploads`\
+            \ response, the multipart uploads aren't sorted lexicographically based\
+            \ on the object keys."
+        MaxUploads:
+          $ref: '#/components/schemas/MaxUploads'
+          description: Sets the maximum number of multipart uploads, from 1 to 1,000,
+            to return in the response body. 1,000 is the maximum number of uploads
+            that can be returned in a response.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'Lists in-progress uploads only for those keys that begin with
+            the specified prefix. You can use prefixes to separate a bucket into different
+            grouping of keys. (You can think of using `prefix` to make groups in the
+            same way that you''d use a folder in a file system.)
+
+
+            **Directory buckets** \- For directory buckets, only prefixes that end
+            in a delimiter (`/`) are supported.'
+        UploadIdMarker:
+          $ref: '#/components/schemas/UploadIdMarker'
+          description: 'Together with key-marker, specifies the multipart upload after
+            which listing should begin. If key-marker is not specified, the upload-id-marker
+            parameter is ignored. Otherwise, any multipart uploads for a key equal
+            to the key-marker might be included in the list only if they have an upload
+            ID lexicographically greater than the specified `upload-id-marker`.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+      required:
+      - Bucket
+    ListObjectVersionsOutput:
+      type: object
+      properties:
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: A flag that indicates whether Amazon S3 returned all of the
+            results that satisfied the search criteria. If your results were truncated,
+            you can make a follow-up paginated request by using the `NextKeyMarker`
+            and `NextVersionIdMarker` response parameters as a starting place in another
+            request to return the rest of the results.
+        KeyMarker:
+          $ref: '#/components/schemas/KeyMarker'
+          description: Marks the last key returned in a truncated response.
+        VersionIdMarker:
+          $ref: '#/components/schemas/VersionIdMarker'
+          description: Marks the last version of the key returned in a truncated response.
+        NextKeyMarker:
+          $ref: '#/components/schemas/NextKeyMarker'
+          description: When the number of responses exceeds the value of `MaxKeys`,
+            `NextKeyMarker` specifies the first key not returned that satisfies the
+            search criteria. Use this value for the key-marker request parameter in
+            a subsequent request.
+        NextVersionIdMarker:
+          $ref: '#/components/schemas/NextVersionIdMarker'
+          description: When the number of responses exceeds the value of `MaxKeys`,
+            `NextVersionIdMarker` specifies the first object version not returned
+            that satisfies the search criteria. Use this value for the `version-id-marker`
+            request parameter in a subsequent request.
+        Versions:
+          $ref: '#/components/schemas/ObjectVersionList'
+          description: Container for version information.
+        DeleteMarkers:
+          $ref: '#/components/schemas/DeleteMarkers'
+          description: Container for an object that is a delete marker. To learn more
+            about delete markers, see [Working with delete markers](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html).
+        Name:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: Selects objects that start with the value supplied by this
+            parameter.
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: The delimiter grouping the included keys. A delimiter is a
+            character that you specify to group keys. All keys that contain the same
+            string between the prefix and the first occurrence of the delimiter are
+            grouped under a single result element in `CommonPrefixes`. These groups
+            are counted as one result against the `max-keys` limitation. These keys
+            are not returned elsewhere in the response.
+        MaxKeys:
+          $ref: '#/components/schemas/MaxKeys'
+          description: Specifies the maximum number of objects to return.
+        CommonPrefixes:
+          $ref: '#/components/schemas/CommonPrefixList'
+          description: All of the keys rolled up into a common prefix count as a single
+            return when calculating the number of returns.
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+          description: 'Encoding type used by Amazon S3 to encode object key names
+            in the XML response.
+
+
+            If you specify the `encoding-type` request parameter, Amazon S3 includes
+            this element in the response, and returns encoded key name values in the
+            following response elements:
+
+
+            `KeyMarker, NextKeyMarker, Prefix, Key`, and `Delimiter`.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    ListObjectVersionsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name that contains the objects.
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: 'A delimiter is a character that you specify to group keys.
+            All keys that contain the same string between the `prefix` and the first
+            occurrence of the delimiter are grouped under a single result element
+            in `CommonPrefixes`. These groups are counted as one result against the
+            `max-keys` limitation. These keys are not returned elsewhere in the response.
+
+
+            `CommonPrefixes` is filtered out from results if it is not lexicographically
+            greater than the key-marker.'
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+        KeyMarker:
+          $ref: '#/components/schemas/KeyMarker'
+          description: Specifies the key to start with when listing objects in a bucket.
+        MaxKeys:
+          $ref: '#/components/schemas/MaxKeys'
+          description: Sets the maximum number of keys returned in the response. By
+            default, the action returns up to 1,000 key names. The response might
+            contain fewer keys but will never contain more. If additional keys satisfy
+            the search criteria, but were not returned because `max-keys` was exceeded,
+            the response contains `true`. To return the additional keys, see `key-marker`
+            and `version-id-marker`.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: Use this parameter to select only those keys that begin with
+            the specified prefix. You can use prefixes to separate a bucket into different
+            groupings of keys. (You can think of using `prefix` to make groups in
+            the same way that you'd use a folder in a file system.) You can use `prefix`
+            with `delimiter` to roll up numerous objects into a single result under
+            `CommonPrefixes`.
+        VersionIdMarker:
+          $ref: '#/components/schemas/VersionIdMarker'
+          description: Specifies the object version you want to start listing from.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        OptionalObjectAttributes:
+          $ref: '#/components/schemas/OptionalObjectAttributesList'
+          description: Specifies the optional fields that you want returned in the
+            response. Fields that you do not specify are not returned.
+      required:
+      - Bucket
+    ListObjectsOutput:
+      type: object
+      properties:
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: A flag that indicates whether Amazon S3 returned all of the
+            results that satisfied the search criteria.
+        Marker:
+          $ref: '#/components/schemas/Marker'
+          description: Indicates where in the bucket listing begins. Marker is included
+            in the response if it was sent with the request.
+        NextMarker:
+          $ref: '#/components/schemas/NextMarker'
+          description: 'When the response is truncated (the `IsTruncated` element
+            value in the response is `true`), you can use the key name in this field
+            as the `marker` parameter in the subsequent request to get the next set
+            of objects. Amazon S3 lists objects in alphabetical order.
+
+
+            This element is returned only if you have the `delimiter` request parameter
+            specified. If the response does not include the `NextMarker` element and
+            it is truncated, you can use the value of the last `Key` element in the
+            response as the `marker` parameter in the subsequent request to get the
+            next set of object keys.'
+        Contents:
+          $ref: '#/components/schemas/ObjectList'
+          description: Metadata about each object returned.
+        Name:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: Keys that begin with the indicated prefix.
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: Causes keys that contain the same string between the prefix
+            and the first occurrence of the delimiter to be rolled up into a single
+            result element in the `CommonPrefixes` collection. These rolled-up keys
+            are not returned elsewhere in the response. Each rolled-up result counts
+            as only one return against the `MaxKeys` value.
+        MaxKeys:
+          $ref: '#/components/schemas/MaxKeys'
+          description: The maximum number of keys returned in the response body.
+        CommonPrefixes:
+          $ref: '#/components/schemas/CommonPrefixList'
+          description: 'All of the keys (up to 1,000) rolled up in a common prefix
+            count as a single return when calculating the number of returns.
+
+
+            A response can contain `CommonPrefixes` only if you specify a delimiter.
+
+
+            `CommonPrefixes` contains all (if there are any) keys between `Prefix`
+            and the next occurrence of the string specified by the delimiter.
+
+
+            `CommonPrefixes` lists keys that act like subdirectories in the directory
+            specified by `Prefix`.
+
+
+            For example, if the prefix is `notes/` and the delimiter is a slash (`/`),
+            as in `notes/summer/july`, the common prefix is `notes/summer/`. All of
+            the keys that roll up into a common prefix count as a single return when
+            calculating the number of returns.'
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+          description: 'Encoding type used by Amazon S3 to encode the [object keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)
+            in the response. Responses are encoded only in UTF-8. An object key can
+            contain any Unicode character. However, the XML 1.0 parser can''t parse
+            certain characters, such as characters with an ASCII value from 0 to 10.
+            For characters that aren''t supported in XML 1.0, you can add this parameter
+            to request that Amazon S3 encode the keys in the response. For more information
+            about characters to avoid in object key names, see [Object key naming
+            guidelines](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-guidelines).
+
+
+            When using the URL encoding type, non-ASCII characters that are used in
+            an object''s key name will be percent-encoded according to UTF-8 code
+            values. For example, the object `test_file(3).png` will appear as `test_file%283%29.png`.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    ListObjectsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket containing the objects.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: 'A delimiter is a character that you use to group keys.
+
+
+            `CommonPrefixes` is filtered out from results if it is not lexicographically
+            greater than the key-marker.'
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+        Marker:
+          $ref: '#/components/schemas/Marker'
+          description: Marker is where you want Amazon S3 to start listing from. Amazon
+            S3 starts listing after this specified key. Marker can be any key in the
+            bucket.
+        MaxKeys:
+          $ref: '#/components/schemas/MaxKeys'
+          description: Sets the maximum number of keys returned in the response. By
+            default, the action returns up to 1,000 key names. The response might
+            contain fewer keys but will never contain more.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: Limits the response to keys that begin with the specified prefix.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+          description: Confirms that the requester knows that she or he will be charged
+            for the list objects request. Bucket owners need not specify this parameter
+            in their requests.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        OptionalObjectAttributes:
+          $ref: '#/components/schemas/OptionalObjectAttributesList'
+          description: Specifies the optional fields that you want returned in the
+            response. Fields that you do not specify are not returned.
+      required:
+      - Bucket
+    ListObjectsV2Output:
+      type: object
+      properties:
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Set to `false` if all of the results were returned. Set to
+            `true` if more keys are available to return. If the number of results
+            exceeds that specified by `MaxKeys`, all of the results might not be returned.
+        Contents:
+          $ref: '#/components/schemas/ObjectList'
+          description: Metadata about each object returned.
+        Name:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'Keys that begin with the indicated prefix.
+
+
+            **Directory buckets** \- For directory buckets, only prefixes that end
+            in a delimiter (`/`) are supported.'
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: 'Causes keys that contain the same string between the `prefix`
+            and the first occurrence of the delimiter to be rolled up into a single
+            result element in the `CommonPrefixes` collection. These rolled-up keys
+            are not returned elsewhere in the response. Each rolled-up result counts
+            as only one return against the `MaxKeys` value.
+
+
+            **Directory buckets** \- For directory buckets, `/` is the only supported
+            delimiter.'
+        MaxKeys:
+          $ref: '#/components/schemas/MaxKeys'
+          description: Sets the maximum number of keys returned in the response. By
+            default, the action returns up to 1,000 key names. The response might
+            contain fewer keys but will never contain more.
+        CommonPrefixes:
+          $ref: '#/components/schemas/CommonPrefixList'
+          description: "All of the keys (up to 1,000) that share the same prefix are\
+            \ grouped together. When counting the total numbers of returns by this\
+            \ API operation, this group of keys is considered as one item.\n\nA response\
+            \ can contain `CommonPrefixes` only if you specify a delimiter.\n\n`CommonPrefixes`\
+            \ contains all (if there are any) keys between `Prefix` and the next occurrence\
+            \ of the string specified by a delimiter.\n\n`CommonPrefixes` lists keys\
+            \ that act like subdirectories in the directory specified by `Prefix`.\n\
+            \nFor example, if the prefix is `notes/` and the delimiter is a slash\
+            \ (`/`) as in `notes/summer/july`, the common prefix is `notes/summer/`.\
+            \ All of the keys that roll up into a common prefix count as a single\
+            \ return when calculating the number of returns.\n\n  * **Directory buckets**\
+            \ \\- For directory buckets, only prefixes that end in a delimiter (`/`)\
+            \ are supported.\n\n  * **Directory buckets** \\- When you query `ListObjectsV2`\
+            \ with a delimiter during in-progress multipart uploads, the `CommonPrefixes`\
+            \ response parameter contains the prefixes that are associated with the\
+            \ in-progress multipart uploads. For more information about multipart\
+            \ uploads, see [Multipart Upload Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html)\
+            \ in the _Amazon S3 User Guide_."
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+          description: 'Encoding type used by Amazon S3 to encode object key names
+            in the XML response.
+
+
+            If you specify the `encoding-type` request parameter, Amazon S3 includes
+            this element in the response, and returns encoded key name values in the
+            following response elements:
+
+
+            `Delimiter, Prefix, Key,` and `StartAfter`.'
+        KeyCount:
+          $ref: '#/components/schemas/KeyCount'
+          description: '`KeyCount` is the number of keys returned with this request.
+            `KeyCount` will always be less than or equal to the `MaxKeys` field. For
+            example, if you ask for 50 keys, your result will include 50 keys or fewer.'
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: If `ContinuationToken` was sent with the request, it is included
+            in the response. You can use the returned `ContinuationToken` for pagination
+            of the list response.
+        NextContinuationToken:
+          $ref: '#/components/schemas/NextToken'
+          description: '`NextContinuationToken` is sent when `isTruncated` is true,
+            which means there are more keys in the bucket that can be listed. The
+            next list requests to Amazon S3 can be continued with this `NextContinuationToken`.
+            `NextContinuationToken` is obfuscated and is not a real key'
+        StartAfter:
+          $ref: '#/components/schemas/StartAfter'
+          description: 'If StartAfter was sent with the request, it is included in
+            the response.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    ListObjectsV2Request:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: '**Directory buckets** \- When you use this operation with
+            a directory bucket, you must use virtual-hosted-style requests in the
+            format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Delimiter:
+          $ref: '#/components/schemas/Delimiter'
+          description: "A delimiter is a character that you use to group keys.\n\n\
+            `CommonPrefixes` is filtered out from results if it is not lexicographically\
+            \ greater than the `StartAfter` value.\n\n  * **Directory buckets** \\\
+            - For directory buckets, `/` is the only supported delimiter.\n\n  * **Directory\
+            \ buckets** \\- When you query `ListObjectsV2` with a delimiter during\
+            \ in-progress multipart uploads, the `CommonPrefixes` response parameter\
+            \ contains the prefixes that are associated with the in-progress multipart\
+            \ uploads. For more information about multipart uploads, see [Multipart\
+            \ Upload Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html)\
+            \ in the _Amazon S3 User Guide_."
+        EncodingType:
+          $ref: '#/components/schemas/EncodingType'
+          description: 'Encoding type used by Amazon S3 to encode the [object keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)
+            in the response. Responses are encoded only in UTF-8. An object key can
+            contain any Unicode character. However, the XML 1.0 parser can''t parse
+            certain characters, such as characters with an ASCII value from 0 to 10.
+            For characters that aren''t supported in XML 1.0, you can add this parameter
+            to request that Amazon S3 encode the keys in the response. For more information
+            about characters to avoid in object key names, see [Object key naming
+            guidelines](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-guidelines).
+
+
+            When using the URL encoding type, non-ASCII characters that are used in
+            an object''s key name will be percent-encoded according to UTF-8 code
+            values. For example, the object `test_file(3).png` will appear as `test_file%283%29.png`.'
+        MaxKeys:
+          $ref: '#/components/schemas/MaxKeys'
+          description: Sets the maximum number of keys returned in the response. By
+            default, the action returns up to 1,000 key names. The response might
+            contain fewer keys but will never contain more.
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'Limits the response to keys that begin with the specified
+            prefix.
+
+
+            **Directory buckets** \- For directory buckets, only prefixes that end
+            in a delimiter (`/`) are supported.'
+        ContinuationToken:
+          $ref: '#/components/schemas/Token'
+          description: '`ContinuationToken` indicates to Amazon S3 that the list is
+            being continued on this bucket with a token. `ContinuationToken` is obfuscated
+            and is not a real key. You can use this `ContinuationToken` for pagination
+            of the list results.'
+        FetchOwner:
+          $ref: '#/components/schemas/FetchOwner'
+          description: 'The owner field is not present in `ListObjectsV2` by default.
+            If you want to return the owner field with each key in the result, then
+            set the `FetchOwner` field to `true`.
+
+
+            **Directory buckets** \- For directory buckets, the bucket owner is returned
+            as the object owner for all objects.'
+        StartAfter:
+          $ref: '#/components/schemas/StartAfter'
+          description: 'StartAfter is where you want Amazon S3 to start listing from.
+            Amazon S3 starts listing after this specified key. StartAfter can be any
+            key in the bucket.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+          description: 'Confirms that the requester knows that she or he will be charged
+            for the list objects request in V2 style. Bucket owners need not specify
+            this parameter in their requests.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        OptionalObjectAttributes:
+          $ref: '#/components/schemas/OptionalObjectAttributesList'
+          description: 'Specifies the optional fields that you want returned in the
+            response. Fields that you do not specify are not returned.
+
+
+            This functionality is not supported for directory buckets.'
+      required:
+      - Bucket
+    ListPartsOutput:
+      type: object
+      properties:
+        AbortDate:
+          $ref: '#/components/schemas/AbortDate'
+          description: 'If the bucket has a lifecycle rule configured with an action
+            to abort incomplete multipart uploads and the prefix in the lifecycle
+            rule matches the object name in the request, then the response includes
+            this header indicating when the initiated multipart upload will become
+            eligible for abort operation. For more information, see [Aborting Incomplete
+            Multipart Uploads Using a Bucket Lifecycle Configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config).
+
+
+            The response will also include the `x-amz-abort-rule-id` header that will
+            provide the ID of the lifecycle configuration rule that defines this action.
+
+
+            This functionality is not supported for directory buckets.'
+        AbortRuleId:
+          $ref: '#/components/schemas/AbortRuleId'
+          description: 'This header is returned along with the `x-amz-abort-date`
+            header. It identifies applicable lifecycle configuration rule that defines
+            the action to abort incomplete multipart uploads.
+
+
+            This functionality is not supported for directory buckets.'
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket to which the multipart upload was initiated.
+            Does not return the access point ARN or access point alias if used.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the multipart upload was initiated.
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: Upload ID identifying the multipart upload whose parts are
+            being listed.
+        PartNumberMarker:
+          $ref: '#/components/schemas/PartNumberMarker'
+          description: Specifies the part after which listing should begin. Only parts
+            with higher part numbers will be listed.
+        NextPartNumberMarker:
+          $ref: '#/components/schemas/NextPartNumberMarker'
+          description: When a list is truncated, this element specifies the last part
+            in the list, as well as the value to use for the `part-number-marker`
+            request parameter in a subsequent request.
+        MaxParts:
+          $ref: '#/components/schemas/MaxParts'
+          description: Maximum number of parts that were allowed in the response.
+        IsTruncated:
+          $ref: '#/components/schemas/IsTruncated'
+          description: Indicates whether the returned list of parts is truncated.
+            A true value indicates that the list was truncated. A list can be truncated
+            if the number of parts exceeds the limit returned in the MaxParts element.
+        Parts:
+          $ref: '#/components/schemas/Parts'
+          description: Container for elements related to a particular part. A response
+            can contain zero or more `Part` elements.
+        Initiator:
+          $ref: '#/components/schemas/Initiator'
+          description: Container element that identifies who initiated the multipart
+            upload. If the initiator is an Amazon Web Services account, this element
+            provides the same information as the `Owner` element. If the initiator
+            is an IAM User, this element provides the user ARN.
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: 'Container element that identifies the object owner, after
+            the object is created. If multipart upload is initiated by an IAM user,
+            this element provides the parent account ID.
+
+
+            **Directory buckets** \- The bucket owner is returned as the object owner
+            for all the parts.'
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: 'The class of storage used to store the uploaded object.
+
+
+            **Directory buckets** \- Directory buckets only support `EXPRESS_ONEZONE`
+            (the S3 Express One Zone storage class) in Availability Zones and `ONEZONE_IA`
+            (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: The algorithm that was used to create a checksum of the object.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type, which determines how part-level checksums
+            are combined to create an object-level checksum for multipart objects.
+            You can use this header response to verify that the checksum type that
+            is received is the same checksum type that was specified in `CreateMultipartUpload`
+            request. For more information, see [Checking object integrity in the Amazon
+            S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+    ListPartsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket to which the parts are being uploaded.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the multipart upload was initiated.
+        MaxParts:
+          $ref: '#/components/schemas/MaxParts'
+          description: Sets the maximum number of parts to return.
+        PartNumberMarker:
+          $ref: '#/components/schemas/PartNumberMarker'
+          description: Specifies the part after which listing should begin. Only parts
+            with higher part numbers will be listed.
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: Upload ID identifying the multipart upload whose parts are
+            being listed.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'The server-side encryption (SSE) algorithm used to encrypt
+            the object. This parameter is needed only when the object was created
+            using a checksum algorithm. For more information, see [Protecting data
+            using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'The server-side encryption (SSE) customer managed key. This
+            parameter is needed only when the object was created using a checksum
+            algorithm. For more information, see [Protecting data using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'The MD5 server-side encryption (SSE) customer managed key.
+            This parameter is needed only when the object was created using a checksum
+            algorithm. For more information, see [Protecting data using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+      required:
+      - Bucket
+      - Key
+      - UploadId
+    Location:
+      type: string
+    LocationInfo:
+      type: object
+      properties:
+        Type:
+          $ref: '#/components/schemas/LocationType'
+          description: The type of location where the bucket will be created.
+        Name:
+          $ref: '#/components/schemas/LocationNameAsString'
+          description: 'The name of the location where the bucket will be created.
+
+
+            For directory buckets, the name of the location is the Zone ID of the
+            Availability Zone (AZ) or Local Zone (LZ) where the bucket will be created.
+            An example AZ ID value is `usw2-az1`.'
+      description: 'Specifies the location where the bucket will be created.
+
+
+        For directory buckets, the location type is Availability Zone or Local Zone.
+        For more information about directory buckets, see [Working with directory
+        buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-overview.html)
+        in the _Amazon S3 User Guide_.
+
+
+        This functionality is only supported by directory buckets.'
+    LocationNameAsString:
+      type: string
+    LocationPrefix:
+      type: string
+    LocationType:
+      type: string
+      enum:
+      - AvailabilityZone
+      - LocalZone
+    LoggingEnabled:
+      type: object
+      properties:
+        TargetBucket:
+          $ref: '#/components/schemas/TargetBucket'
+          description: Specifies the bucket where you want Amazon S3 to store server
+            access logs. You can have your logs delivered to any bucket that you own,
+            including the same bucket that is being logged. You can also configure
+            multiple buckets to deliver their logs to the same target bucket. In this
+            case, you should choose a different `TargetPrefix` for each source bucket
+            so that the delivered log files can be distinguished by key.
+        TargetGrants:
+          $ref: '#/components/schemas/TargetGrants'
+          description: 'Container for granting information.
+
+
+            Buckets that use the bucket owner enforced setting for Object Ownership
+            don''t support target grants. For more information, see [Permissions for
+            server access log delivery](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html#grant-log-delivery-permissions-general)
+            in the _Amazon S3 User Guide_.'
+        TargetPrefix:
+          $ref: '#/components/schemas/TargetPrefix'
+          description: A prefix for all log object keys. If you store log files from
+            multiple Amazon S3 buckets in a single bucket, you can use a prefix to
+            distinguish which log files came from which bucket.
+        TargetObjectKeyFormat:
+          $ref: '#/components/schemas/TargetObjectKeyFormat'
+          description: Amazon S3 key format for log objects.
+      required:
+      - TargetBucket
+      - TargetPrefix
+      description: Describes where logs are stored and the prefix that Amazon S3 assigns
+        to all log object keys for a bucket. For more information, see [PUT Bucket
+        logging](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html)
+        in the _Amazon S3 API Reference_.
+    MFA:
+      type: string
+    MFADelete:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    MFADeleteStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    Marker:
+      type: string
+    MaxAgeSeconds:
+      type: integer
+    MaxBuckets:
+      type: integer
+      minimum: 1
+      maximum: 10000
+    MaxDirectoryBuckets:
+      type: integer
+      minimum: 0
+      maximum: 1000
+    MaxKeys:
+      type: integer
+    MaxParts:
+      type: integer
+    MaxUploads:
+      type: integer
+    Message:
+      type: string
+    Metadata:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/metadatavalue'
+    MetadataConfiguration:
+      type: object
+      properties:
+        JournalTableConfiguration:
+          $ref: '#/components/schemas/JournalTableConfiguration'
+          description: The journal table configuration for a metadata configuration.
+        InventoryTableConfiguration:
+          $ref: '#/components/schemas/InventoryTableConfiguration'
+          description: The inventory table configuration for a metadata configuration.
+      required:
+      - JournalTableConfiguration
+      description: The S3 Metadata configuration for a general purpose bucket.
+    MetadataConfigurationResult:
+      type: object
+      properties:
+        DestinationResult:
+          $ref: '#/components/schemas/DestinationResult'
+          description: The destination settings for a metadata configuration.
+        JournalTableConfigurationResult:
+          $ref: '#/components/schemas/JournalTableConfigurationResult'
+          description: The journal table configuration for a metadata configuration.
+        InventoryTableConfigurationResult:
+          $ref: '#/components/schemas/InventoryTableConfigurationResult'
+          description: The inventory table configuration for a metadata configuration.
+      required:
+      - DestinationResult
+      description: The S3 Metadata configuration for a general purpose bucket.
+    MetadataDirective:
+      type: string
+      enum:
+      - COPY
+      - REPLACE
+    MetadataEntry:
+      type: object
+      properties:
+        Name:
+          $ref: '#/components/schemas/MetadataKey'
+          description: Name of the object.
+        Value:
+          $ref: '#/components/schemas/MetadataValue'
+          description: Value of the object.
+      description: A metadata key-value pair to store with an object.
+    MetadataKey:
+      type: string
+    MetadataTableConfiguration:
+      type: object
+      properties:
+        S3TablesDestination:
+          $ref: '#/components/schemas/S3TablesDestination'
+          description: The destination information for the metadata table configuration.
+            The destination table bucket must be in the same Region and Amazon Web
+            Services account as the general purpose bucket. The specified metadata
+            table name must be unique within the `aws_s3_metadata` namespace in the
+            destination table bucket.
+      required:
+      - S3TablesDestination
+      description: 'The V1 S3 Metadata configuration for a general purpose bucket.
+
+
+        If you created your S3 Metadata configuration before July 15, 2025, we recommend
+        that you delete and re-create your configuration by using [CreateBucketMetadataConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html)
+        so that you can expire journal table records and create a live inventory table.'
+    MetadataTableConfigurationResult:
+      type: object
+      properties:
+        S3TablesDestinationResult:
+          $ref: '#/components/schemas/S3TablesDestinationResult'
+          description: The destination information for the metadata table configuration.
+            The destination table bucket must be in the same Region and Amazon Web
+            Services account as the general purpose bucket. The specified metadata
+            table name must be unique within the `aws_s3_metadata` namespace in the
+            destination table bucket.
+      required:
+      - S3TablesDestinationResult
+      description: 'The V1 S3 Metadata configuration for a general purpose bucket.
+        The destination table bucket must be in the same Region and Amazon Web Services
+        account as the general purpose bucket. The specified metadata table name must
+        be unique within the `aws_s3_metadata` namespace in the destination table
+        bucket.
+
+
+        If you created your S3 Metadata configuration before July 15, 2025, we recommend
+        that you delete and re-create your configuration by using [CreateBucketMetadataConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html)
+        so that you can expire journal table records and create a live inventory table.'
+    MetadataTableEncryptionConfiguration:
+      type: object
+      properties:
+        SseAlgorithm:
+          $ref: '#/components/schemas/TableSseAlgorithm'
+          description: The encryption type specified for a metadata table. To specify
+            server-side encryption with Key Management Service (KMS) keys (SSE-KMS),
+            use the `aws:kms` value. To specify server-side encryption with Amazon
+            S3 managed keys (SSE-S3), use the `AES256` value.
+        KmsKeyArn:
+          $ref: '#/components/schemas/KmsKeyArn'
+          description: If server-side encryption with Key Management Service (KMS)
+            keys (SSE-KMS) is specified, you must also specify the KMS key Amazon
+            Resource Name (ARN). You must specify a customer-managed KMS key that's
+            located in the same Region as the general purpose bucket that corresponds
+            to the metadata table configuration.
+      required:
+      - SseAlgorithm
+      description: The encryption settings for an S3 Metadata journal table or inventory
+        table configuration.
+    MetadataTableStatus:
+      type: string
+    MetadataValue:
+      type: string
+    Metrics:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/MetricsStatus'
+          description: Specifies whether the replication metrics are enabled.
+        EventThreshold:
+          $ref: '#/components/schemas/ReplicationTimeValue'
+          description: A container specifying the time threshold for emitting the
+            `s3:Replication:OperationMissedThreshold` event.
+      required:
+      - Status
+      description: A container specifying replication metrics-related settings enabling
+        replication metrics and events.
+    MetricsAndOperator:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: The prefix used when evaluating an AND predicate.
+        Tags:
+          $ref: '#/components/schemas/TagSet'
+          description: The list of tags used when evaluating an AND predicate.
+        AccessPointArn:
+          $ref: '#/components/schemas/AccessPointArn'
+          description: The access point ARN used when evaluating an `AND` predicate.
+      description: A conjunction (logical AND) of predicates, which is used in evaluating
+        a metrics filter. The operator must have at least two predicates, and an object
+        must match all of the predicates in order for the filter to apply.
+    MetricsConfiguration:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/MetricsId'
+          description: The ID used to identify the metrics configuration. The ID has
+            a 64 character limit and can only contain letters, numbers, periods, dashes,
+            and underscores.
+        Filter:
+          $ref: '#/components/schemas/MetricsFilter'
+          description: Specifies a metrics configuration filter. The metrics configuration
+            will only include objects that meet the filter's criteria. A filter must
+            be a prefix, an object tag, an access point ARN, or a conjunction (MetricsAndOperator).
+      required:
+      - Id
+      description: Specifies a metrics configuration for the CloudWatch request metrics
+        (specified by the metrics configuration ID) from an Amazon S3 bucket. If you're
+        updating an existing metrics configuration, note that this is a full replacement
+        of the existing metrics configuration. If you don't include the elements you
+        want to keep, they are erased. For more information, see [PutBucketMetricsConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTMetricConfiguration.html).
+    MetricsConfigurationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/MetricsConfiguration'
+    MetricsFilter:
+      allOf:
+      - $ref: '#/components/schemas/Prefix'
+        description: |-
+          The prefix used when evaluating a metrics filter.
+      - $ref: '#/components/schemas/Tag'
+        description: |-
+          The tag used when evaluating a metrics filter.
+      - $ref: '#/components/schemas/AccessPointArn'
+        description: |-
+          The access point ARN used when evaluating a metrics filter.
+      - $ref: '#/components/schemas/MetricsAndOperator'
+        description: |-
+          A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter. The operator must have at least two predicates, and an object must match all of the predicates in order for the filter to apply.
+      description: |-
+        Specifies a metrics configuration filter. The metrics configuration only includes objects that meet the filter's criteria. A filter must be a prefix, an object tag, an access point ARN, or a conjunction (MetricsAndOperator). For more information, see [PutBucketMetricsConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html).
+    MetricsId:
+      type: string
+    MetricsStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    Minutes:
+      type: integer
+    MissingMeta:
+      type: integer
+    MpuObjectSize:
+      type: integer
+      format: int64
+    MultipartUpload:
+      type: object
+      properties:
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: Upload ID that identifies the multipart upload.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Key of the object for which the multipart upload was initiated.
+        Initiated:
+          $ref: '#/components/schemas/Initiated'
+          description: Date and time at which the multipart upload was initiated.
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: 'The class of storage used to store the object.
+
+
+            **Directory buckets** \- Directory buckets only support `EXPRESS_ONEZONE`
+            (the S3 Express One Zone storage class) in Availability Zones and `ONEZONE_IA`
+            (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.'
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: 'Specifies the owner of the object that is part of the multipart
+            upload.
+
+
+            **Directory buckets** \- The bucket owner is returned as the object owner
+            for all the objects.'
+        Initiator:
+          $ref: '#/components/schemas/Initiator'
+          description: Identifies who initiated the multipart upload.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: The algorithm that was used to create a checksum of the object.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type that is used to calculate the object’s checksum
+            value. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+      description: Container for the `MultipartUpload` for the Amazon S3 object.
+    MultipartUploadId:
+      type: string
+    MultipartUploadList:
+      type: array
+      items:
+        $ref: '#/components/schemas/MultipartUpload'
+    NextKeyMarker:
+      type: string
+    NextMarker:
+      type: string
+    NextPartNumberMarker:
+      type: string
+    NextToken:
+      type: string
+    NextUploadIdMarker:
+      type: string
+    NextVersionIdMarker:
+      type: string
+    NoSuchBucket:
+      type: object
+      properties: {}
+      description: The specified bucket does not exist.
+    NoSuchKey:
+      type: object
+      properties: {}
+      description: The specified key does not exist.
+    NoSuchUpload:
+      type: object
+      properties: {}
+      description: The specified multipart upload does not exist.
+    NoncurrentVersionExpiration:
+      type: object
+      properties:
+        NoncurrentDays:
+          $ref: '#/components/schemas/Days'
+          description: 'Specifies the number of days an object is noncurrent before
+            Amazon S3 can perform the associated action. The value must be a non-zero
+            positive integer. For information about the noncurrent days calculations,
+            see [How Amazon S3 Calculates When an Object Became Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations)
+            in the _Amazon S3 User Guide_.
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+        NewerNoncurrentVersions:
+          $ref: '#/components/schemas/VersionCount'
+          description: 'Specifies how many noncurrent versions Amazon S3 will retain.
+            You can specify up to 100 noncurrent versions to retain. Amazon S3 will
+            permanently delete any additional noncurrent versions beyond the specified
+            number to retain. For more information about noncurrent versions, see
+            [Lifecycle configuration elements](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+      description: 'Specifies when noncurrent object versions expire. Upon expiration,
+        Amazon S3 permanently deletes the noncurrent object versions. You set this
+        lifecycle configuration action on a bucket that has versioning enabled (or
+        suspended) to request that Amazon S3 delete noncurrent object versions at
+        a specific period in the object''s lifetime.
+
+
+        This parameter applies to general purpose buckets only. It is not supported
+        for directory bucket lifecycle configurations.'
+    NoncurrentVersionTransition:
+      type: object
+      properties:
+        NoncurrentDays:
+          $ref: '#/components/schemas/Days'
+          description: Specifies the number of days an object is noncurrent before
+            Amazon S3 can perform the associated action. For information about the
+            noncurrent days calculations, see [How Amazon S3 Calculates How Long an
+            Object Has Been Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations)
+            in the _Amazon S3 User Guide_.
+        StorageClass:
+          $ref: '#/components/schemas/TransitionStorageClass'
+          description: The class of storage used to store the object.
+        NewerNoncurrentVersions:
+          $ref: '#/components/schemas/VersionCount'
+          description: Specifies how many noncurrent versions Amazon S3 will retain
+            in the same storage class before transitioning objects. You can specify
+            up to 100 noncurrent versions to retain. Amazon S3 will transition any
+            additional noncurrent versions beyond the specified number to retain.
+            For more information about noncurrent versions, see [Lifecycle configuration
+            elements](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html)
+            in the _Amazon S3 User Guide_.
+      description: Container for the transition rule that describes when noncurrent
+        objects transition to the `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`,
+        `GLACIER_IR`, `GLACIER`, or `DEEP_ARCHIVE` storage class. If your bucket is
+        versioning-enabled (or versioning is suspended), you can set this action to
+        request that Amazon S3 transition noncurrent object versions to the `STANDARD_IA`,
+        `ONEZONE_IA`, `INTELLIGENT_TIERING`, `GLACIER_IR`, `GLACIER`, or `DEEP_ARCHIVE`
+        storage class at a specific period in the object's lifetime.
+    NoncurrentVersionTransitionList:
+      type: array
+      items:
+        $ref: '#/components/schemas/NoncurrentVersionTransition'
+    NotFound:
+      type: object
+      properties: {}
+      description: The specified content does not exist.
+    NotificationConfiguration:
+      type: object
+      properties:
+        TopicConfigurations:
+          $ref: '#/components/schemas/TopicConfigurationList'
+          description: The topic to which notifications are sent and the events for
+            which notifications are generated.
+        QueueConfigurations:
+          $ref: '#/components/schemas/QueueConfigurationList'
+          description: The Amazon Simple Queue Service queues to publish messages
+            to and the events for which to publish messages.
+        LambdaFunctionConfigurations:
+          $ref: '#/components/schemas/LambdaFunctionConfigurationList'
+          description: Describes the Lambda functions to invoke and the events for
+            which to invoke them.
+        EventBridgeConfiguration:
+          $ref: '#/components/schemas/EventBridgeConfiguration'
+          description: Enables delivery of events to Amazon EventBridge.
+      description: A container for specifying the notification configuration of the
+        bucket. If this element is empty, notifications are turned off for the bucket.
+    NotificationConfigurationFilter:
+      type: object
+      properties:
+        Key:
+          $ref: '#/components/schemas/S3KeyFilter'
+      description: Specifies object key name filtering rules. For information about
+        key name filtering, see [Configuring event notifications using object key
+        name filtering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-filtering.html)
+        in the _Amazon S3 User Guide_.
+    NotificationId:
+      type: string
+    Object:
+      type: object
+      properties:
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The name that you assign to an object. You use the object key
+            to retrieve the object.
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Creation date of the object.
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: "The entity tag is a hash of the object. The ETag reflects\
+            \ changes only to the contents of an object, not its metadata. The ETag\
+            \ may or may not be an MD5 digest of the object data. Whether or not it\
+            \ is depends on how the object was created and how it is encrypted as\
+            \ described below:\n\n  * Objects created by the PUT Object, POST Object,\
+            \ or Copy operation, or through the Amazon Web Services Management Console,\
+            \ and are encrypted by SSE-S3 or plaintext, have ETags that are an MD5\
+            \ digest of their object data.\n\n  * Objects created by the PUT Object,\
+            \ POST Object, or Copy operation, or through the Amazon Web Services Management\
+            \ Console, and are encrypted by SSE-C or SSE-KMS, have ETags that are\
+            \ not an MD5 digest of their object data.\n\n  * If an object is created\
+            \ by either the Multipart Upload or Part Copy operation, the ETag is not\
+            \ an MD5 digest, regardless of the method of encryption. If an object\
+            \ is larger than 16 MB, the Amazon Web Services Management Console will\
+            \ upload or copy that object as a Multipart Upload, and therefore the\
+            \ ETag will not be an MD5 digest.\n\n**Directory buckets** \\- MD5 is\
+            \ not supported by directory buckets."
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithmList'
+          description: The algorithm that was used to create a checksum of the object.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type that is used to calculate the object’s checksum
+            value. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        Size:
+          $ref: '#/components/schemas/Size'
+          description: Size in bytes of the object
+        StorageClass:
+          $ref: '#/components/schemas/ObjectStorageClass'
+          description: 'The class of storage used to store the object.
+
+
+            **Directory buckets** \- Directory buckets only support `EXPRESS_ONEZONE`
+            (the S3 Express One Zone storage class) in Availability Zones and `ONEZONE_IA`
+            (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.'
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: 'The owner of the object
+
+
+            **Directory buckets** \- The bucket owner is returned as the object owner.'
+        RestoreStatus:
+          $ref: '#/components/schemas/RestoreStatus'
+          description: 'Specifies the restoration status of an object. Objects in
+            certain storage classes must be restored before they can be retrieved.
+            For more information about these storage classes and how to work with
+            archived objects, see [ Working with archived objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/archived-objects.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets. Directory buckets
+            only support `EXPRESS_ONEZONE` (the S3 Express One Zone storage class)
+            in Availability Zones and `ONEZONE_IA` (the S3 One Zone-Infrequent Access
+            storage class) in Dedicated Local Zones.'
+      description: An object consists of data and its descriptive metadata.
+    ObjectAlreadyInActiveTierError:
+      type: object
+      properties: {}
+      description: This action is not allowed against this storage tier.
+    ObjectAttributes:
+      type: string
+      enum:
+      - ETag
+      - Checksum
+      - ObjectParts
+      - StorageClass
+      - ObjectSize
+    ObjectAttributesList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ObjectAttributes'
+    ObjectCannedACL:
+      type: string
+      enum:
+      - private
+      - public-read
+      - public-read-write
+      - authenticated-read
+      - aws-exec-read
+      - bucket-owner-read
+      - bucket-owner-full-control
+    ObjectIdentifier:
+      type: object
+      properties:
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: 'Key name of the object.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID for the specific version of the object to delete.
+
+
+            This functionality is not supported for directory buckets.'
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: 'An entity tag (ETag) is an identifier assigned by a web server
+            to a specific version of a resource found at a URL. This header field
+            makes the request method conditional on `ETags`.
+
+
+            Entity tags (ETags) for S3 Express One Zone are random alphanumeric strings
+            unique to the object.'
+        LastModifiedTime:
+          $ref: '#/components/schemas/LastModifiedTime'
+          description: 'If present, the objects are deleted only if its modification
+            times matches the provided `Timestamp`.
+
+
+            This functionality is only supported for directory buckets.'
+        Size:
+          $ref: '#/components/schemas/Size'
+          description: 'If present, the objects are deleted only if its size matches
+            the provided size in bytes.
+
+
+            This functionality is only supported for directory buckets.'
+      required:
+      - Key
+      description: Object Identifier is unique value to identify objects.
+    ObjectIdentifierList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ObjectIdentifier'
+    ObjectKey:
+      type: string
+      minLength: 1
+    ObjectList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Object'
+    ObjectLockConfiguration:
+      type: object
+      properties:
+        ObjectLockEnabled:
+          $ref: '#/components/schemas/ObjectLockEnabled'
+          description: Indicates whether this bucket has an Object Lock configuration
+            enabled. Enable `ObjectLockEnabled` when you apply `ObjectLockConfiguration`
+            to a bucket.
+        Rule:
+          $ref: '#/components/schemas/ObjectLockRule'
+          description: Specifies the Object Lock rule for the specified object. Enable
+            the this rule when you apply `ObjectLockConfiguration` to a bucket. Bucket
+            settings require both a mode and a period. The period can be either `Days`
+            or `Years` but you must select one. You cannot specify `Days` and `Years`
+            at the same time.
+      description: The container element for Object Lock configuration parameters.
+    ObjectLockEnabled:
+      type: string
+      enum:
+      - Enabled
+    ObjectLockEnabledForBucket:
+      type: boolean
+    ObjectLockLegalHold:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/ObjectLockLegalHoldStatus'
+          description: Indicates whether the specified object has a legal hold in
+            place.
+      description: A legal hold configuration for an object.
+    ObjectLockLegalHoldStatus:
+      type: string
+      enum:
+      - 'ON'
+      - 'OFF'
+    ObjectLockMode:
+      type: string
+      enum:
+      - GOVERNANCE
+      - COMPLIANCE
+    ObjectLockRetainUntilDate:
+      type: string
+      format: date-time
+    ObjectLockRetention:
+      type: object
+      properties:
+        Mode:
+          $ref: '#/components/schemas/ObjectLockRetentionMode'
+          description: Indicates the Retention mode for the specified object.
+        RetainUntilDate:
+          $ref: '#/components/schemas/Date'
+          description: The date on which this Object Lock Retention will expire.
+      description: A Retention configuration for an object.
+    ObjectLockRetentionMode:
+      type: string
+      enum:
+      - GOVERNANCE
+      - COMPLIANCE
+    ObjectLockRule:
+      type: object
+      properties:
+        DefaultRetention:
+          $ref: '#/components/schemas/DefaultRetention'
+          description: The default Object Lock retention mode and period that you
+            want to apply to new objects placed in the specified bucket. Bucket settings
+            require both a mode and a period. The period can be either `Days` or `Years`
+            but you must select one. You cannot specify `Days` and `Years` at the
+            same time.
+      description: The container element for an Object Lock rule.
+    ObjectLockToken:
+      type: string
+    ObjectNotInActiveTierError:
+      type: object
+      properties: {}
+      description: The source object of the COPY action is not in the active tier
+        and is only stored in Amazon S3 Glacier.
+    ObjectOwnership:
+      type: string
+      enum:
+      - BucketOwnerPreferred
+      - ObjectWriter
+      - BucketOwnerEnforced
+      description: "<p>The container element for object ownership for a bucket's ownership\
+        \ controls.</p>\n         <p>\n            <code>BucketOwnerPreferred</code>\
+        \ - Objects uploaded to the bucket change ownership to the bucket\n      owner\
+        \ if the objects are uploaded with the <code>bucket-owner-full-control</code>\
+        \ canned ACL.</p>\n         <p>\n            <code>ObjectWriter</code> - The\
+        \ uploading account will own the object if the object is uploaded with\n \
+        \     the <code>bucket-owner-full-control</code> canned ACL.</p>\n       \
+        \  <p>\n            <code>BucketOwnerEnforced</code> - Access control lists\
+        \ (ACLs) are disabled and no longer affect\n      permissions. The bucket\
+        \ owner automatically owns and has full control over every object in the bucket.\n\
+        \      The bucket only accepts PUT requests that don't specify an ACL or specify\
+        \ bucket owner full control ACLs\n      (such as the predefined <code>bucket-owner-full-control</code>\
+        \ canned ACL or a custom ACL in XML format\n      that grants the same permissions).</p>\n\
+        \         <p>By default, <code>ObjectOwnership</code> is set to <code>BucketOwnerEnforced</code>\
+        \ and ACLs are\n      disabled. We recommend keeping ACLs disabled, except\
+        \ in uncommon use cases where you must control access\n      for each object\
+        \ individually. For more information about S3 Object Ownership, see <a href=\"\
+        https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html\"\
+        >Controlling\n        ownership of objects and disabling ACLs for your bucket</a>\
+        \ in the\n        <i>Amazon S3 User Guide</i>. </p>\n         <note>\n   \
+        \         <p>This functionality is not supported for directory buckets. Directory\
+        \ buckets use the bucket owner enforced setting for S3 Object Ownership.</p>\n\
+        \         </note>"
+    ObjectPart:
+      type: object
+      properties:
+        PartNumber:
+          $ref: '#/components/schemas/PartNumber'
+          description: The part number identifying the part. This value is a positive
+            integer between 1 and 10,000.
+        Size:
+          $ref: '#/components/schemas/Size'
+          description: The size of the uploaded part in bytes.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32` checksum of the part. This
+            checksum is present if the multipart upload request was created with the
+            `CRC32` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the part. This
+            checksum is present if the multipart upload request was created with the
+            `CRC32C` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the part.
+            This checksum is present if the multipart upload request was created with
+            the `CRC64NVME` checksum algorithm, or if the object was uploaded without
+            a checksum (and Amazon S3 added the default checksum, `CRC64NVME`, to
+            the uploaded object). For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` checksum of the part. This
+            checksum is present if the multipart upload request was created with the
+            `SHA1` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` checksum of the part.
+            This checksum is present if the multipart upload request was created with
+            the `SHA256` checksum algorithm. For more information, see [Checking object
+            integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+      description: A container for elements related to an individual part.
+    ObjectSize:
+      type: integer
+      format: int64
+    ObjectSizeGreaterThanBytes:
+      type: integer
+      format: int64
+    ObjectSizeLessThanBytes:
+      type: integer
+      format: int64
+    ObjectStorageClass:
+      type: string
+      enum:
+      - STANDARD
+      - REDUCED_REDUNDANCY
+      - GLACIER
+      - STANDARD_IA
+      - ONEZONE_IA
+      - INTELLIGENT_TIERING
+      - DEEP_ARCHIVE
+      - OUTPOSTS
+      - GLACIER_IR
+      - SNOW
+      - EXPRESS_ONEZONE
+      - FSX_OPENZFS
+      - FSX_ONTAP
+    ObjectVersion:
+      type: object
+      properties:
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: The entity tag is an MD5 hash of that version of the object.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithmList'
+          description: The algorithm that was used to create a checksum of the object.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: The checksum type that is used to calculate the object’s checksum
+            value. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        Size:
+          $ref: '#/components/schemas/Size'
+          description: Size in bytes of the object.
+        StorageClass:
+          $ref: '#/components/schemas/ObjectVersionStorageClass'
+          description: The class of storage used to store the object.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The object key.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: Version ID of an object.
+        IsLatest:
+          $ref: '#/components/schemas/IsLatest'
+          description: Specifies whether the object is (true) or is not (false) the
+            latest version of an object.
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Date and time when the object was last modified.
+        Owner:
+          $ref: '#/components/schemas/Owner'
+          description: Specifies the owner of the object.
+        RestoreStatus:
+          $ref: '#/components/schemas/RestoreStatus'
+          description: Specifies the restoration status of an object. Objects in certain
+            storage classes must be restored before they can be retrieved. For more
+            information about these storage classes and how to work with archived
+            objects, see [ Working with archived objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/archived-objects.html)
+            in the _Amazon S3 User Guide_.
+      description: The version of an object.
+    ObjectVersionId:
+      type: string
+    ObjectVersionList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ObjectVersion'
+    ObjectVersionStorageClass:
+      type: string
+      enum:
+      - STANDARD
+    OptionalObjectAttributes:
+      type: string
+      enum:
+      - RestoreStatus
+    OptionalObjectAttributesList:
+      type: array
+      items:
+        $ref: '#/components/schemas/OptionalObjectAttributes'
+    OutputLocation:
+      type: object
+      properties:
+        S3:
+          $ref: '#/components/schemas/S3Location'
+          description: Describes an S3 location that will receive the results of the
+            restore request.
+      description: Describes the location where the restore job's output is stored.
+    OutputSerialization:
+      type: object
+      properties:
+        CSV:
+          $ref: '#/components/schemas/CSVOutput'
+          description: Describes the serialization of CSV-encoded Select results.
+        JSON:
+          $ref: '#/components/schemas/JSONOutput'
+          description: Specifies JSON as request's output serialization format.
+      description: Describes how results of the Select job are serialized.
+    Owner:
+      type: object
+      properties:
+        DisplayName:
+          $ref: '#/components/schemas/DisplayName'
+          description: ''
+        ID:
+          $ref: '#/components/schemas/ID'
+          description: Container for the ID of the owner.
+      description: Container for the owner's display name and ID.
+    OwnerOverride:
+      type: string
+      enum:
+      - Destination
+    OwnershipControls:
+      type: object
+      properties:
+        Rules:
+          $ref: '#/components/schemas/OwnershipControlsRules'
+          description: The container element for an ownership control rule.
+      required:
+      - Rules
+      description: The container element for a bucket's ownership controls.
+    OwnershipControlsRule:
+      type: object
+      properties:
+        ObjectOwnership:
+          $ref: '#/components/schemas/ObjectOwnership'
+      required:
+      - ObjectOwnership
+      description: The container element for an ownership control rule.
+    OwnershipControlsRules:
+      type: array
+      items:
+        $ref: '#/components/schemas/OwnershipControlsRule'
+    ParquetInput:
+      type: object
+      properties: {}
+      description: Container for Parquet.
+    Part:
+      type: object
+      properties:
+        PartNumber:
+          $ref: '#/components/schemas/PartNumber'
+          description: Part number identifying the part. This is a positive integer
+            between 1 and 10,000.
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: Date and time at which the part was uploaded.
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: Entity tag returned when the part was uploaded.
+        Size:
+          $ref: '#/components/schemas/Size'
+          description: Size in bytes of the uploaded part data.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32` checksum of the part. This
+            checksum is present if the object was uploaded with the `CRC32` checksum
+            algorithm. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the part. This
+            checksum is present if the object was uploaded with the `CRC32C` checksum
+            algorithm. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the part.
+            This checksum is present if the multipart upload request was created with
+            the `CRC64NVME` checksum algorithm, or if the object was uploaded without
+            a checksum (and Amazon S3 added the default checksum, `CRC64NVME`, to
+            the uploaded object). For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` checksum of the part. This
+            checksum is present if the object was uploaded with the `SHA1` checksum
+            algorithm. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` checksum of the part.
+            This checksum is present if the object was uploaded with the `SHA256`
+            checksum algorithm. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+      description: Container for elements related to a part.
+    PartNumber:
+      type: integer
+    PartNumberMarker:
+      type: string
+    PartitionDateSource:
+      type: string
+      enum:
+      - EventTime
+      - DeliveryTime
+    PartitionedPrefix:
+      type: object
+      properties:
+        PartitionDateSource:
+          $ref: '#/components/schemas/PartitionDateSource'
+          description: 'Specifies the partition date source for the partitioned prefix.
+            `PartitionDateSource` can be `EventTime` or `DeliveryTime`.
+
+
+            For `DeliveryTime`, the time in the log file names corresponds to the
+            delivery time for the log files.
+
+
+            For `EventTime`, The logs delivered are for a specific day only. The year,
+            month, and day correspond to the day on which the event occurred, and
+            the hour, minutes and seconds are set to 00 in the key.'
+      description: 'Amazon S3 keys for log objects are partitioned in the following
+        format:
+
+
+        `[DestinationPrefix][SourceAccountId]/[SourceRegion]/[SourceBucket]/[YYYY]/[MM]/[DD]/[YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]`
+
+
+        PartitionedPrefix defaults to EventTime delivery when server access logs are
+        delivered.'
+    Parts:
+      type: array
+      items:
+        $ref: '#/components/schemas/Part'
+    PartsCount:
+      type: integer
+    PartsList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ObjectPart'
+    Payer:
+      type: string
+      enum:
+      - Requester
+      - BucketOwner
+    Permission:
+      type: string
+      enum:
+      - FULL_CONTROL
+      - WRITE
+      - WRITE_ACP
+      - READ
+      - READ_ACP
+    Policy:
+      type: string
+    PolicyStatus:
+      type: object
+      properties:
+        IsPublic:
+          $ref: '#/components/schemas/IsPublic'
+          description: The policy status for this bucket. `TRUE` indicates that this
+            bucket is public. `FALSE` indicates that the bucket is not public.
+      description: The container element for a bucket's policy status.
+    Prefix:
+      type: string
+    Priority:
+      type: integer
+    Progress:
+      type: object
+      properties:
+        BytesScanned:
+          $ref: '#/components/schemas/BytesScanned'
+          description: The current number of object bytes scanned.
+        BytesProcessed:
+          $ref: '#/components/schemas/BytesProcessed'
+          description: The current number of uncompressed object bytes processed.
+        BytesReturned:
+          $ref: '#/components/schemas/BytesReturned'
+          description: The current number of bytes of records payload data returned.
+      description: This data type contains information about progress of an operation.
+    ProgressEvent:
+      type: object
+      properties:
+        Details:
+          $ref: '#/components/schemas/Progress'
+          description: The Progress event details.
+      description: This data type contains information about the progress event of
+        an operation.
+    Protocol:
+      type: string
+      enum:
+      - http
+      - https
+    PublicAccessBlockConfiguration:
+      type: object
+      properties:
+        BlockPublicAcls:
+          $ref: '#/components/schemas/Setting'
+          description: "Specifies whether Amazon S3 should block public access control\
+            \ lists (ACLs) for this bucket and objects in this bucket. Setting this\
+            \ element to `TRUE` causes the following behavior:\n\n  * PUT Bucket ACL\
+            \ and PUT Object ACL calls fail if the specified ACL is public.\n\n  *\
+            \ PUT Object calls fail if the request includes a public ACL.\n\n  * PUT\
+            \ Bucket calls fail if the request includes a public ACL.\n\nEnabling\
+            \ this setting doesn't affect existing policies or ACLs."
+        IgnorePublicAcls:
+          $ref: '#/components/schemas/Setting'
+          description: 'Specifies whether Amazon S3 should ignore public ACLs for
+            this bucket and objects in this bucket. Setting this element to `TRUE`
+            causes Amazon S3 to ignore all public ACLs on this bucket and objects
+            in this bucket.
+
+
+            Enabling this setting doesn''t affect the persistence of any existing
+            ACLs and doesn''t prevent new public ACLs from being set.'
+        BlockPublicPolicy:
+          $ref: '#/components/schemas/Setting'
+          description: 'Specifies whether Amazon S3 should block public bucket policies
+            for this bucket. Setting this element to `TRUE` causes Amazon S3 to reject
+            calls to PUT Bucket policy if the specified bucket policy allows public
+            access.
+
+
+            Enabling this setting doesn''t affect existing bucket policies.'
+        RestrictPublicBuckets:
+          $ref: '#/components/schemas/Setting'
+          description: 'Specifies whether Amazon S3 should restrict public bucket
+            policies for this bucket. Setting this element to `TRUE` restricts access
+            to this bucket to only Amazon Web Services service principals and authorized
+            users within this account if the bucket has a public policy.
+
+
+            Enabling this setting doesn''t affect previously stored bucket policies,
+            except that public and cross-account access within any public bucket policy,
+            including non-public delegation to specific accounts, is blocked.'
+      description: The PublicAccessBlock configuration that you want to apply to this
+        Amazon S3 bucket. You can enable the configuration options in any combination.
+        Bucket-level settings work alongside account-level settings (which may inherit
+        from organization-level policies). For more information about when Amazon
+        S3 considers a bucket or object public, see [The Meaning of "Public"](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status)
+        in the _Amazon S3 User Guide_.
+    PutBucketAbacRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the general purpose bucket.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash of the `PutBucketAbac` request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: Indicates the algorithm that you want Amazon S3 to use to create
+            the checksum. For more information, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The Amazon Web Services account ID of the general purpose bucket's
+            owner.
+        AbacStatus:
+          $ref: '#/components/schemas/AbacStatus'
+          description: The ABAC status of the general purpose bucket. When ABAC is
+            enabled for the general purpose bucket, you can use tags to manage access
+            to the general purpose buckets as well as for cost tracking purposes.
+            When ABAC is disabled for the general purpose buckets, you can only use
+            tags for cost tracking purposes. For more information, see [Using tags
+            with S3 general purpose buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html).
+      required:
+      - Bucket
+      - AbacStatus
+    PutBucketAccelerateConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which the accelerate configuration
+            is set.
+        AccelerateConfiguration:
+          $ref: '#/components/schemas/AccelerateConfiguration'
+          description: Container for setting the transfer acceleration state.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+      required:
+      - Bucket
+      - AccelerateConfiguration
+    PutBucketAclRequest:
+      type: object
+      properties:
+        ACL:
+          $ref: '#/components/schemas/BucketCannedACL'
+          description: The canned ACL to apply to the bucket.
+        AccessControlPolicy:
+          $ref: '#/components/schemas/AccessControlPolicy'
+          description: Contains the elements that set the ACL permissions for an object
+            per grantee.
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket to which to apply the ACL.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the data. This
+            header must be used as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, go to [RFC 1864.](http://www.ietf.org/rfc/rfc1864.txt)
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        GrantFullControl:
+          $ref: '#/components/schemas/GrantFullControl'
+          description: Allows grantee the read, write, read ACP, and write ACP permissions
+            on the bucket.
+        GrantRead:
+          $ref: '#/components/schemas/GrantRead'
+          description: Allows grantee to list the objects in the bucket.
+        GrantReadACP:
+          $ref: '#/components/schemas/GrantReadACP'
+          description: Allows grantee to read the bucket ACL.
+        GrantWrite:
+          $ref: '#/components/schemas/GrantWrite'
+          description: 'Allows grantee to create new objects in the bucket.
+
+
+            For the bucket and object owners of existing objects, also allows deletions
+            and overwrites of those objects.'
+        GrantWriteACP:
+          $ref: '#/components/schemas/GrantWriteACP'
+          description: Allows grantee to write the ACL for the applicable bucket.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    PutBucketAnalyticsConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket to which an analytics configuration
+            is stored.
+        Id:
+          $ref: '#/components/schemas/AnalyticsId'
+          description: The ID that identifies the analytics configuration.
+        AnalyticsConfiguration:
+          $ref: '#/components/schemas/AnalyticsConfiguration'
+          description: The configuration and any analyses for the analytics filter.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+      - AnalyticsConfiguration
+    PutBucketCorsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: Specifies the bucket impacted by the `cors`configuration.
+        CORSConfiguration:
+          $ref: '#/components/schemas/CORSConfiguration'
+          description: Describes the cross-origin access configuration for objects
+            in an Amazon S3 bucket. For more information, see [Enabling Cross-Origin
+            Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html)
+            in the _Amazon S3 User Guide_.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the data. This
+            header must be used as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, go to [RFC 1864.](http://www.ietf.org/rfc/rfc1864.txt)
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - CORSConfiguration
+    PutBucketEncryptionRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'Specifies default encryption for a bucket using server-side
+            encryption with different key options.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_'
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the server-side
+            encryption configuration.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.
+
+
+            This functionality is not supported for directory buckets.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.
+
+
+            For directory buckets, when you use Amazon Web Services SDKs, `CRC32`
+            is the default checksum algorithm that''s used for performance.'
+        ServerSideEncryptionConfiguration:
+          $ref: '#/components/schemas/ServerSideEncryptionConfiguration'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            For directory buckets, this header is not supported in this API operation.
+            If you specify this header, the request fails with the HTTP status code
+            `501 Not Implemented`.'
+      required:
+      - Bucket
+      - ServerSideEncryptionConfiguration
+    PutBucketIntelligentTieringConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose configuration you want
+            to modify or retrieve.
+        Id:
+          $ref: '#/components/schemas/IntelligentTieringId'
+          description: The ID used to identify the S3 Intelligent-Tiering configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        IntelligentTieringConfiguration:
+          $ref: '#/components/schemas/IntelligentTieringConfiguration'
+          description: Container for S3 Intelligent-Tiering configuration.
+      required:
+      - Bucket
+      - Id
+      - IntelligentTieringConfiguration
+    PutBucketInventoryConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket where the inventory configuration will
+            be stored.
+        Id:
+          $ref: '#/components/schemas/InventoryId'
+          description: The ID used to identify the inventory configuration.
+        InventoryConfiguration:
+          $ref: '#/components/schemas/InventoryConfiguration'
+          description: Specifies the inventory configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+      - InventoryConfiguration
+    PutBucketLifecycleConfigurationOutput:
+      type: object
+      properties:
+        TransitionDefaultMinimumObjectSize:
+          $ref: '#/components/schemas/TransitionDefaultMinimumObjectSize'
+          description: "Indicates which default minimum object size behavior is applied\
+            \ to the lifecycle configuration.\n\nThis parameter applies to general\
+            \ purpose buckets only. It is not supported for directory bucket lifecycle\
+            \ configurations.\n\n  * `all_storage_classes_128K` \\- Objects smaller\
+            \ than 128 KB will not transition to any storage class by default. \n\n\
+            \  * `varies_by_storage_class` \\- Objects smaller than 128 KB will transition\
+            \ to Glacier Flexible Retrieval or Glacier Deep Archive storage classes.\
+            \ By default, all other storage classes will prevent transitions smaller\
+            \ than 128 KB. \n\nTo customize the minimum object size for any transition\
+            \ you can add a filter that specifies a custom `ObjectSizeGreaterThan`\
+            \ or `ObjectSizeLessThan` in the body of your transition rule. Custom\
+            \ filters always take precedence over the default transition behavior."
+    PutBucketLifecycleConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which to set the configuration.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        LifecycleConfiguration:
+          $ref: '#/components/schemas/BucketLifecycleConfiguration'
+          description: Container for lifecycle rules. You can add as many as 1,000
+            rules.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            This parameter applies to general purpose buckets only. It is not supported
+            for directory bucket lifecycle configurations.'
+        TransitionDefaultMinimumObjectSize:
+          $ref: '#/components/schemas/TransitionDefaultMinimumObjectSize'
+          description: "Indicates which default minimum object size behavior is applied\
+            \ to the lifecycle configuration.\n\nThis parameter applies to general\
+            \ purpose buckets only. It is not supported for directory bucket lifecycle\
+            \ configurations.\n\n  * `all_storage_classes_128K` \\- Objects smaller\
+            \ than 128 KB will not transition to any storage class by default. \n\n\
+            \  * `varies_by_storage_class` \\- Objects smaller than 128 KB will transition\
+            \ to Glacier Flexible Retrieval or Glacier Deep Archive storage classes.\
+            \ By default, all other storage classes will prevent transitions smaller\
+            \ than 128 KB. \n\nTo customize the minimum object size for any transition\
+            \ you can add a filter that specifies a custom `ObjectSizeGreaterThan`\
+            \ or `ObjectSizeLessThan` in the body of your transition rule. Custom\
+            \ filters always take precedence over the default transition behavior."
+      required:
+      - Bucket
+    PutBucketLoggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which to set the logging parameters.
+        BucketLoggingStatus:
+          $ref: '#/components/schemas/BucketLoggingStatus'
+          description: Container for logging status information.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash of the `PutBucketLogging` request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - BucketLoggingStatus
+    PutBucketMetricsConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket for which the metrics configuration
+            is set.
+        Id:
+          $ref: '#/components/schemas/MetricsId'
+          description: The ID used to identify the metrics configuration. The ID has
+            a 64 character limit and can only contain letters, numbers, periods, dashes,
+            and underscores.
+        MetricsConfiguration:
+          $ref: '#/components/schemas/MetricsConfiguration'
+          description: Specifies the metrics configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Id
+      - MetricsConfiguration
+    PutBucketNotificationConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket.
+        NotificationConfiguration:
+          $ref: '#/components/schemas/NotificationConfiguration'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        SkipDestinationValidation:
+          $ref: '#/components/schemas/SkipValidation'
+          description: Skips validation of Amazon SQS, Amazon SNS, and Lambda destinations.
+            True or false value.
+      required:
+      - Bucket
+      - NotificationConfiguration
+    PutBucketOwnershipControlsRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose `OwnershipControls`
+            you want to set.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash of the `OwnershipControls` request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        OwnershipControls:
+          $ref: '#/components/schemas/OwnershipControls'
+          description: The `OwnershipControls` (BucketOwnerEnforced, BucketOwnerPreferred,
+            or ObjectWriter) that you want to apply to this Amazon S3 bucket.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum-_algorithm_ ` header sent. Otherwise,
+            Amazon S3 fails the request with the HTTP status code `400 Bad Request`.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+      required:
+      - Bucket
+      - OwnershipControls
+    PutBucketPolicyRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use path-style requests in the format `https://s3express-control._region-code_.amazonaws.com/_bucket-name_
+            `. Virtual-hosted-style requests aren''t supported. Directory bucket names
+            must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket
+            names must also follow the format ` _bucket-base-name_ --_zone-id_ --x-s3`
+            (for example, ` _DOC-EXAMPLE-BUCKET_ --_usw2-az1_ --x-s3`). For information
+            about bucket naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_'
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash of the request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.
+
+
+            This functionality is not supported for directory buckets.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: "Indicates the algorithm used to create the checksum for the\
+            \ request when you use the SDK. This header will not provide any additional\
+            \ functionality if you don't use the SDK. When you send this header, there\
+            \ must be a corresponding `x-amz-checksum-_algorithm_ ` or `x-amz-trailer`\
+            \ header sent. Otherwise, Amazon S3 fails the request with the HTTP status\
+            \ code `400 Bad Request`.\n\nFor the `x-amz-checksum-_algorithm_ ` header,\
+            \ replace ` _algorithm_ ` with the supported algorithm from the following\
+            \ list:\n\n  * `CRC32`\n\n  * `CRC32C`\n\n  * `CRC64NVME`\n\n  * `SHA1`\n\
+            \n  * `SHA256`\n\nFor more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)\
+            \ in the _Amazon S3 User Guide_.\n\nIf the individual checksum value you\
+            \ provide through `x-amz-checksum-_algorithm_ ` doesn't match the checksum\
+            \ algorithm you set through `x-amz-sdk-checksum-algorithm`, Amazon S3\
+            \ fails the request with a `BadDigest` error.\n\nFor directory buckets,\
+            \ when you use Amazon Web Services SDKs, `CRC32` is the default checksum\
+            \ algorithm that's used for performance."
+        ConfirmRemoveSelfBucketAccess:
+          $ref: '#/components/schemas/ConfirmRemoveSelfBucketAccess'
+          description: 'Set this parameter to true to confirm that you want to remove
+            your permissions to change this bucket policy in the future.
+
+
+            This functionality is not supported for directory buckets.'
+        Policy:
+          $ref: '#/components/schemas/Policy'
+          description: 'The bucket policy as a JSON document.
+
+
+            For directory buckets, the only IAM action supported in the bucket policy
+            is `s3express:CreateSession`.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: 'The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+
+
+            For directory buckets, this header is not supported in this API operation.
+            If you specify this header, the request fails with the HTTP status code
+            `501 Not Implemented`.'
+      required:
+      - Bucket
+      - Policy
+    PutBucketReplicationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the data. You must
+            use this header as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, see [RFC 1864](http://www.ietf.org/rfc/rfc1864.txt).
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        ReplicationConfiguration:
+          $ref: '#/components/schemas/ReplicationConfiguration'
+        Token:
+          $ref: '#/components/schemas/ObjectLockToken'
+          description: A token to allow Object Lock to be enabled for an existing
+            bucket.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - ReplicationConfiguration
+    PutBucketRequestPaymentRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the data. You must
+            use this header as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, see [RFC 1864](http://www.ietf.org/rfc/rfc1864.txt).
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        RequestPaymentConfiguration:
+          $ref: '#/components/schemas/RequestPaymentConfiguration'
+          description: Container for Payer.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - RequestPaymentConfiguration
+    PutBucketTaggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the data. You must
+            use this header as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, see [RFC 1864](http://www.ietf.org/rfc/rfc1864.txt).
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        Tagging:
+          $ref: '#/components/schemas/Tagging'
+          description: Container for the `TagSet` and `Tag` elements.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Tagging
+    PutBucketVersioningRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: '>The Base64 encoded 128-bit `MD5` digest of the data. You
+            must use this header as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, see [RFC 1864](http://www.ietf.org/rfc/rfc1864.txt).
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        MFA:
+          $ref: '#/components/schemas/MFA'
+          description: The concatenation of the authentication device's serial number,
+            a space, and the value that is displayed on your authentication device.
+            The serial number is the number that uniquely identifies the MFA device.
+            For physical MFA devices, this is the unique serial number that's provided
+            with the device. For virtual MFA devices, the serial number is the device
+            ARN. For more information, see [Enabling versioning on buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html)
+            and [Configuring MFA delete](https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html)
+            in the _Amazon Simple Storage Service User Guide_.
+        VersioningConfiguration:
+          $ref: '#/components/schemas/VersioningConfiguration'
+          description: Container for setting the versioning state.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - VersioningConfiguration
+    PutBucketWebsiteRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket name.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the data. You must
+            use this header as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, see [RFC 1864](http://www.ietf.org/rfc/rfc1864.txt).
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            request when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        WebsiteConfiguration:
+          $ref: '#/components/schemas/WebsiteConfiguration'
+          description: Container for the request.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - WebsiteConfiguration
+    PutObjectAclOutput:
+      type: object
+      properties:
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    PutObjectAclRequest:
+      type: object
+      properties:
+        ACL:
+          $ref: '#/components/schemas/ObjectCannedACL'
+          description: The canned ACL to apply to the object. For more information,
+            see [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+        AccessControlPolicy:
+          $ref: '#/components/schemas/AccessControlPolicy'
+          description: Contains the elements that set the ACL permissions for an object
+            per grantee.
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name that contains the object to which you want
+            to attach the ACL.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the data. This
+            header must be used as a message integrity check to verify that the request
+            body was not corrupted in transit. For more information, go to [RFC 1864.>](http://www.ietf.org/rfc/rfc1864.txt)
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        GrantFullControl:
+          $ref: '#/components/schemas/GrantFullControl'
+          description: 'Allows grantee the read, write, read ACP, and write ACP permissions
+            on the bucket.
+
+
+            This functionality is not supported for Amazon S3 on Outposts.'
+        GrantRead:
+          $ref: '#/components/schemas/GrantRead'
+          description: 'Allows grantee to list the objects in the bucket.
+
+
+            This functionality is not supported for Amazon S3 on Outposts.'
+        GrantReadACP:
+          $ref: '#/components/schemas/GrantReadACP'
+          description: 'Allows grantee to read the bucket ACL.
+
+
+            This functionality is not supported for Amazon S3 on Outposts.'
+        GrantWrite:
+          $ref: '#/components/schemas/GrantWrite'
+          description: 'Allows grantee to create new objects in the bucket.
+
+
+            For the bucket and object owners of existing objects, also allows deletions
+            and overwrites of those objects.'
+        GrantWriteACP:
+          $ref: '#/components/schemas/GrantWriteACP'
+          description: 'Allows grantee to write the ACL for the applicable bucket.
+
+
+            This functionality is not supported for Amazon S3 on Outposts.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Key for which the PUT action was initiated.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID used to reference a specific version of the object.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    PutObjectLegalHoldOutput:
+      type: object
+      properties:
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    PutObjectLegalHoldRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the object that you want to place
+            a legal hold on.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The key name for the object that you want to place a legal
+            hold on.
+        LegalHold:
+          $ref: '#/components/schemas/ObjectLockLegalHold'
+          description: Container element for the legal hold configuration you want
+            to apply to the specified object.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The version ID of the object that you want to place a legal
+            hold on.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash for the request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    PutObjectLockConfigurationOutput:
+      type: object
+      properties:
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    PutObjectLockConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The bucket whose Object Lock configuration you want to create
+            or replace.
+        ObjectLockConfiguration:
+          $ref: '#/components/schemas/ObjectLockConfiguration'
+          description: The Object Lock configuration that you want to apply to the
+            specified bucket.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        Token:
+          $ref: '#/components/schemas/ObjectLockToken'
+          description: A token to allow Object Lock to be enabled for an existing
+            bucket.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash for the request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+    PutObjectOutput:
+      type: object
+      properties:
+        Expiration:
+          $ref: '#/components/schemas/Expiration'
+          description: 'If the expiration is configured for the object (see [PutBucketLifecycleConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html))
+            in the _Amazon S3 User Guide_ , the response includes this header. It
+            includes the `expiry-date` and `rule-id` key-value pairs that provide
+            information about object expiration. The value of the `rule-id` is URL-encoded.
+
+
+            Object expiration information is not returned in directory buckets and
+            this header returns the value "`NotImplemented`" in all responses for
+            directory buckets.'
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: 'Entity tag for the uploaded object.
+
+
+            **General purpose buckets** \- To ensure that data is not corrupted traversing
+            the network, for objects where the ETag is the MD5 digest of the object,
+            you can calculate the MD5 while putting an object to Amazon S3 and compare
+            the returned ETag to the calculated MD5 value.
+
+
+            **Directory buckets** \- The ETag for the object in a directory bucket
+            isn''t the MD5 digest of the object.'
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32 checksum` of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: The Base64 encoded, 64-bit `CRC64NVME` checksum of the object.
+            This header is present if the object was uploaded with the `CRC64NVME`
+            checksum algorithm, or if it was uploaded without a checksum (and Amazon
+            S3 added the default checksum, `CRC64NVME`, to the uploaded object). For
+            more information about how checksums are calculated with multipart uploads,
+            see [Checking object integrity in the Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` digest of the object. This
+            checksum is only present if the checksum was uploaded with the object.
+            When you use the API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` digest of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumType:
+          $ref: '#/components/schemas/ChecksumType'
+          description: This header specifies the checksum type of the object, which
+            determines how part-level checksums are combined to create an object-level
+            checksum for multipart objects. For `PutObject` uploads, the checksum
+            type is always `FULL_OBJECT`. You can use this header as a data integrity
+            check to verify that the checksum type that is received is the same checksum
+            that was specified. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store this
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: 'Version ID of the object.
+
+
+            If you enable versioning for a bucket, Amazon S3 automatically generates
+            a unique version ID for the object being stored. Amazon S3 returns this
+            ID in the response. When you enable versioning for a bucket, if Amazon
+            S3 receives multiple write requests for the same object simultaneously,
+            it stores all of the objects. For more information about versioning, see
+            [Adding Objects to Versioning-Enabled Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/AddingObjectstoVersioningEnabledBuckets.html)
+            in the _Amazon S3 User Guide_. For information about returning the versioning
+            state of a bucket, see [GetBucketVersioning](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html).
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to confirm the
+            encryption algorithm that''s used.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to provide the
+            round-trip message integrity verification of the customer-provided encryption
+            key.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: If present, indicates the Amazon Web Services KMS Encryption
+            Context to use for object encryption. The value of this header is a Base64
+            encoded string of a UTF-8 encoded JSON, which contains the encryption
+            context as key-value pairs. This value is stored as object metadata and
+            automatically gets passed on to Amazon Web Services KMS for future `GetObject`
+            operations on this object.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the uploaded object uses an S3 Bucket Key
+            for server-side encryption with Key Management Service (KMS) keys (SSE-KMS).
+        Size:
+          $ref: '#/components/schemas/Size'
+          description: 'The size of the object in bytes. This value is only be present
+            if you append to an object.
+
+
+            This functionality is only supported for objects in the Amazon S3 Express
+            One Zone storage class in directory buckets.'
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    PutObjectRequest:
+      type: object
+      properties:
+        ACL:
+          $ref: '#/components/schemas/ObjectCannedACL'
+          description: "The canned ACL to apply to the object. For more information,\
+            \ see [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL)\
+            \ in the _Amazon S3 User Guide_.\n\nWhen adding a new object, you can\
+            \ use headers to grant ACL-based permissions to individual Amazon Web\
+            \ Services accounts or to predefined groups defined by Amazon S3. These\
+            \ permissions are then added to the ACL on the object. By default, all\
+            \ objects are private. Only the owner has full access control. For more\
+            \ information, see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)\
+            \ and [Managing ACLs Using the REST API](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html)\
+            \ in the _Amazon S3 User Guide_.\n\nIf the bucket that you're uploading\
+            \ objects to uses the bucket owner enforced setting for S3 Object Ownership,\
+            \ ACLs are disabled and no longer affect permissions. Buckets that use\
+            \ this setting only accept PUT requests that don't specify an ACL or PUT\
+            \ requests that specify bucket owner full control ACLs, such as the `bucket-owner-full-control`\
+            \ canned ACL or an equivalent form of this ACL expressed in the XML format.\
+            \ PUT requests that contain other ACLs (for example, custom grants to\
+            \ certain Amazon Web Services accounts) fail and return a `400` error\
+            \ with the error code `AccessControlListNotSupported`. For more information,\
+            \ see [ Controlling ownership of objects and disabling ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)\
+            \ in the _Amazon S3 User Guide_.\n\n  * This functionality is not supported\
+            \ for directory buckets.\n\n  * This functionality is not supported for\
+            \ Amazon S3 on Outposts."
+        Body:
+          $ref: '#/components/schemas/StreamingBlob'
+          description: Object data.
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name to which the PUT action was initiated.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        CacheControl:
+          $ref: '#/components/schemas/CacheControl'
+          description: Can be used to specify caching behavior along the request/reply
+            chain. For more information, see <http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9>.
+        ContentDisposition:
+          $ref: '#/components/schemas/ContentDisposition'
+          description: Specifies presentational information for the object. For more
+            information, see <https://www.rfc-editor.org/rfc/rfc6266#section-4>.
+        ContentEncoding:
+          $ref: '#/components/schemas/ContentEncoding'
+          description: Specifies what content encodings have been applied to the object
+            and thus what decoding mechanisms must be applied to obtain the media-type
+            referenced by the Content-Type header field. For more information, see
+            <https://www.rfc-editor.org/rfc/rfc9110.html#field.content-encoding>.
+        ContentLanguage:
+          $ref: '#/components/schemas/ContentLanguage'
+          description: The language the content is in.
+        ContentLength:
+          $ref: '#/components/schemas/ContentLength'
+          description: Size of the body in bytes. This parameter is useful when the
+            size of the body cannot be determined automatically. For more information,
+            see <https://www.rfc-editor.org/rfc/rfc9110.html#name-content-length>.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit `MD5` digest of the message (without
+            the headers) according to RFC 1864. This header can be used as a message
+            integrity check to verify that the data is the same data that was originally
+            sent. Although it is optional, we recommend using the Content-MD5 mechanism
+            as an end-to-end integrity check. For more information about REST request
+            authentication, see [REST Authentication](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html).
+
+
+            The `Content-MD5` or `x-amz-sdk-checksum-algorithm` header is required
+            for any request to upload an object with a retention period configured
+            using Amazon S3 Object Lock. For more information, see [Uploading objects
+            to an Object Lock enabled bucket ](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-put-object)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        ContentType:
+          $ref: '#/components/schemas/ContentType'
+          description: A standard MIME type describing the format of the contents.
+            For more information, see <https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type>.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: "Indicates the algorithm used to create the checksum for the\
+            \ object when you use the SDK. This header will not provide any additional\
+            \ functionality if you don't use the SDK. When you send this header, there\
+            \ must be a corresponding `x-amz-checksum-_algorithm_ ` or `x-amz-trailer`\
+            \ header sent. Otherwise, Amazon S3 fails the request with the HTTP status\
+            \ code `400 Bad Request`.\n\nFor the `x-amz-checksum-_algorithm_ ` header,\
+            \ replace ` _algorithm_ ` with the supported algorithm from the following\
+            \ list:\n\n  * `CRC32`\n\n  * `CRC32C`\n\n  * `CRC64NVME`\n\n  * `SHA1`\n\
+            \n  * `SHA256`\n\nFor more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)\
+            \ in the _Amazon S3 User Guide_.\n\nIf the individual checksum value you\
+            \ provide through `x-amz-checksum-_algorithm_ ` doesn't match the checksum\
+            \ algorithm you set through `x-amz-sdk-checksum-algorithm`, Amazon S3\
+            \ fails the request with a `BadDigest` error.\n\nThe `Content-MD5` or\
+            \ `x-amz-sdk-checksum-algorithm` header is required for any request to\
+            \ upload an object with a retention period configured using Amazon S3\
+            \ Object Lock. For more information, see [Uploading objects to an Object\
+            \ Lock enabled bucket ](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-put-object)\
+            \ in the _Amazon S3 User Guide_.\n\nFor directory buckets, when you use\
+            \ Amazon Web Services SDKs, `CRC32` is the default checksum algorithm\
+            \ that's used for performance."
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32` checksum of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 64-bit `CRC64NVME` checksum of the
+            object. The `CRC64NVME` checksum is always a full object checksum. For
+            more information, see [Checking object integrity in the Amazon S3 User
+            Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html).
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 160-bit `SHA1` digest of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 256-bit `SHA256` digest of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        Expires:
+          $ref: '#/components/schemas/Expires'
+          description: The date and time at which the object is no longer cacheable.
+            For more information, see <https://www.rfc-editor.org/rfc/rfc7234#section-5.3>.
+        IfMatch:
+          $ref: '#/components/schemas/IfMatch'
+          description: 'Uploads the object only if the ETag (entity tag) value provided
+            during the WRITE operation matches the ETag of the object in S3. If the
+            ETag values do not match, the operation returns a `412 Precondition Failed`
+            error.
+
+
+            If a conflicting operation occurs during the upload S3 returns a `409
+            ConditionalRequestConflict` response. On a 409 failure you should fetch
+            the object''s ETag and retry the upload.
+
+
+            Expects the ETag value as a string.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232),
+            or [Conditional requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html)
+            in the _Amazon S3 User Guide_.'
+        IfNoneMatch:
+          $ref: '#/components/schemas/IfNoneMatch'
+          description: 'Uploads the object only if the object key name does not already
+            exist in the bucket specified. Otherwise, Amazon S3 returns a `412 Precondition
+            Failed` error.
+
+
+            If a conflicting operation occurs during the upload S3 returns a `409
+            ConditionalRequestConflict` response. On a 409 failure you should retry
+            the upload.
+
+
+            Expects the ''*'' (asterisk) character.
+
+
+            For more information about conditional requests, see [RFC 7232](https://tools.ietf.org/html/rfc7232),
+            or [Conditional requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html)
+            in the _Amazon S3 User Guide_.'
+        GrantFullControl:
+          $ref: '#/components/schemas/GrantFullControl'
+          description: "Gives the grantee READ, READ_ACP, and WRITE_ACP permissions\
+            \ on the object.\n\n  * This functionality is not supported for directory\
+            \ buckets.\n\n  * This functionality is not supported for Amazon S3 on\
+            \ Outposts."
+        GrantRead:
+          $ref: '#/components/schemas/GrantRead'
+          description: "Allows grantee to read the object data and its metadata.\n\
+            \n  * This functionality is not supported for directory buckets.\n\n \
+            \ * This functionality is not supported for Amazon S3 on Outposts."
+        GrantReadACP:
+          $ref: '#/components/schemas/GrantReadACP'
+          description: "Allows grantee to read the object ACL.\n\n  * This functionality\
+            \ is not supported for directory buckets.\n\n  * This functionality is\
+            \ not supported for Amazon S3 on Outposts."
+        GrantWriteACP:
+          $ref: '#/components/schemas/GrantWriteACP'
+          description: "Allows grantee to write the ACL for the applicable object.\n\
+            \n  * This functionality is not supported for directory buckets.\n\n \
+            \ * This functionality is not supported for Amazon S3 on Outposts."
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the PUT action was initiated.
+        WriteOffsetBytes:
+          $ref: '#/components/schemas/WriteOffsetBytes'
+          description: 'Specifies the offset for appending data to existing objects
+            in bytes. The offset must be equal to the size of the existing object
+            being appended to. If no object exists, setting this header to 0 will
+            create a new object.
+
+
+            This functionality is only supported for objects in the Amazon S3 Express
+            One Zone storage class in directory buckets.'
+        Metadata:
+          $ref: '#/components/schemas/Metadata'
+          description: A map of metadata to store with the object in S3.
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: "The server-side encryption algorithm that was used when you\
+            \ store this object in Amazon S3 or Amazon FSx.\n\n  * **General purpose\
+            \ buckets** \\- You have four mutually exclusive options to protect data\
+            \ using server-side encryption in Amazon S3, depending on how you choose\
+            \ to manage the encryption keys. Specifically, the encryption key options\
+            \ are Amazon S3 managed keys (SSE-S3), Amazon Web Services KMS keys (SSE-KMS\
+            \ or DSSE-KMS), and customer-provided keys (SSE-C). Amazon S3 encrypts\
+            \ data with server-side encryption by using Amazon S3 managed keys (SSE-S3)\
+            \ by default. You can optionally tell Amazon S3 to encrypt data at rest\
+            \ by using server-side encryption with other key options. For more information,\
+            \ see [Using Server-Side Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)\
+            \ in the _Amazon S3 User Guide_.\n\n  * **Directory buckets** \\- For\
+            \ directory buckets, there are only two supported options for server-side\
+            \ encryption: server-side encryption with Amazon S3 managed keys (SSE-S3)\
+            \ (`AES256`) and server-side encryption with KMS keys (SSE-KMS) (`aws:kms`).\
+            \ We recommend that the bucket's default encryption uses the desired encryption\
+            \ configuration and you don't override the bucket default encryption in\
+            \ your `CreateSession` requests or `PUT` object requests. Then, new objects\
+            \ are automatically encrypted with the desired encryption settings. For\
+            \ more information, see [Protecting data with server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-serv-side-encryption.html)\
+            \ in the _Amazon S3 User Guide_. For more information about the encryption\
+            \ overriding behaviors in directory buckets, see [Specifying server-side\
+            \ encryption with KMS for new object uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-specifying-kms-encryption.html).\
+            \ \n\nIn the Zonal endpoint API calls (except [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html)\
+            \ and [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html))\
+            \ using the REST API, the encryption request headers must match the encryption\
+            \ settings that are specified in the `CreateSession` request. You can't\
+            \ override the values of the encryption settings (`x-amz-server-side-encryption`,\
+            \ `x-amz-server-side-encryption-aws-kms-key-id`, `x-amz-server-side-encryption-context`,\
+            \ and `x-amz-server-side-encryption-bucket-key-enabled`) that are specified\
+            \ in the `CreateSession` request. You don't need to explicitly specify\
+            \ these encryption settings values in Zonal endpoint API calls, and Amazon\
+            \ S3 will use the encryption settings values from the `CreateSession`\
+            \ request to protect new objects in the directory bucket.\n\nWhen you\
+            \ use the CLI or the Amazon Web Services SDKs, for `CreateSession`, the\
+            \ session token refreshes automatically to avoid service interruptions\
+            \ when a session expires. The CLI or the Amazon Web Services SDKs use\
+            \ the bucket's default encryption configuration for the `CreateSession`\
+            \ request. It's not supported to override the encryption settings values\
+            \ in the `CreateSession` request. So in the Zonal endpoint API calls (except\
+            \ [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html)\
+            \ and [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html)),\
+            \ the encryption request headers must match the default encryption configuration\
+            \ of the directory bucket.\n\n  * **S3 access points for Amazon FSx**\
+            \ \\- When accessing data stored in Amazon FSx file systems using S3 access\
+            \ points, the only valid server side encryption option is `aws:fsx`. All\
+            \ Amazon FSx file systems have encryption configured by default and are\
+            \ encrypted at rest. Data is automatically encrypted before being written\
+            \ to the file system, and automatically decrypted as it is read. These\
+            \ processes are handled transparently by Amazon FSx."
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: "By default, Amazon S3 uses the STANDARD Storage Class to store\
+            \ newly created objects. The STANDARD storage class provides high durability\
+            \ and high availability. Depending on performance needs, you can specify\
+            \ a different Storage Class. For more information, see [Storage Classes](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)\
+            \ in the _Amazon S3 User Guide_.\n\n  * Directory buckets only support\
+            \ `EXPRESS_ONEZONE` (the S3 Express One Zone storage class) in Availability\
+            \ Zones and `ONEZONE_IA` (the S3 One Zone-Infrequent Access storage class)\
+            \ in Dedicated Local Zones.\n\n  * Amazon S3 on Outposts only uses the\
+            \ OUTPOSTS Storage Class."
+        WebsiteRedirectLocation:
+          $ref: '#/components/schemas/WebsiteRedirectLocation'
+          description: 'If the bucket is configured as a website, redirects requests
+            for this object to another object in the same bucket or to an external
+            URL. Amazon S3 stores the value of this header in the object metadata.
+            For information about object metadata, see [Object Key and Metadata](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html)
+            in the _Amazon S3 User Guide_.
+
+
+            In the following example, the request header sets the redirect to an object
+            (anotherPage.html) in the same bucket:
+
+
+            `x-amz-website-redirect-location: /anotherPage.html`
+
+
+            In the following example, the request header sets the object redirect
+            to another website:
+
+
+            `x-amz-website-redirect-location: http://www.example.com/`
+
+
+            For more information about website hosting in Amazon S3, see [Hosting
+            Websites on Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html)
+            and [How to Configure Website Page Redirects](https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when encrypting the object
+            (for example, `AES256`).
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use in encrypting data. This value is used to store the object and
+            then it is discarded; Amazon S3 does not store the encryption key. The
+            key must be appropriate for use with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm`
+            header.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: 'Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to
+            use for object encryption. If the KMS key doesn''t exist in the same account
+            that''s issuing the command, you must use the full Key ARN not the Key
+            ID.
+
+
+            **General purpose buckets** \- If you specify `x-amz-server-side-encryption`
+            with `aws:kms` or `aws:kms:dsse`, this header specifies the ID (Key ID,
+            Key ARN, or Key Alias) of the KMS key to use. If you specify `x-amz-server-side-encryption:aws:kms`
+            or `x-amz-server-side-encryption:aws:kms:dsse`, but do not provide `x-amz-server-side-encryption-aws-kms-key-id`,
+            Amazon S3 uses the Amazon Web Services managed key (`aws/s3`) to protect
+            the data.
+
+
+            **Directory buckets** \- To encrypt data using SSE-KMS, it''s recommended
+            to specify the `x-amz-server-side-encryption` header to `aws:kms`. Then,
+            the `x-amz-server-side-encryption-aws-kms-key-id` header implicitly uses
+            the bucket''s default KMS customer managed key ID. If you want to explicitly
+            set the ` x-amz-server-side-encryption-aws-kms-key-id` header, it must
+            match the bucket''s default customer managed key (using key ID or ARN,
+            not alias). Your SSE-KMS configuration can only support 1 [customer managed
+            key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+            per directory bucket''s lifetime. The [Amazon Web Services managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)
+            (`aws/s3`) isn''t supported. Incorrect key specification results in an
+            HTTP `400 Bad Request` error.'
+        SSEKMSEncryptionContext:
+          $ref: '#/components/schemas/SSEKMSEncryptionContext'
+          description: 'Specifies the Amazon Web Services KMS Encryption Context as
+            an additional encryption context to use for object encryption. The value
+            of this header is a Base64 encoded string of a UTF-8 encoded JSON, which
+            contains the encryption context as key-value pairs. This value is stored
+            as object metadata and automatically gets passed on to Amazon Web Services
+            KMS for future `GetObject` operations on this object.
+
+
+            **General purpose buckets** \- This value must be explicitly added during
+            `CopyObject` operations if you want an additional encryption context for
+            your object. For more information, see [Encryption context](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context)
+            in the _Amazon S3 User Guide_.
+
+
+            **Directory buckets** \- You can optionally provide an explicit encryption
+            context value. The value must match the default encryption context - the
+            bucket Amazon Resource Name (ARN). An additional encryption context value
+            is not supported.'
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: 'Specifies whether Amazon S3 should use an S3 Bucket Key for
+            object encryption with server-side encryption using Key Management Service
+            (KMS) keys (SSE-KMS).
+
+
+            **General purpose buckets** \- Setting this header to `true` causes Amazon
+            S3 to use an S3 Bucket Key for object encryption with SSE-KMS. Also, specifying
+            this header with a PUT action doesn''t affect bucket-level settings for
+            S3 Bucket Key.
+
+
+            **Directory buckets** \- S3 Bucket Keys are always enabled for `GET` and
+            `PUT` operations in a directory bucket and can’t be disabled. S3 Bucket
+            Keys aren''t supported, when you copy SSE-KMS encrypted objects from general
+            purpose buckets to directory buckets, from directory buckets to general
+            purpose buckets, or between directory buckets, through [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html),
+            [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html),
+            [the Copy operation in Batch Operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-Batch-Ops),
+            or [the import jobs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-import-job).
+            In this case, Amazon S3 makes a call to KMS every time a copy request
+            is made for a KMS-encrypted object.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        Tagging:
+          $ref: '#/components/schemas/TaggingHeader'
+          description: 'The tag-set for the object. The tag-set must be encoded as
+            URL Query parameters. (For example, "Key1=Value1")
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockMode:
+          $ref: '#/components/schemas/ObjectLockMode'
+          description: 'The Object Lock mode that you want to apply to this object.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockRetainUntilDate:
+          $ref: '#/components/schemas/ObjectLockRetainUntilDate'
+          description: 'The date and time when you want this object''s Object Lock
+            to expire. Must be formatted as a timestamp parameter.
+
+
+            This functionality is not supported for directory buckets.'
+        ObjectLockLegalHoldStatus:
+          $ref: '#/components/schemas/ObjectLockLegalHoldStatus'
+          description: 'Specifies whether a legal hold will be applied to this object.
+            For more information about S3 Object Lock, see [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html)
+            in the _Amazon S3 User Guide_.
+
+
+            This functionality is not supported for directory buckets.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    PutObjectRetentionOutput:
+      type: object
+      properties:
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    PutObjectRetentionRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name that contains the object you want to apply
+            this Object Retention configuration to.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The key name for the object that you want to apply this Object
+            Retention configuration to.
+        Retention:
+          $ref: '#/components/schemas/ObjectLockRetention'
+          description: The container element for the Object Retention configuration.
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The version ID for the object that you want to apply this Object
+            Retention configuration to.
+        BypassGovernanceRetention:
+          $ref: '#/components/schemas/BypassGovernanceRetention'
+          description: Indicates whether this action should bypass Governance-mode
+            restrictions.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash for the request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    PutObjectTaggingOutput:
+      type: object
+      properties:
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The versionId of the object the tag-set was added to.
+    PutObjectTaggingRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the object.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Name of the object key.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: The versionId of the object that the tag-set will be added
+            to.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash for the request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        Tagging:
+          $ref: '#/components/schemas/Tagging'
+          description: Container for the `TagSet` and `Tag` elements
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+          description: Confirms that the requester knows that she or he will be charged
+            for the tagging object request. Bucket owners need not specify this parameter
+            in their requests.
+      required:
+      - Bucket
+      - Key
+      - Tagging
+    PutPublicAccessBlockRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the Amazon S3 bucket whose `PublicAccessBlock`
+            configuration you want to set.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The MD5 hash of the `PutPublicAccessBlock` request body.
+
+
+            For requests made using the Amazon Web Services Command Line Interface
+            (CLI) or Amazon Web Services SDKs, this field is calculated automatically.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        PublicAccessBlockConfiguration:
+          $ref: '#/components/schemas/PublicAccessBlockConfiguration'
+          description: The `PublicAccessBlock` configuration that you want to apply
+            to this Amazon S3 bucket. You can enable the configuration options in
+            any combination. For more information about when Amazon S3 considers a
+            bucket or object public, see [The Meaning of "Public"](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status)
+            in the _Amazon S3 User Guide_.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - PublicAccessBlockConfiguration
+    QueueArn:
+      type: string
+    QueueConfiguration:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/NotificationId'
+        QueueArn:
+          $ref: '#/components/schemas/QueueArn'
+          description: The Amazon Resource Name (ARN) of the Amazon SQS queue to which
+            Amazon S3 publishes a message when it detects events of the specified
+            type.
+        Events:
+          $ref: '#/components/schemas/EventList'
+          description: A collection of bucket events for which to send notifications
+        Filter:
+          $ref: '#/components/schemas/NotificationConfigurationFilter'
+      required:
+      - QueueArn
+      - Events
+      description: Specifies the configuration for publishing messages to an Amazon
+        Simple Queue Service (Amazon SQS) queue when Amazon S3 detects specified events.
+    QueueConfigurationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/QueueConfiguration'
+    Quiet:
+      type: boolean
+    QuoteCharacter:
+      type: string
+    QuoteEscapeCharacter:
+      type: string
+    QuoteFields:
+      type: string
+      enum:
+      - ALWAYS
+      - ASNEEDED
+    Range:
+      type: string
+    RecordDelimiter:
+      type: string
+    RecordExpiration:
+      type: object
+      properties:
+        Expiration:
+          $ref: '#/components/schemas/ExpirationState'
+          description: Specifies whether journal table record expiration is enabled
+            or disabled.
+        Days:
+          $ref: '#/components/schemas/RecordExpirationDays'
+          description: If you enable journal table record expiration, you can set
+            the number of days to retain your journal table records. Journal table
+            records must be retained for a minimum of 7 days. To set this value, specify
+            any whole number from `7` to `2147483647`. For example, to retain your
+            journal table records for one year, set this value to `365`.
+      required:
+      - Expiration
+      description: The journal table record expiration settings for a journal table
+        in an S3 Metadata configuration.
+    RecordExpirationDays:
+      type: integer
+    RecordsEvent:
+      type: object
+      properties:
+        Payload:
+          $ref: '#/components/schemas/Body'
+          description: The byte array of partial, one or more result records. S3 Select
+            doesn't guarantee that a record will be self-contained in one record frame.
+            To ensure continuous streaming of data, S3 Select might split the same
+            record across multiple record frames instead of aggregating the results
+            in memory. Some S3 clients (for example, the SDK for Java) handle this
+            behavior by creating a `ByteStream` out of the response by default. Other
+            clients might not handle this behavior by default. In those cases, you
+            must aggregate the results on the client side and parse the response.
+      description: The container for the records event.
+    Redirect:
+      type: object
+      properties:
+        HostName:
+          $ref: '#/components/schemas/HostName'
+          description: The host name to use in the redirect request.
+        HttpRedirectCode:
+          $ref: '#/components/schemas/HttpRedirectCode'
+          description: The HTTP redirect code to use on the response. Not required
+            if one of the siblings is present.
+        Protocol:
+          $ref: '#/components/schemas/Protocol'
+          description: Protocol to use when redirecting requests. The default is the
+            protocol that is used in the original request.
+        ReplaceKeyPrefixWith:
+          $ref: '#/components/schemas/ReplaceKeyPrefixWith'
+          description: 'The object key prefix to use in the redirect request. For
+            example, to redirect requests for all pages with prefix `docs/` (objects
+            in the `docs/` folder) to `documents/`, you can set a condition block
+            with `KeyPrefixEquals` set to `docs/` and in the Redirect set `ReplaceKeyPrefixWith`
+            to `/documents`. Not required if one of the siblings is present. Can be
+            present only if `ReplaceKeyWith` is not provided.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+        ReplaceKeyWith:
+          $ref: '#/components/schemas/ReplaceKeyWith'
+          description: 'The specific object key to use in the redirect request. For
+            example, redirect request to `error.html`. Not required if one of the
+            siblings is present. Can be present only if `ReplaceKeyPrefixWith` is
+            not provided.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+      description: Specifies how requests are redirected. In the event of an error,
+        you can specify a different error code to return.
+    RedirectAllRequestsTo:
+      type: object
+      properties:
+        HostName:
+          $ref: '#/components/schemas/HostName'
+          description: Name of the host where requests are redirected.
+        Protocol:
+          $ref: '#/components/schemas/Protocol'
+          description: Protocol to use when redirecting requests. The default is the
+            protocol that is used in the original request.
+      required:
+      - HostName
+      description: Specifies the redirect behavior of all requests to a website endpoint
+        of an Amazon S3 bucket.
+    Region:
+      type: string
+      minLength: 0
+      maxLength: 20
+    RenameObjectOutput:
+      type: object
+      properties: {}
+    RenameObjectRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name of the directory bucket containing the object.
+
+
+            You must use virtual-hosted-style requests in the format `Bucket-name.s3express-zone-id.region-code.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Availability Zone. Bucket names must follow the format
+            `bucket-base-name--zone-id--x-s3 ` (for example, `amzn-s3-demo-bucket--usw2-az1--x-s3`).
+            For information about bucket naming restrictions, see [Directory bucket
+            naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Key name of the object to rename.
+        RenameSource:
+          $ref: '#/components/schemas/RenameSource'
+          description: Specifies the source for the rename operation. The value must
+            be URL encoded.
+        DestinationIfMatch:
+          $ref: '#/components/schemas/IfMatch'
+          description: 'Renames the object only if the ETag (entity tag) value provided
+            during the operation matches the ETag of the object in S3. The `If-Match`
+            header field makes the request method conditional on ETags. If the ETag
+            values do not match, the operation returns a `412 Precondition Failed`
+            error.
+
+
+            Expects the ETag value as a string.'
+        DestinationIfNoneMatch:
+          $ref: '#/components/schemas/IfNoneMatch'
+          description: 'Renames the object only if the destination does not already
+            exist in the specified directory bucket. If the object does exist when
+            you send a request with `If-None-Match:*`, the S3 API will return a `412
+            Precondition Failed` error, preventing an overwrite. The `If-None-Match`
+            header prevents overwrites of existing data by validating that there''s
+            not an object with the same key name already in your directory bucket.
+
+
+            Expects the `*` character (asterisk).'
+        DestinationIfModifiedSince:
+          $ref: '#/components/schemas/IfModifiedSince'
+          description: Renames the object if the destination exists and if it has
+            been modified since the specified time.
+        DestinationIfUnmodifiedSince:
+          $ref: '#/components/schemas/IfUnmodifiedSince'
+          description: Renames the object if it hasn't been modified since the specified
+            time.
+        SourceIfMatch:
+          $ref: '#/components/schemas/RenameSourceIfMatch'
+          description: Renames the object if the source exists and if its entity tag
+            (ETag) matches the specified ETag.
+        SourceIfNoneMatch:
+          $ref: '#/components/schemas/RenameSourceIfNoneMatch'
+          description: Renames the object if the source exists and if its entity tag
+            (ETag) is different than the specified ETag. If an asterisk (`*`) character
+            is provided, the operation will fail and return a `412 Precondition Failed`
+            error.
+        SourceIfModifiedSince:
+          $ref: '#/components/schemas/RenameSourceIfModifiedSince'
+          description: Renames the object if the source exists and if it has been
+            modified since the specified time.
+        SourceIfUnmodifiedSince:
+          $ref: '#/components/schemas/RenameSourceIfUnmodifiedSince'
+          description: Renames the object if the source exists and hasn't been modified
+            since the specified time.
+        ClientToken:
+          $ref: '#/components/schemas/ClientToken'
+          description: 'A unique string with a max of 64 ASCII characters in the ASCII
+            range of 33 - 126.
+
+
+            `RenameObject` supports idempotency using a client token. To make an idempotent
+            API request using `RenameObject`, specify a client token in the request.
+            You should not reuse the same client token for other API requests. If
+            you retry a request that completed successfully using the same client
+            token and the same parameters, the retry succeeds without performing any
+            further actions. If you retry a successful request using the same client
+            token, but one or more of the parameters are different, the retry fails
+            and an `IdempotentParameterMismatch` error is returned.'
+      required:
+      - Bucket
+      - Key
+      - RenameSource
+    RenameSource:
+      type: string
+      pattern: ^\/?.+\/.+$
+    RenameSourceIfMatch:
+      type: string
+    RenameSourceIfModifiedSince:
+      type: string
+      format: date-time
+    RenameSourceIfNoneMatch:
+      type: string
+    RenameSourceIfUnmodifiedSince:
+      type: string
+      format: date-time
+    ReplaceKeyPrefixWith:
+      type: string
+    ReplaceKeyWith:
+      type: string
+    ReplicaKmsKeyID:
+      type: string
+    ReplicaModifications:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/ReplicaModificationsStatus'
+          description: Specifies whether Amazon S3 replicates modifications on replicas.
+      required:
+      - Status
+      description: 'A filter that you can specify for selection for modifications
+        on replicas. Amazon S3 doesn''t replicate replica modifications by default.
+        In the latest version of replication configuration (when `Filter` is specified),
+        you can specify this element and set the status to `Enabled` to replicate
+        modifications on replicas.
+
+
+        If you don''t specify the `Filter` element, Amazon S3 assumes that the replication
+        configuration is the earlier version, V1. In the earlier version, this element
+        is not allowed.'
+    ReplicaModificationsStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    ReplicationConfiguration:
+      type: object
+      properties:
+        Role:
+          $ref: '#/components/schemas/Role'
+          description: The Amazon Resource Name (ARN) of the Identity and Access Management
+            (IAM) role that Amazon S3 assumes when replicating objects. For more information,
+            see [How to Set Up Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-how-setup.html)
+            in the _Amazon S3 User Guide_.
+        Rules:
+          $ref: '#/components/schemas/ReplicationRules'
+          description: A container for one or more replication rules. A replication
+            configuration must have at least one rule and can contain a maximum of
+            1,000 rules.
+      required:
+      - Role
+      - Rules
+      description: A container for replication rules. You can add up to 1,000 rules.
+        The maximum size of a replication configuration is 2 MB.
+    ReplicationRule:
+      type: object
+      properties:
+        ID:
+          $ref: '#/components/schemas/ID'
+          description: A unique identifier for the rule. The maximum value is 255
+            characters.
+        Priority:
+          $ref: '#/components/schemas/Priority'
+          description: 'The priority indicates which rule has precedence whenever
+            two or more replication rules conflict. Amazon S3 will attempt to replicate
+            objects according to all replication rules. However, if there are two
+            or more rules with the same destination bucket, then objects will be replicated
+            according to the rule with the highest priority. The higher the number,
+            the higher the priority.
+
+
+            For more information, see [Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html)
+            in the _Amazon S3 User Guide_.'
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'An object key name prefix that identifies the object or objects
+            to which the rule applies. The maximum prefix length is 1,024 characters.
+            To include all objects in a bucket, specify an empty string.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+        Filter:
+          $ref: '#/components/schemas/ReplicationRuleFilter'
+        Status:
+          $ref: '#/components/schemas/ReplicationRuleStatus'
+          description: Specifies whether the rule is enabled.
+        SourceSelectionCriteria:
+          $ref: '#/components/schemas/SourceSelectionCriteria'
+          description: A container that describes additional filters for identifying
+            the source objects that you want to replicate. You can choose to enable
+            or disable the replication of these objects. Currently, Amazon S3 supports
+            only the filter that you can specify for objects created with server-side
+            encryption using a customer managed key stored in Amazon Web Services
+            Key Management Service (SSE-KMS).
+        ExistingObjectReplication:
+          $ref: '#/components/schemas/ExistingObjectReplication'
+          description: 'Optional configuration to replicate existing source bucket
+            objects.
+
+
+            This parameter is no longer supported. To replicate existing objects,
+            see [Replicating existing objects with S3 Batch Replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-batch-replication-batch.html)
+            in the _Amazon S3 User Guide_.'
+        Destination:
+          $ref: '#/components/schemas/Destination'
+          description: A container for information about the replication destination
+            and its configurations including enabling the S3 Replication Time Control
+            (S3 RTC).
+        DeleteMarkerReplication:
+          $ref: '#/components/schemas/DeleteMarkerReplication'
+      required:
+      - Status
+      - Destination
+      description: Specifies which Amazon S3 objects to replicate and where to store
+        the replicas.
+    ReplicationRuleAndOperator:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: An object key name prefix that identifies the subset of objects
+            to which the rule applies.
+        Tags:
+          $ref: '#/components/schemas/TagSet'
+          description: An array of tags containing key and value pairs.
+      description: "A container for specifying rule filters. The filters determine\
+        \ the subset of objects to which the rule applies. This element is required\
+        \ only if you specify more than one filter.\n\nFor example:\n\n  * If you\
+        \ specify both a `Prefix` and a `Tag` filter, wrap these filters in an `And`\
+        \ tag. \n\n  * If you specify a filter based on multiple tags, wrap the `Tag`\
+        \ elements in an `And` tag."
+    ReplicationRuleFilter:
+      type: object
+      properties:
+        Prefix:
+          $ref: '#/components/schemas/Prefix'
+          description: 'An object key name prefix that identifies the subset of objects
+            to which the rule applies.
+
+
+            Replacement must be made for object keys containing special characters
+            (such as carriage returns) when using XML requests. For more information,
+            see [ XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).'
+        Tag:
+          $ref: '#/components/schemas/Tag'
+          description: 'A container for specifying a tag key and value.
+
+
+            The rule applies only to objects that have the tag in their tag set.'
+        And:
+          $ref: '#/components/schemas/ReplicationRuleAndOperator'
+          description: "A container for specifying rule filters. The filters determine\
+            \ the subset of objects to which the rule applies. This element is required\
+            \ only if you specify more than one filter. For example:\n\n  * If you\
+            \ specify both a `Prefix` and a `Tag` filter, wrap these filters in an\
+            \ `And` tag.\n\n  * If you specify a filter based on multiple tags, wrap\
+            \ the `Tag` elements in an `And` tag."
+      description: A filter that identifies the subset of objects to which the replication
+        rule applies. A `Filter` must specify exactly one `Prefix`, `Tag`, or an `And`
+        child element.
+    ReplicationRuleStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    ReplicationRules:
+      type: array
+      items:
+        $ref: '#/components/schemas/ReplicationRule'
+    ReplicationStatus:
+      type: string
+      enum:
+      - COMPLETE
+      - PENDING
+      - FAILED
+      - REPLICA
+      - COMPLETED
+    ReplicationTime:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/ReplicationTimeStatus'
+          description: Specifies whether the replication time is enabled.
+        Time:
+          $ref: '#/components/schemas/ReplicationTimeValue'
+          description: A container specifying the time by which replication should
+            be complete for all objects and operations on objects.
+      required:
+      - Status
+      - Time
+      description: A container specifying S3 Replication Time Control (S3 RTC) related
+        information, including whether S3 RTC is enabled and the time when all objects
+        and operations on objects must be replicated. Must be specified together with
+        a `Metrics` block.
+    ReplicationTimeStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    ReplicationTimeValue:
+      type: object
+      properties:
+        Minutes:
+          $ref: '#/components/schemas/Minutes'
+          description: 'Contains an integer specifying time in minutes.
+
+
+            Valid value: 15'
+      description: A container specifying the time value for S3 Replication Time Control
+        (S3 RTC) and replication metrics `EventThreshold`.
+    RequestCharged:
+      type: string
+      enum:
+      - requester
+      description: "<p>If present, indicates that the requester was successfully charged\
+        \ for the request. For more\n      information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html\"\
+        >Using Requester Pays buckets for storage transfers and usage</a> in the <i>Amazon\
+        \ Simple\n        Storage Service user guide</i>.</p>\n         <note>\n \
+        \           <p>This functionality is not supported for directory buckets.</p>\n\
+        \         </note>"
+    RequestPayer:
+      type: string
+      enum:
+      - requester
+      description: "<p>Confirms that the requester knows that they will be charged\
+        \ for the request. Bucket owners need not\n      specify this parameter in\
+        \ their requests. If either the source or destination S3 bucket has Requester\n\
+        \      Pays enabled, the requester will pay for corresponding charges to copy\
+        \ the object. For information about\n      downloading objects from Requester\
+        \ Pays buckets, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html\"\
+        >Downloading Objects in Requester Pays\n        Buckets</a> in the <i>Amazon\
+        \ S3 User Guide</i>.</p>\n         <note>\n            <p>This functionality\
+        \ is not supported for directory buckets.</p>\n         </note>"
+    RequestPaymentConfiguration:
+      type: object
+      properties:
+        Payer:
+          $ref: '#/components/schemas/Payer'
+          description: Specifies who pays for the download and request fees.
+      required:
+      - Payer
+      description: Container for Payer.
+    RequestProgress:
+      type: object
+      properties:
+        Enabled:
+          $ref: '#/components/schemas/EnableRequestProgress'
+          description: 'Specifies whether periodic QueryProgress frames should be
+            sent. Valid values: TRUE, FALSE. Default value: FALSE.'
+      description: Container for specifying if periodic `QueryProgress` messages should
+        be sent.
+    RequestRoute:
+      type: string
+    RequestToken:
+      type: string
+    ResponseCacheControl:
+      type: string
+    ResponseContentDisposition:
+      type: string
+    ResponseContentEncoding:
+      type: string
+    ResponseContentLanguage:
+      type: string
+    ResponseContentType:
+      type: string
+    ResponseExpires:
+      type: string
+      format: date-time
+    Restore:
+      type: string
+    RestoreExpiryDate:
+      type: string
+      format: date-time
+    RestoreObjectOutput:
+      type: object
+      properties:
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        RestoreOutputPath:
+          $ref: '#/components/schemas/RestoreOutputPath'
+          description: Indicates the path in the provided S3 output location where
+            Select results will be restored to.
+    RestoreObjectRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name containing the object to restore.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the action was initiated.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: VersionId used to reference a specific version of the object.
+        RestoreRequest:
+          $ref: '#/components/schemas/RestoreRequest'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+    RestoreOutputPath:
+      type: string
+    RestoreRequest:
+      type: object
+      properties:
+        Days:
+          $ref: '#/components/schemas/Days'
+          description: 'Lifetime of the active copy in days. Do not use with restores
+            that specify `OutputLocation`.
+
+
+            The Days element is required for regular restores, and must not be provided
+            for select requests.'
+        GlacierJobParameters:
+          $ref: '#/components/schemas/GlacierJobParameters'
+          description: S3 Glacier related parameters pertaining to this job. Do not
+            use with restores that specify `OutputLocation`.
+        Type:
+          $ref: '#/components/schemas/RestoreRequestType'
+          description: 'Amazon S3 Select is no longer available to new customers.
+            Existing customers of Amazon S3 Select can continue to use the feature
+            as usual. [Learn more](http://aws.amazon.com/blogs/storage/how-to-optimize-querying-your-data-in-amazon-s3/)
+
+
+            Type of restore request.'
+        Tier:
+          $ref: '#/components/schemas/Tier'
+          description: Retrieval tier at which the restore will be processed.
+        Description:
+          $ref: '#/components/schemas/Description'
+          description: The optional description for the job.
+        SelectParameters:
+          $ref: '#/components/schemas/SelectParameters'
+          description: 'Amazon S3 Select is no longer available to new customers.
+            Existing customers of Amazon S3 Select can continue to use the feature
+            as usual. [Learn more](http://aws.amazon.com/blogs/storage/how-to-optimize-querying-your-data-in-amazon-s3/)
+
+
+            Describes the parameters for Select job types.'
+        OutputLocation:
+          $ref: '#/components/schemas/OutputLocation'
+          description: Describes the location where the restore job's output is stored.
+      description: Container for restore job parameters.
+    RestoreRequestType:
+      type: string
+      enum:
+      - SELECT
+    RestoreStatus:
+      type: object
+      properties:
+        IsRestoreInProgress:
+          $ref: '#/components/schemas/IsRestoreInProgress'
+          description: 'Specifies whether the object is currently being restored.
+            If the object restoration is in progress, the header returns the value
+            `TRUE`. For example:
+
+
+            `x-amz-optional-object-attributes: IsRestoreInProgress="true"`
+
+
+            If the object restoration has completed, the header returns the value
+            `FALSE`. For example:
+
+
+            `x-amz-optional-object-attributes: IsRestoreInProgress="false", RestoreExpiryDate="2012-12-21T00:00:00.000Z"`
+
+
+            If the object hasn''t been restored, there is no header response.'
+        RestoreExpiryDate:
+          $ref: '#/components/schemas/RestoreExpiryDate'
+          description: 'Indicates when the restored copy will expire. This value is
+            populated only if the object has already been restored. For example:
+
+
+            `x-amz-optional-object-attributes: IsRestoreInProgress="false", RestoreExpiryDate="2012-12-21T00:00:00.000Z"`'
+      description: 'Specifies the restoration status of an object. Objects in certain
+        storage classes must be restored before they can be retrieved. For more information
+        about these storage classes and how to work with archived objects, see [ Working
+        with archived objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/archived-objects.html)
+        in the _Amazon S3 User Guide_.
+
+
+        This functionality is not supported for directory buckets. Directory buckets
+        only support `EXPRESS_ONEZONE` (the S3 Express One Zone storage class) in
+        Availability Zones and `ONEZONE_IA` (the S3 One Zone-Infrequent Access storage
+        class) in Dedicated Local Zones.'
+    Role:
+      type: string
+    RoutingRule:
+      type: object
+      properties:
+        Condition:
+          $ref: '#/components/schemas/Condition'
+          description: A container for describing a condition that must be met for
+            the specified redirect to apply. For example, 1. If request is for pages
+            in the `/docs` folder, redirect to the `/documents` folder. 2. If request
+            results in HTTP error 4xx, redirect request to another host where you
+            might process the error.
+        Redirect:
+          $ref: '#/components/schemas/Redirect'
+          description: Container for redirect information. You can redirect requests
+            to another host, to another page, or with another protocol. In the event
+            of an error, you can specify a different error code to return.
+      required:
+      - Redirect
+      description: Specifies the redirect behavior and when a redirect is applied.
+        For more information about routing rules, see [Configuring advanced conditional
+        redirects](https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html#advanced-conditional-redirects)
+        in the _Amazon S3 User Guide_.
+    RoutingRules:
+      type: array
+      items:
+        $ref: '#/components/schemas/RoutingRule'
+    S3KeyFilter:
+      type: object
+      properties:
+        FilterRules:
+          $ref: '#/components/schemas/FilterRuleList'
+      description: A container for object key name prefix and suffix filtering rules.
+    S3Location:
+      type: object
+      properties:
+        BucketName:
+          $ref: '#/components/schemas/BucketName'
+          description: The name of the bucket where the restore results will be placed.
+        Prefix:
+          $ref: '#/components/schemas/LocationPrefix'
+          description: The prefix that is prepended to the restore results for this
+            request.
+        Encryption:
+          $ref: '#/components/schemas/Encryption'
+        CannedACL:
+          $ref: '#/components/schemas/ObjectCannedACL'
+          description: The canned ACL to apply to the restore results.
+        AccessControlList:
+          $ref: '#/components/schemas/Grants'
+          description: A list of grants that control access to the staged results.
+        Tagging:
+          $ref: '#/components/schemas/Tagging'
+          description: The tag-set that is applied to the restore results.
+        UserMetadata:
+          $ref: '#/components/schemas/UserMetadata'
+          description: A list of metadata to store with the restore results in S3.
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: The class of storage used to store the restore results.
+      required:
+      - BucketName
+      - Prefix
+      description: Describes an Amazon S3 location that will receive the results of
+        the restore request.
+    S3RegionalOrS3ExpressBucketArnString:
+      type: string
+      pattern: '^arn:[^:]+:(s3|s3express):'
+      minLength: 1
+      maxLength: 128
+    S3TablesArn:
+      type: string
+    S3TablesBucketArn:
+      type: string
+    S3TablesBucketType:
+      type: string
+      enum:
+      - aws
+      - customer
+    S3TablesDestination:
+      type: object
+      properties:
+        TableBucketArn:
+          $ref: '#/components/schemas/S3TablesBucketArn'
+          description: The Amazon Resource Name (ARN) for the table bucket that's
+            specified as the destination in the metadata table configuration. The
+            destination table bucket must be in the same Region and Amazon Web Services
+            account as the general purpose bucket.
+        TableName:
+          $ref: '#/components/schemas/S3TablesName'
+          description: The name for the metadata table in your metadata table configuration.
+            The specified metadata table name must be unique within the `aws_s3_metadata`
+            namespace in the destination table bucket.
+      required:
+      - TableBucketArn
+      - TableName
+      description: 'The destination information for a V1 S3 Metadata configuration.
+        The destination table bucket must be in the same Region and Amazon Web Services
+        account as the general purpose bucket. The specified metadata table name must
+        be unique within the `aws_s3_metadata` namespace in the destination table
+        bucket.
+
+
+        If you created your S3 Metadata configuration before July 15, 2025, we recommend
+        that you delete and re-create your configuration by using [CreateBucketMetadataConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html)
+        so that you can expire journal table records and create a live inventory table.'
+    S3TablesDestinationResult:
+      type: object
+      properties:
+        TableBucketArn:
+          $ref: '#/components/schemas/S3TablesBucketArn'
+          description: The Amazon Resource Name (ARN) for the table bucket that's
+            specified as the destination in the metadata table configuration. The
+            destination table bucket must be in the same Region and Amazon Web Services
+            account as the general purpose bucket.
+        TableName:
+          $ref: '#/components/schemas/S3TablesName'
+          description: The name for the metadata table in your metadata table configuration.
+            The specified metadata table name must be unique within the `aws_s3_metadata`
+            namespace in the destination table bucket.
+        TableArn:
+          $ref: '#/components/schemas/S3TablesArn'
+          description: The Amazon Resource Name (ARN) for the metadata table in the
+            metadata table configuration. The specified metadata table name must be
+            unique within the `aws_s3_metadata` namespace in the destination table
+            bucket.
+        TableNamespace:
+          $ref: '#/components/schemas/S3TablesNamespace'
+          description: The table bucket namespace for the metadata table in your metadata
+            table configuration. This value is always `aws_s3_metadata`.
+      required:
+      - TableBucketArn
+      - TableName
+      - TableArn
+      - TableNamespace
+      description: 'The destination information for a V1 S3 Metadata configuration.
+        The destination table bucket must be in the same Region and Amazon Web Services
+        account as the general purpose bucket. The specified metadata table name must
+        be unique within the `aws_s3_metadata` namespace in the destination table
+        bucket.
+
+
+        If you created your S3 Metadata configuration before July 15, 2025, we recommend
+        that you delete and re-create your configuration by using [CreateBucketMetadataConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html)
+        so that you can expire journal table records and create a live inventory table.'
+    S3TablesName:
+      type: string
+    S3TablesNamespace:
+      type: string
+    SSECustomerAlgorithm:
+      type: string
+    SSECustomerKey:
+      type: string
+    SSECustomerKeyMD5:
+      type: string
+    SSEKMS:
+      type: object
+      properties:
+        KeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: Specifies the ID of the Key Management Service (KMS) symmetric
+            encryption customer managed key to use for encrypting inventory reports.
+      required:
+      - KeyId
+      description: Specifies the use of SSE-KMS to encrypt delivered inventory reports.
+    SSEKMSEncryptionContext:
+      type: string
+    SSEKMSKeyId:
+      type: string
+    SSES3:
+      type: object
+      properties: {}
+      description: Specifies the use of SSE-S3 to encrypt delivered inventory reports.
+    ScanRange:
+      type: object
+      properties:
+        Start:
+          $ref: '#/components/schemas/Start'
+          description: 'Specifies the start of the byte range. This parameter is optional.
+            Valid values: non-negative integers. The default value is 0. If only `start`
+            is supplied, it means scan from that point to the end of the file. For
+            example, `50` means scan from byte 50 until the end of the file.'
+        End:
+          $ref: '#/components/schemas/End'
+          description: 'Specifies the end of the byte range. This parameter is optional.
+            Valid values: non-negative integers. The default value is one less than
+            the size of the object being queried. If only the End parameter is supplied,
+            it is interpreted to mean scan the last N bytes of the file. For example,
+            `50` means scan the last 50 bytes.'
+      description: Specifies the byte range of the object to get the records from.
+        A record is processed when its first byte is contained by the range. This
+        parameter is optional, but when specified, it must not be empty. See RFC 2616,
+        Section 14.35.1 about how to specify the start and end of the range.
+    SelectObjectContentEventStream:
+      allOf:
+      - $ref: '#/components/schemas/RecordsEvent'
+        description: |-
+          The Records Event.
+      - $ref: '#/components/schemas/StatsEvent'
+        description: |-
+          The Stats Event.
+      - $ref: '#/components/schemas/ProgressEvent'
+        description: |-
+          The Progress Event.
+      - $ref: '#/components/schemas/ContinuationEvent'
+        description: |-
+          The Continuation Event.
+      - $ref: '#/components/schemas/EndEvent'
+        description: |-
+          The End Event.
+      description: |-
+        The container for selecting objects from a content event stream.
+    SelectObjectContentOutput:
+      type: object
+      properties:
+        Payload:
+          $ref: '#/components/schemas/SelectObjectContentEventStream'
+          description: The array of results.
+    SelectObjectContentRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The S3 bucket.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: The object key.
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: The server-side encryption (SSE) algorithm used to encrypt
+            the object. This parameter is needed only when the object was created
+            using a checksum algorithm. For more information, see [Protecting data
+            using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: The server-side encryption (SSE) customer managed key. This
+            parameter is needed only when the object was created using a checksum
+            algorithm. For more information, see [Protecting data using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: The MD5 server-side encryption (SSE) customer managed key.
+            This parameter is needed only when the object was created using a checksum
+            algorithm. For more information, see [Protecting data using SSE-C keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
+            in the _Amazon S3 User Guide_.
+        Expression:
+          $ref: '#/components/schemas/Expression'
+          description: The expression that is used to query the object.
+        ExpressionType:
+          $ref: '#/components/schemas/ExpressionType'
+          description: The type of the provided expression (for example, SQL).
+        RequestProgress:
+          $ref: '#/components/schemas/RequestProgress'
+          description: Specifies if periodic request progress information should be
+            enabled.
+        InputSerialization:
+          $ref: '#/components/schemas/InputSerialization'
+          description: Describes the format of the data in the object that is being
+            queried.
+        OutputSerialization:
+          $ref: '#/components/schemas/OutputSerialization'
+          description: Describes the format of the data that you want Amazon S3 to
+            return in response.
+        ScanRange:
+          $ref: '#/components/schemas/ScanRange'
+          description: "Specifies the byte range of the object to get the records\
+            \ from. A record is processed when its first byte is contained by the\
+            \ range. This parameter is optional, but when specified, it must not be\
+            \ empty. See RFC 2616, Section 14.35.1 about how to specify the start\
+            \ and end of the range.\n\n`ScanRange`may be used in the following ways:\n\
+            \n  * `50100` \\- process only the records starting between the bytes\
+            \ 50 and 100 (inclusive, counting from zero)\n\n  * `50` \\- process only\
+            \ the records starting after the byte 50\n\n  * `50` \\- process only\
+            \ the records within the last 50 bytes of the file."
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+      - Expression
+      - ExpressionType
+      - InputSerialization
+      - OutputSerialization
+      description: 'Learn Amazon S3 Select is no longer available to new customers.
+        Existing customers of Amazon S3 Select can continue to use the feature as
+        usual. [Learn more](http://aws.amazon.com/blogs/storage/how-to-optimize-querying-your-data-in-amazon-s3/)
+
+
+        Request to filter the contents of an Amazon S3 object based on a simple Structured
+        Query Language (SQL) statement. In the request, along with the SQL expression,
+        you must specify a data serialization format (JSON or CSV) of the object.
+        Amazon S3 uses this to parse object data into records. It returns only records
+        that match the specified SQL expression. You must also specify the data serialization
+        format for the response. For more information, see [S3Select API Documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html).'
+    SelectParameters:
+      type: object
+      properties:
+        InputSerialization:
+          $ref: '#/components/schemas/InputSerialization'
+          description: Describes the serialization format of the object.
+        ExpressionType:
+          $ref: '#/components/schemas/ExpressionType'
+          description: The type of the provided expression (for example, SQL).
+        Expression:
+          $ref: '#/components/schemas/Expression'
+          description: 'Amazon S3 Select is no longer available to new customers.
+            Existing customers of Amazon S3 Select can continue to use the feature
+            as usual. [Learn more](http://aws.amazon.com/blogs/storage/how-to-optimize-querying-your-data-in-amazon-s3/)
+
+
+            The expression that is used to query the object.'
+        OutputSerialization:
+          $ref: '#/components/schemas/OutputSerialization'
+          description: Describes how the results of the Select job are serialized.
+      required:
+      - InputSerialization
+      - ExpressionType
+      - Expression
+      - OutputSerialization
+      description: 'Amazon S3 Select is no longer available to new customers. Existing
+        customers of Amazon S3 Select can continue to use the feature as usual. [Learn
+        more](http://aws.amazon.com/blogs/storage/how-to-optimize-querying-your-data-in-amazon-s3/)
+
+
+        Describes the parameters for Select job types.
+
+
+        Learn [How to optimize querying your data in Amazon S3](http://aws.amazon.com/blogs/storage/how-to-optimize-querying-your-data-in-amazon-s3/)
+        using [Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/what-is.html),
+        [S3 Object Lambda](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transforming-objects.html),
+        or client-side filtering.'
+    ServerSideEncryption:
+      type: string
+      enum:
+      - AES256
+      - aws:fsx
+      - aws:kms
+      - aws:kms:dsse
+    ServerSideEncryptionByDefault:
+      type: object
+      properties:
+        SSEAlgorithm:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'Server-side encryption algorithm to use for the default encryption.
+
+
+            For directory buckets, there are only two supported values for server-side
+            encryption: `AES256` and `aws:kms`.'
+        KMSMasterKeyID:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: "Amazon Web Services Key Management Service (KMS) customer\
+            \ managed key ID to use for the default encryption.\n\n  * **General purpose\
+            \ buckets** \\- This parameter is allowed if and only if `SSEAlgorithm`\
+            \ is set to `aws:kms` or `aws:kms:dsse`.\n\n  * **Directory buckets**\
+            \ \\- This parameter is allowed if and only if `SSEAlgorithm` is set to\
+            \ `aws:kms`.\n\nYou can specify the key ID, key alias, or the Amazon Resource\
+            \ Name (ARN) of the KMS key.\n\n  * Key ID: `1234abcd-12ab-34cd-56ef-1234567890ab`\n\
+            \n  * Key ARN: `arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`\n\
+            \n  * Key Alias: `alias/alias-name`\n\nIf you are using encryption with\
+            \ cross-account or Amazon Web Services service operations, you must use\
+            \ a fully qualified KMS key ARN. For more information, see [Using encryption\
+            \ for cross-account operations](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html#bucket-encryption-update-bucket-policy).\n\
+            \n  * **General purpose buckets** \\- If you're specifying a customer\
+            \ managed KMS key, we recommend using a fully qualified KMS key ARN. If\
+            \ you use a KMS key alias instead, then KMS resolves the key within the\
+            \ requester’s account. This behavior can result in data that's encrypted\
+            \ with a KMS key that belongs to the requester, and not the bucket owner.\
+            \ Also, if you use a key ID, you can run into a LogDestination undeliverable\
+            \ error when creating a VPC flow log. \n\n  * **Directory buckets** \\\
+            - When you specify an [KMS customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)\
+            \ for encryption in your directory bucket, only use the key ID or key\
+            \ ARN. The key alias format of the KMS key isn't supported.\n\nAmazon\
+            \ S3 only supports symmetric encryption KMS keys. For more information,\
+            \ see [Asymmetric keys in Amazon Web Services KMS](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)\
+            \ in the _Amazon Web Services Key Management Service Developer Guide_."
+      required:
+      - SSEAlgorithm
+      description: "Describes the default server-side encryption to apply to new objects\
+        \ in the bucket. If a PUT Object request doesn't specify any server-side encryption,\
+        \ this default encryption will be applied. For more information, see [PutBucketEncryption](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTencryption.html).\n\
+        \n  * **General purpose buckets** \\- If you don't specify a customer managed\
+        \ key at configuration, Amazon S3 automatically creates an Amazon Web Services\
+        \ KMS key (`aws/s3`) in your Amazon Web Services account the first time that\
+        \ you add an object encrypted with SSE-KMS to a bucket. By default, Amazon\
+        \ S3 uses this KMS key for SSE-KMS. \n\n  * **Directory buckets** \\- Your\
+        \ SSE-KMS configuration can only support 1 [customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)\
+        \ per directory bucket's lifetime. The [Amazon Web Services managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)\
+        \ (`aws/s3`) isn't supported. \n\n  * **Directory buckets** \\- For directory\
+        \ buckets, there are only two supported options for server-side encryption:\
+        \ SSE-S3 and SSE-KMS."
+    ServerSideEncryptionConfiguration:
+      type: object
+      properties:
+        Rules:
+          $ref: '#/components/schemas/ServerSideEncryptionRules'
+          description: Container for information about a particular server-side encryption
+            configuration rule.
+      required:
+      - Rules
+      description: Specifies the default server-side-encryption configuration.
+    ServerSideEncryptionRule:
+      type: object
+      properties:
+        ApplyServerSideEncryptionByDefault:
+          $ref: '#/components/schemas/ServerSideEncryptionByDefault'
+          description: Specifies the default server-side encryption to apply to new
+            objects in the bucket. If a PUT Object request doesn't specify any server-side
+            encryption, this default encryption will be applied.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: "Specifies whether Amazon S3 should use an S3 Bucket Key with\
+            \ server-side encryption using KMS (SSE-KMS) for new objects in the bucket.\
+            \ Existing objects are not affected. Setting the `BucketKeyEnabled` element\
+            \ to `true` causes Amazon S3 to use an S3 Bucket Key.\n\n  * **General\
+            \ purpose buckets** \\- By default, S3 Bucket Key is not enabled. For\
+            \ more information, see [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html)\
+            \ in the _Amazon S3 User Guide_.\n\n  * **Directory buckets** \\- S3 Bucket\
+            \ Keys are always enabled for `GET` and `PUT` operations in a directory\
+            \ bucket and can’t be disabled. S3 Bucket Keys aren't supported, when\
+            \ you copy SSE-KMS encrypted objects from general purpose buckets to directory\
+            \ buckets, from directory buckets to general purpose buckets, or between\
+            \ directory buckets, through [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html),\
+            \ [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html),\
+            \ [the Copy operation in Batch Operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-Batch-Ops),\
+            \ or [the import jobs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-import-job).\
+            \ In this case, Amazon S3 makes a call to KMS every time a copy request\
+            \ is made for a KMS-encrypted object."
+        BlockedEncryptionTypes:
+          $ref: '#/components/schemas/BlockedEncryptionTypes'
+          description: 'A bucket-level setting for Amazon S3 general purpose buckets
+            used to prevent the upload of new objects encrypted with the specified
+            server-side encryption type. For example, blocking an encryption type
+            will block `PutObject`, `CopyObject`, `PostObject`, multipart upload,
+            and replication requests to the bucket for objects with the specified
+            encryption type. However, you can continue to read and list any pre-existing
+            objects already encrypted with the specified encryption type. For more
+            information, see [Blocking or unblocking SSE-C for a general purpose bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html).
+
+
+            Currently, this parameter only supports blocking or unblocking server-side
+            encryption with customer-provided keys (SSE-C). For more information about
+            SSE-C, see [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).'
+      description: "Specifies the default server-side encryption configuration.\n\n\
+        \  * **General purpose buckets** \\- If you're specifying a customer managed\
+        \ KMS key, we recommend using a fully qualified KMS key ARN. If you use a\
+        \ KMS key alias instead, then KMS resolves the key within the requester’s\
+        \ account. This behavior can result in data that's encrypted with a KMS key\
+        \ that belongs to the requester, and not the bucket owner.\n\n  * **Directory\
+        \ buckets** \\- When you specify an [KMS customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)\
+        \ for encryption in your directory bucket, only use the key ID or key ARN.\
+        \ The key alias format of the KMS key isn't supported."
+    ServerSideEncryptionRules:
+      type: array
+      items:
+        $ref: '#/components/schemas/ServerSideEncryptionRule'
+    SessionCredentialValue:
+      type: string
+    SessionCredentials:
+      type: object
+      properties:
+        AccessKeyId:
+          $ref: '#/components/schemas/AccessKeyIdValue'
+          description: A unique identifier that's associated with a secret access
+            key. The access key ID and the secret access key are used together to
+            sign programmatic Amazon Web Services requests cryptographically.
+        SecretAccessKey:
+          $ref: '#/components/schemas/SessionCredentialValue'
+          description: A key that's used with the access key ID to cryptographically
+            sign programmatic Amazon Web Services requests. Signing a request identifies
+            the sender and prevents the request from being altered.
+        SessionToken:
+          $ref: '#/components/schemas/SessionCredentialValue'
+          description: A part of the temporary security credentials. The session token
+            is used to validate the temporary security credentials.
+        Expiration:
+          $ref: '#/components/schemas/SessionExpiration'
+          description: Temporary security credentials expire after a specified interval.
+            After temporary credentials expire, any calls that you make with those
+            credentials will fail. So you must generate a new set of temporary credentials.
+            Temporary credentials cannot be extended or refreshed beyond the original
+            specified interval.
+      required:
+      - AccessKeyId
+      - SecretAccessKey
+      - SessionToken
+      - Expiration
+      description: 'The established temporary security credentials of the session.
+
+
+        **Directory buckets** \- These session credentials are only supported for
+        the authentication and authorization of Zonal endpoint API operations on directory
+        buckets.'
+    SessionExpiration:
+      type: string
+      format: date-time
+    SessionMode:
+      type: string
+      enum:
+      - ReadOnly
+      - ReadWrite
+    Setting:
+      type: boolean
+    SimplePrefix:
+      type: object
+      properties: {}
+      description: 'To use simple format for S3 keys for log objects, set SimplePrefix
+        to an empty object.
+
+
+        `[DestinationPrefix][YYYY]-[MM]-[DD]-[hh]-[mm]-[ss]-[UniqueString]`'
+    Size:
+      type: integer
+      format: int64
+    SkipValidation:
+      type: boolean
+    SourceSelectionCriteria:
+      type: object
+      properties:
+        SseKmsEncryptedObjects:
+          $ref: '#/components/schemas/SseKmsEncryptedObjects'
+          description: A container for filter information for the selection of Amazon
+            S3 objects encrypted with Amazon Web Services KMS. If you include `SourceSelectionCriteria`
+            in the replication configuration, this element is required.
+        ReplicaModifications:
+          $ref: '#/components/schemas/ReplicaModifications'
+          description: 'A filter that you can specify for selections for modifications
+            on replicas. Amazon S3 doesn''t replicate replica modifications by default.
+            In the latest version of replication configuration (when `Filter` is specified),
+            you can specify this element and set the status to `Enabled` to replicate
+            modifications on replicas.
+
+
+            If you don''t specify the `Filter` element, Amazon S3 assumes that the
+            replication configuration is the earlier version, V1. In the earlier version,
+            this element is not allowed'
+      description: A container that describes additional filters for identifying the
+        source objects that you want to replicate. You can choose to enable or disable
+        the replication of these objects. Currently, Amazon S3 supports only the filter
+        that you can specify for objects created with server-side encryption using
+        a customer managed key stored in Amazon Web Services Key Management Service
+        (SSE-KMS).
+    SseKmsEncryptedObjects:
+      type: object
+      properties:
+        Status:
+          $ref: '#/components/schemas/SseKmsEncryptedObjectsStatus'
+          description: Specifies whether Amazon S3 replicates objects created with
+            server-side encryption using an Amazon Web Services KMS key stored in
+            Amazon Web Services Key Management Service.
+      required:
+      - Status
+      description: A container for filter information for the selection of S3 objects
+        encrypted with Amazon Web Services KMS.
+    SseKmsEncryptedObjectsStatus:
+      type: string
+      enum:
+      - Enabled
+      - Disabled
+    Start:
+      type: integer
+      format: int64
+    StartAfter:
+      type: string
+    Stats:
+      type: object
+      properties:
+        BytesScanned:
+          $ref: '#/components/schemas/BytesScanned'
+          description: The total number of object bytes scanned.
+        BytesProcessed:
+          $ref: '#/components/schemas/BytesProcessed'
+          description: The total number of uncompressed object bytes processed.
+        BytesReturned:
+          $ref: '#/components/schemas/BytesReturned'
+          description: The total number of bytes of records payload data returned.
+      description: Container for the stats details.
+    StatsEvent:
+      type: object
+      properties:
+        Details:
+          $ref: '#/components/schemas/Stats'
+          description: The Stats event details.
+      description: Container for the Stats Event.
+    StorageClass:
+      type: string
+      enum:
+      - STANDARD
+      - REDUCED_REDUNDANCY
+      - STANDARD_IA
+      - ONEZONE_IA
+      - INTELLIGENT_TIERING
+      - GLACIER
+      - DEEP_ARCHIVE
+      - OUTPOSTS
+      - GLACIER_IR
+      - SNOW
+      - EXPRESS_ONEZONE
+      - FSX_OPENZFS
+      - FSX_ONTAP
+    StorageClassAnalysis:
+      type: object
+      properties:
+        DataExport:
+          $ref: '#/components/schemas/StorageClassAnalysisDataExport'
+          description: Specifies how data related to the storage class analysis for
+            an Amazon S3 bucket should be exported.
+      description: Specifies data related to access patterns to be collected and made
+        available to analyze the tradeoffs between different storage classes for an
+        Amazon S3 bucket.
+    StorageClassAnalysisDataExport:
+      type: object
+      properties:
+        OutputSchemaVersion:
+          $ref: '#/components/schemas/StorageClassAnalysisSchemaVersion'
+          description: The version of the output schema to use when exporting data.
+            Must be `V_1`.
+        Destination:
+          $ref: '#/components/schemas/AnalyticsExportDestination'
+          description: The place to store the data for an analysis.
+      required:
+      - OutputSchemaVersion
+      - Destination
+      description: Container for data related to the storage class analysis for an
+        Amazon S3 bucket for export.
+    StorageClassAnalysisSchemaVersion:
+      type: string
+      enum:
+      - V_1
+    StreamingBlob:
+      type: string
+      format: byte
+    Suffix:
+      type: string
+    TableSseAlgorithm:
+      type: string
+      enum:
+      - aws:kms
+      - AES256
+    Tag:
+      type: object
+      properties:
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Name of the object key.
+        Value:
+          $ref: '#/components/schemas/Value'
+          description: Value of the tag.
+      required:
+      - Key
+      - Value
+      description: A container of a key value name pair.
+    TagCount:
+      type: integer
+    TagSet:
+      type: array
+      items:
+        $ref: '#/components/schemas/Tag'
+    Tagging:
+      type: object
+      properties:
+        TagSet:
+          $ref: '#/components/schemas/TagSet'
+          description: A collection for a set of tags
+      required:
+      - TagSet
+      description: Container for `TagSet` elements.
+    TaggingDirective:
+      type: string
+      enum:
+      - COPY
+      - REPLACE
+    TaggingHeader:
+      type: string
+    TargetBucket:
+      type: string
+    TargetGrant:
+      type: object
+      properties:
+        Grantee:
+          $ref: '#/components/schemas/Grantee'
+          description: Container for the person being granted permissions.
+        Permission:
+          $ref: '#/components/schemas/BucketLogsPermission'
+          description: Logging permissions assigned to the grantee for the bucket.
+      description: 'Container for granting information.
+
+
+        Buckets that use the bucket owner enforced setting for Object Ownership don''t
+        support target grants. For more information, see [Permissions server access
+        log delivery](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html#grant-log-delivery-permissions-general)
+        in the _Amazon S3 User Guide_.'
+    TargetGrants:
+      type: array
+      items:
+        $ref: '#/components/schemas/TargetGrant'
+    TargetObjectKeyFormat:
+      type: object
+      properties:
+        SimplePrefix:
+          $ref: '#/components/schemas/SimplePrefix'
+          description: To use the simple format for S3 keys for log objects. To specify
+            SimplePrefix format, set SimplePrefix to {}.
+        PartitionedPrefix:
+          $ref: '#/components/schemas/PartitionedPrefix'
+          description: Partitioned S3 key for log objects.
+      description: Amazon S3 key format for log objects. Only one format, PartitionedPrefix
+        or SimplePrefix, is allowed.
+    TargetPrefix:
+      type: string
+    Tier:
+      type: string
+      enum:
+      - Standard
+      - Bulk
+      - Expedited
+    Tiering:
+      type: object
+      properties:
+        Days:
+          $ref: '#/components/schemas/IntelligentTieringDays'
+          description: The number of consecutive days of no access after which an
+            object will be eligible to be transitioned to the corresponding tier.
+            The minimum number of days specified for Archive Access tier must be at
+            least 90 days and Deep Archive Access tier must be at least 180 days.
+            The maximum can be up to 2 years (730 days).
+        AccessTier:
+          $ref: '#/components/schemas/IntelligentTieringAccessTier'
+          description: S3 Intelligent-Tiering access tier. See [Storage class for
+            automatically optimizing frequently and infrequently accessed objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access)
+            for a list of access tiers in the S3 Intelligent-Tiering storage class.
+      required:
+      - Days
+      - AccessTier
+      description: The S3 Intelligent-Tiering storage class is designed to optimize
+        storage costs by automatically moving data to the most cost-effective storage
+        access tier, without additional operational overhead.
+    TieringList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Tiering'
+    Token:
+      type: string
+    TooManyParts:
+      type: object
+      properties: {}
+      description: You have attempted to add more parts than the maximum of 10000
+        that are allowed for this object. You can use the CopyObject operation to
+        copy this object to another and then add more data to the newly copied object.
+    TopicArn:
+      type: string
+    TopicConfiguration:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/NotificationId'
+        TopicArn:
+          $ref: '#/components/schemas/TopicArn'
+          description: The Amazon Resource Name (ARN) of the Amazon SNS topic to which
+            Amazon S3 publishes a message when it detects events of the specified
+            type.
+        Events:
+          $ref: '#/components/schemas/EventList'
+          description: The Amazon S3 bucket event about which to send notifications.
+            For more information, see [Supported Event Types](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+            in the _Amazon S3 User Guide_.
+        Filter:
+          $ref: '#/components/schemas/NotificationConfigurationFilter'
+      required:
+      - TopicArn
+      - Events
+      description: A container for specifying the configuration for publication of
+        messages to an Amazon Simple Notification Service (Amazon SNS) topic when
+        Amazon S3 detects specified events.
+    TopicConfigurationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/TopicConfiguration'
+    Transition:
+      type: object
+      properties:
+        Date:
+          $ref: '#/components/schemas/Date'
+          description: Indicates when objects are transitioned to the specified storage
+            class. The date value must be in ISO 8601 format. The time is always midnight
+            UTC.
+        Days:
+          $ref: '#/components/schemas/Days'
+          description: Indicates the number of days after creation when objects are
+            transitioned to the specified storage class. If the specified storage
+            class is `INTELLIGENT_TIERING`, `GLACIER_IR`, `GLACIER`, or `DEEP_ARCHIVE`,
+            valid values are `0` or positive integers. If the specified storage class
+            is `STANDARD_IA` or `ONEZONE_IA`, valid values are positive integers greater
+            than `30`. Be aware that some storage classes have a minimum storage duration
+            and that you're charged for transitioning objects before their minimum
+            storage duration. For more information, see [ Constraints and considerations
+            for transitions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html#lifecycle-configuration-constraints)
+            in the _Amazon S3 User Guide_.
+        StorageClass:
+          $ref: '#/components/schemas/TransitionStorageClass'
+          description: The storage class to which you want the object to transition.
+      description: Specifies when an object transitions to a specified storage class.
+        For more information about Amazon S3 lifecycle configuration rules, see [Transitioning
+        Objects Using Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-transition-general-considerations.html)
+        in the _Amazon S3 User Guide_.
+    TransitionDefaultMinimumObjectSize:
+      type: string
+      enum:
+      - varies_by_storage_class
+      - all_storage_classes_128K
+    TransitionList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Transition'
+    TransitionStorageClass:
+      type: string
+      enum:
+      - GLACIER
+      - STANDARD_IA
+      - ONEZONE_IA
+      - INTELLIGENT_TIERING
+      - DEEP_ARCHIVE
+      - GLACIER_IR
+    Type:
+      type: string
+      enum:
+      - CanonicalUser
+      - AmazonCustomerByEmail
+      - Group
+    URI:
+      type: string
+    UpdateBucketMetadataInventoryTableConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that corresponds to the metadata
+            configuration that you want to enable or disable an inventory table for.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: The `Content-MD5` header for the inventory table configuration.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: The checksum algorithm to use with your inventory table configuration.
+        InventoryTableConfiguration:
+          $ref: '#/components/schemas/InventoryTableConfigurationUpdates'
+          description: The contents of your inventory table configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected owner of the general purpose bucket that corresponds
+            to the metadata table configuration that you want to enable or disable
+            an inventory table for.
+      required:
+      - Bucket
+      - InventoryTableConfiguration
+    UpdateBucketMetadataJournalTableConfigurationRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: The general purpose bucket that corresponds to the metadata
+            configuration that you want to enable or disable journal table record
+            expiration for.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: The `Content-MD5` header for the journal table configuration.
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: The checksum algorithm to use with your journal table configuration.
+        JournalTableConfiguration:
+          $ref: '#/components/schemas/JournalTableConfigurationUpdates'
+          description: The contents of your journal table configuration.
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The expected owner of the general purpose bucket that corresponds
+            to the metadata table configuration that you want to enable or disable
+            journal table record expiration for.
+      required:
+      - Bucket
+      - JournalTableConfiguration
+    UploadIdMarker:
+      type: string
+    UploadPartCopyOutput:
+      type: object
+      properties:
+        CopySourceVersionId:
+          $ref: '#/components/schemas/CopySourceVersionId'
+          description: 'The version of the source object that was copied, if you have
+            enabled versioning on the source bucket.
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        CopyPartResult:
+          $ref: '#/components/schemas/CopyPartResult'
+          description: Container for all response elements.
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store this
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to confirm the
+            encryption algorithm that''s used.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to provide the
+            round-trip message integrity verification of the customer-provided encryption
+            key.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the multipart upload uses an S3 Bucket Key
+            for server-side encryption with Key Management Service (KMS) keys (SSE-KMS).
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    UploadPartCopyRequest:
+      type: object
+      properties:
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The bucket name.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Copying objects across different Amazon Web Services Regions isn''t supported
+            when the source or destination bucket is in Amazon Web Services Local
+            Zones. The source and destination buckets must have the same parent Amazon
+            Web Services Region. Otherwise, you get an HTTP `400 Bad Request` error
+            with the error code `InvalidRequest`.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        CopySource:
+          $ref: '#/components/schemas/CopySource'
+          description: "Specifies the source object for the copy operation. You specify\
+            \ the value in one of two formats, depending on whether you want to access\
+            \ the source object through an [access point](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html):\n\
+            \n  * For objects not accessed through an access point, specify the name\
+            \ of the source bucket and key of the source object, separated by a slash\
+            \ (/). For example, to copy the object `reports/january.pdf` from the\
+            \ bucket `awsexamplebucket`, use `awsexamplebucket/reports/january.pdf`.\
+            \ The value must be URL-encoded.\n\n  * For objects accessed through access\
+            \ points, specify the Amazon Resource Name (ARN) of the object as accessed\
+            \ through the access point, in the format `arn:aws:s3:::accesspoint//object/`.\
+            \ For example, to copy the object `reports/january.pdf` through access\
+            \ point `my-access-point` owned by account `123456789012` in Region `us-west-2`,\
+            \ use the URL encoding of `arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf`.\
+            \ The value must be URL encoded.\n\n    * Amazon S3 supports copy operations\
+            \ using Access points only when the source and destination buckets are\
+            \ in the same Amazon Web Services Region.\n\n    * Access points are not\
+            \ supported by directory buckets.\n\nAlternatively, for objects accessed\
+            \ through Amazon S3 on Outposts, specify the ARN of the object as accessed\
+            \ in the format `arn:aws:s3-outposts:::outpost//object/`. For example,\
+            \ to copy the object `reports/january.pdf` through outpost `my-outpost`\
+            \ owned by account `123456789012` in Region `us-west-2`, use the URL encoding\
+            \ of `arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf`.\
+            \ The value must be URL-encoded.\n\nIf your bucket has versioning enabled,\
+            \ you could have multiple versions of the same object. By default, `x-amz-copy-source`\
+            \ identifies the current version of the source object to copy. To copy\
+            \ a specific version of the source object to copy, append `?versionId=`\
+            \ to the `x-amz-copy-source` request header (for example, `x-amz-copy-source:\
+            \ /awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893`).\n\
+            \nIf the current version is a delete marker and you don't specify a versionId\
+            \ in the `x-amz-copy-source` request header, Amazon S3 returns a `404\
+            \ Not Found` error, because the object does not exist. If you specify\
+            \ versionId in the `x-amz-copy-source` and the versionId is a delete marker,\
+            \ Amazon S3 returns an HTTP `400 Bad Request` error, because you are not\
+            \ allowed to specify a delete marker as a version for the `x-amz-copy-source`.\n\
+            \n**Directory buckets** \\- S3 Versioning isn't enabled and supported\
+            \ for directory buckets."
+        CopySourceIfMatch:
+          $ref: '#/components/schemas/CopySourceIfMatch'
+          description: 'Copies the object if its entity tag (ETag) matches the specified
+            tag.
+
+
+            If both of the `x-amz-copy-source-if-match` and `x-amz-copy-source-if-unmodified-since`
+            headers are present in the request as follows:
+
+
+            `x-amz-copy-source-if-match` condition evaluates to `true`, and;
+
+
+            `x-amz-copy-source-if-unmodified-since` condition evaluates to `false`;
+
+
+            Amazon S3 returns `200 OK` and copies the data.'
+        CopySourceIfModifiedSince:
+          $ref: '#/components/schemas/CopySourceIfModifiedSince'
+          description: 'Copies the object if it has been modified since the specified
+            time.
+
+
+            If both of the `x-amz-copy-source-if-none-match` and `x-amz-copy-source-if-modified-since`
+            headers are present in the request as follows:
+
+
+            `x-amz-copy-source-if-none-match` condition evaluates to `false`, and;
+
+
+            `x-amz-copy-source-if-modified-since` condition evaluates to `true`;
+
+
+            Amazon S3 returns `412 Precondition Failed` response code.'
+        CopySourceIfNoneMatch:
+          $ref: '#/components/schemas/CopySourceIfNoneMatch'
+          description: 'Copies the object if its entity tag (ETag) is different than
+            the specified ETag.
+
+
+            If both of the `x-amz-copy-source-if-none-match` and `x-amz-copy-source-if-modified-since`
+            headers are present in the request as follows:
+
+
+            `x-amz-copy-source-if-none-match` condition evaluates to `false`, and;
+
+
+            `x-amz-copy-source-if-modified-since` condition evaluates to `true`;
+
+
+            Amazon S3 returns `412 Precondition Failed` response code.'
+        CopySourceIfUnmodifiedSince:
+          $ref: '#/components/schemas/CopySourceIfUnmodifiedSince'
+          description: 'Copies the object if it hasn''t been modified since the specified
+            time.
+
+
+            If both of the `x-amz-copy-source-if-match` and `x-amz-copy-source-if-unmodified-since`
+            headers are present in the request as follows:
+
+
+            `x-amz-copy-source-if-match` condition evaluates to `true`, and;
+
+
+            `x-amz-copy-source-if-unmodified-since` condition evaluates to `false`;
+
+
+            Amazon S3 returns `200 OK` and copies the data.'
+        CopySourceRange:
+          $ref: '#/components/schemas/CopySourceRange'
+          description: The range of bytes to copy from the source object. The range
+            value must use the form bytes=first-last, where the first and last are
+            the zero-based byte offsets to copy. For example, bytes=0-9 indicates
+            that you want to copy the first 10 bytes of the source. You can copy a
+            range only if the source object is greater than 5 MB.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the multipart upload was initiated.
+        PartNumber:
+          $ref: '#/components/schemas/PartNumber'
+          description: Part number of part being copied. This is a positive integer
+            between 1 and 10,000.
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: Upload ID identifying the multipart upload whose part is being
+            copied.
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when encrypting the object
+            (for example, AES256).
+
+
+            This functionality is not supported when the destination bucket is a directory
+            bucket.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use in encrypting data. This value is used to store the object and
+            then it is discarded; Amazon S3 does not store the encryption key. The
+            key must be appropriate for use with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm`
+            header. This must be the same encryption key specified in the initiate
+            multipart upload request.
+
+
+            This functionality is not supported when the destination bucket is a directory
+            bucket.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            This functionality is not supported when the destination bucket is a directory
+            bucket.'
+        CopySourceSSECustomerAlgorithm:
+          $ref: '#/components/schemas/CopySourceSSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when decrypting the source
+            object (for example, `AES256`).
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        CopySourceSSECustomerKey:
+          $ref: '#/components/schemas/CopySourceSSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use to decrypt the source object. The encryption key provided in
+            this header must be one that was used when the source object was created.
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        CopySourceSSECustomerKeyMD5:
+          $ref: '#/components/schemas/CopySourceSSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            This functionality is not supported when the source object is in a directory
+            bucket.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected destination bucket owner. If
+            the account ID that you provide does not match the actual owner of the
+            destination bucket, the request fails with the HTTP status code `403 Forbidden`
+            (access denied).
+        ExpectedSourceBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected source bucket owner. If the
+            account ID that you provide does not match the actual owner of the source
+            bucket, the request fails with the HTTP status code `403 Forbidden` (access
+            denied).
+      required:
+      - Bucket
+      - CopySource
+      - Key
+      - PartNumber
+      - UploadId
+    UploadPartOutput:
+      type: object
+      properties:
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when you store this
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: Entity tag for the uploaded object.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: The Base64 encoded, 32-bit `CRC32 checksum` of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: The Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 64-bit `CRC64NVME` checksum of the
+            part. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: The Base64 encoded, 160-bit `SHA1` digest of the object. This
+            checksum is only present if the checksum was uploaded with the object.
+            When you use the API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: The Base64 encoded, 256-bit `SHA256` digest of the object.
+            This checksum is only present if the checksum was uploaded with the object.
+            When you use an API operation on an object that was uploaded using multipart
+            uploads, this value may not be a direct checksum value of the full object.
+            Instead, it's a calculation based on the checksum values of each individual
+            part. For more information about how checksums are calculated with multipart
+            uploads, see [ Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums)
+            in the _Amazon S3 User Guide_.
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to confirm the
+            encryption algorithm that''s used.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'If server-side encryption with a customer-provided encryption
+            key was requested, the response will include this header to provide the
+            round-trip message integrity verification of the customer-provided encryption
+            key.
+
+
+            This functionality is not supported for directory buckets.'
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, indicates the ID of the KMS key that was used for
+            object encryption.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the multipart upload uses an S3 Bucket Key
+            for server-side encryption with Key Management Service (KMS) keys (SSE-KMS).
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+    UploadPartRequest:
+      type: object
+      properties:
+        Body:
+          $ref: '#/components/schemas/StreamingBlob'
+          description: Object data.
+        Bucket:
+          $ref: '#/components/schemas/BucketName'
+          description: 'The name of the bucket to which the multipart upload was initiated.
+
+
+            **Directory buckets** \- When you use this operation with a directory
+            bucket, you must use virtual-hosted-style requests in the format ` _Bucket-name_.s3express-_zone-id_._region-code_.amazonaws.com`.
+            Path-style requests are not supported. Directory bucket names must be
+            unique in the chosen Zone (Availability Zone or Local Zone). Bucket names
+            must follow the format ` _bucket-base-name_ --_zone-id_ --x-s3` (for example,
+            ` _amzn-s3-demo-bucket_ --_usw2-az1_ --x-s3`). For information about bucket
+            naming restrictions, see [Directory bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html)
+            in the _Amazon S3 User Guide_.
+
+
+            **Access points** \- When you use this action with an access point for
+            general purpose buckets, you must provide the alias of the access point
+            in place of the bucket name or specify the access point ARN. When you
+            use this action with an access point for directory buckets, you must provide
+            the access point name in place of the bucket name. When using the access
+            point ARN, you must direct requests to the access point hostname. The
+            access point hostname takes the form _AccessPointName_ -_AccountId_.s3-accesspoint._Region_.amazonaws.com.
+            When using this action with an access point through the Amazon Web Services
+            SDKs, you provide the access point ARN in place of the bucket name. For
+            more information about access point ARNs, see [Using access points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Object Lambda access points are not supported by directory buckets.
+
+
+            **S3 on Outposts** \- When you use this action with S3 on Outposts, you
+            must direct requests to the S3 on Outposts hostname. The S3 on Outposts
+            hostname takes the form ` _AccessPointName_ -_AccountId_._outpostID_.s3-outposts._Region_.amazonaws.com`.
+            When you use this action with S3 on Outposts, the destination bucket must
+            be the Outposts access point ARN or the access point alias. For more information
+            about S3 on Outposts, see [What is S3 on Outposts?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+            in the _Amazon S3 User Guide_.'
+        ContentLength:
+          $ref: '#/components/schemas/ContentLength'
+          description: Size of the body in bytes. This parameter is useful when the
+            size of the body cannot be determined automatically.
+        ContentMD5:
+          $ref: '#/components/schemas/ContentMD5'
+          description: 'The Base64 encoded 128-bit MD5 digest of the part data. This
+            parameter is auto-populated when using the command from the CLI. This
+            parameter is required if object lock parameters are specified.
+
+
+            This functionality is not supported for directory buckets.'
+        ChecksumAlgorithm:
+          $ref: '#/components/schemas/ChecksumAlgorithm'
+          description: 'Indicates the algorithm used to create the checksum for the
+            object when you use the SDK. This header will not provide any additional
+            functionality if you don''t use the SDK. When you send this header, there
+            must be a corresponding `x-amz-checksum` or `x-amz-trailer` header sent.
+            Otherwise, Amazon S3 fails the request with the HTTP status code `400
+            Bad Request`. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            If you provide an individual checksum, Amazon S3 ignores any provided
+            `ChecksumAlgorithm` parameter.
+
+
+            This checksum algorithm must be the same for all parts and it match the
+            checksum value supplied in the `CreateMultipartUpload` request.'
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32` checksum of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 32-bit `CRC32C` checksum of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 64-bit `CRC64NVME` checksum of the
+            part. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 160-bit `SHA1` digest of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 256-bit `SHA256` digest of the object.
+            For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        Key:
+          $ref: '#/components/schemas/ObjectKey'
+          description: Object key for which the multipart upload was initiated.
+        PartNumber:
+          $ref: '#/components/schemas/PartNumber'
+          description: Part number of part being uploaded. This is a positive integer
+            between 1 and 10,000.
+        UploadId:
+          $ref: '#/components/schemas/MultipartUploadId'
+          description: Upload ID identifying the multipart upload whose part is being
+            uploaded.
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: 'Specifies the algorithm to use when encrypting the object
+            (for example, AES256).
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKey:
+          $ref: '#/components/schemas/SSECustomerKey'
+          description: 'Specifies the customer-provided encryption key for Amazon
+            S3 to use in encrypting data. This value is used to store the object and
+            then it is discarded; Amazon S3 does not store the encryption key. The
+            key must be appropriate for use with the algorithm specified in the `x-amz-server-side-encryption-customer-algorithm
+            header`. This must be the same encryption key specified in the initiate
+            multipart upload request.
+
+
+            This functionality is not supported for directory buckets.'
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 'Specifies the 128-bit MD5 digest of the encryption key according
+            to RFC 1321. Amazon S3 uses this header for a message integrity check
+            to ensure that the encryption key was transmitted without error.
+
+
+            This functionality is not supported for directory buckets.'
+        RequestPayer:
+          $ref: '#/components/schemas/RequestPayer'
+        ExpectedBucketOwner:
+          $ref: '#/components/schemas/AccountId'
+          description: The account ID of the expected bucket owner. If the account
+            ID that you provide does not match the actual owner of the bucket, the
+            request fails with the HTTP status code `403 Forbidden` (access denied).
+      required:
+      - Bucket
+      - Key
+      - PartNumber
+      - UploadId
+    UserMetadata:
+      type: array
+      items:
+        $ref: '#/components/schemas/MetadataEntry'
+    Value:
+      type: string
+    VersionCount:
+      type: integer
+    VersionIdMarker:
+      type: string
+    VersioningConfiguration:
+      type: object
+      properties:
+        MFADelete:
+          $ref: '#/components/schemas/MFADelete'
+          description: Specifies whether MFA delete is enabled in the bucket versioning
+            configuration. This element is only returned if the bucket has been configured
+            with MFA delete. If the bucket has never been so configured, this element
+            is not returned.
+        Status:
+          $ref: '#/components/schemas/BucketVersioningStatus'
+          description: The versioning state of the bucket.
+      description: Describes the versioning state of an Amazon S3 bucket. For more
+        information, see [PUT Bucket versioning](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTVersioningStatus.html)
+        in the _Amazon S3 API Reference_.
+    WebsiteConfiguration:
+      type: object
+      properties:
+        ErrorDocument:
+          $ref: '#/components/schemas/ErrorDocument'
+          description: The name of the error document for the website.
+        IndexDocument:
+          $ref: '#/components/schemas/IndexDocument'
+          description: The name of the index document for the website.
+        RedirectAllRequestsTo:
+          $ref: '#/components/schemas/RedirectAllRequestsTo'
+          description: 'The redirect behavior for every request to this bucket''s
+            website endpoint.
+
+
+            If you specify this property, you can''t specify any other property.'
+        RoutingRules:
+          $ref: '#/components/schemas/RoutingRules'
+          description: Rules that define when a redirect is applied and the redirect
+            behavior.
+      description: Specifies website configuration parameters for an Amazon S3 bucket.
+    WebsiteRedirectLocation:
+      type: string
+    WriteGetObjectResponseRequest:
+      type: object
+      properties:
+        RequestRoute:
+          $ref: '#/components/schemas/RequestRoute'
+          description: Route prefix to the HTTP URL generated.
+        RequestToken:
+          $ref: '#/components/schemas/RequestToken'
+          description: A single use encrypted token that maps `WriteGetObjectResponse`
+            to the end user `GetObject` request.
+        Body:
+          $ref: '#/components/schemas/StreamingBlob'
+          description: The object data.
+        StatusCode:
+          $ref: '#/components/schemas/GetObjectResponseStatusCode'
+          description: "The integer status code for an HTTP response of a corresponding\
+            \ `GetObject` request. The following is a list of status codes.\n\n  *\
+            \ `200 - OK`\n\n  * `206 - Partial Content`\n\n  * `304 - Not Modified`\n\
+            \n  * `400 - Bad Request`\n\n  * `401 - Unauthorized`\n\n  * `403 - Forbidden`\n\
+            \n  * `404 - Not Found`\n\n  * `405 - Method Not Allowed`\n\n  * `409\
+            \ - Conflict`\n\n  * `411 - Length Required`\n\n  * `412 - Precondition\
+            \ Failed`\n\n  * `416 - Range Not Satisfiable`\n\n  * `500 - Internal\
+            \ Server Error`\n\n  * `503 - Service Unavailable`"
+        ErrorCode:
+          $ref: '#/components/schemas/ErrorCode'
+          description: A string that uniquely identifies an error condition. Returned
+            in the ` tag of the error XML response for a corresponding `GetObject`
+            call. Cannot be used with a successful `StatusCode` header or when the
+            transformed object is provided in the body. All error codes from S3 are
+            sentence-cased. The regular expression (regex) value is `"^[A-Z][a-zA-Z]+$"`.
+        ErrorMessage:
+          $ref: '#/components/schemas/ErrorMessage'
+          description: Contains a generic description of the error condition. Returned
+            in the  tag of the error XML response for a corresponding `GetObject`
+            call. Cannot be used with a successful `StatusCode` header or when the
+            transformed object is provided in body.
+        AcceptRanges:
+          $ref: '#/components/schemas/AcceptRanges'
+          description: Indicates that a range of bytes was specified.
+        CacheControl:
+          $ref: '#/components/schemas/CacheControl'
+          description: Specifies caching behavior along the request/reply chain.
+        ContentDisposition:
+          $ref: '#/components/schemas/ContentDisposition'
+          description: Specifies presentational information for the object.
+        ContentEncoding:
+          $ref: '#/components/schemas/ContentEncoding'
+          description: Specifies what content encodings have been applied to the object
+            and thus what decoding mechanisms must be applied to obtain the media-type
+            referenced by the Content-Type header field.
+        ContentLanguage:
+          $ref: '#/components/schemas/ContentLanguage'
+          description: The language the content is in.
+        ContentLength:
+          $ref: '#/components/schemas/ContentLength'
+          description: The size of the content body in bytes.
+        ContentRange:
+          $ref: '#/components/schemas/ContentRange'
+          description: The portion of the object returned in the response.
+        ContentType:
+          $ref: '#/components/schemas/ContentType'
+          description: A standard MIME type describing the format of the object data.
+        ChecksumCRC32:
+          $ref: '#/components/schemas/ChecksumCRC32'
+          description: 'This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            specifies the Base64 encoded, 32-bit `CRC32` checksum of the object returned
+            by the Object Lambda function. This may not match the checksum for the
+            object stored in Amazon S3. Amazon S3 will perform validation of the checksum
+            values only when the original `GetObject` request required checksum validation.
+            For more information about checksums, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Only one checksum header can be specified at a time. If you supply multiple
+            checksum headers, this request will fail.'
+        ChecksumCRC32C:
+          $ref: '#/components/schemas/ChecksumCRC32C'
+          description: 'This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            specifies the Base64 encoded, 32-bit `CRC32C` checksum of the object returned
+            by the Object Lambda function. This may not match the checksum for the
+            object stored in Amazon S3. Amazon S3 will perform validation of the checksum
+            values only when the original `GetObject` request required checksum validation.
+            For more information about checksums, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Only one checksum header can be specified at a time. If you supply multiple
+            checksum headers, this request will fail.'
+        ChecksumCRC64NVME:
+          $ref: '#/components/schemas/ChecksumCRC64NVME'
+          description: This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            header specifies the Base64 encoded, 64-bit `CRC64NVME` checksum of the
+            part. For more information, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+        ChecksumSHA1:
+          $ref: '#/components/schemas/ChecksumSHA1'
+          description: 'This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            specifies the Base64 encoded, 160-bit `SHA1` digest of the object returned
+            by the Object Lambda function. This may not match the checksum for the
+            object stored in Amazon S3. Amazon S3 will perform validation of the checksum
+            values only when the original `GetObject` request required checksum validation.
+            For more information about checksums, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Only one checksum header can be specified at a time. If you supply multiple
+            checksum headers, this request will fail.'
+        ChecksumSHA256:
+          $ref: '#/components/schemas/ChecksumSHA256'
+          description: 'This header can be used as a data integrity check to verify
+            that the data received is the same data that was originally sent. This
+            specifies the Base64 encoded, 256-bit `SHA256` digest of the object returned
+            by the Object Lambda function. This may not match the checksum for the
+            object stored in Amazon S3. Amazon S3 will perform validation of the checksum
+            values only when the original `GetObject` request required checksum validation.
+            For more information about checksums, see [Checking object integrity](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+            in the _Amazon S3 User Guide_.
+
+
+            Only one checksum header can be specified at a time. If you supply multiple
+            checksum headers, this request will fail.'
+        DeleteMarker:
+          $ref: '#/components/schemas/DeleteMarker'
+          description: Specifies whether an object stored in Amazon S3 is (`true`)
+            or is not (`false`) a delete marker. To learn more about delete markers,
+            see [Working with delete markers](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html).
+        ETag:
+          $ref: '#/components/schemas/ETag'
+          description: An opaque identifier assigned by a web server to a specific
+            version of a resource found at a URL.
+        Expires:
+          $ref: '#/components/schemas/Expires'
+          description: The date and time at which the object is no longer cacheable.
+        Expiration:
+          $ref: '#/components/schemas/Expiration'
+          description: If the object expiration is configured (see PUT Bucket lifecycle),
+            the response includes this header. It includes the `expiry-date` and `rule-id`
+            key-value pairs that provide the object expiration information. The value
+            of the `rule-id` is URL-encoded.
+        LastModified:
+          $ref: '#/components/schemas/LastModified'
+          description: The date and time that the object was last modified.
+        MissingMeta:
+          $ref: '#/components/schemas/MissingMeta'
+          description: Set to the number of metadata entries not returned in `x-amz-meta`
+            headers. This can happen if you create metadata using an API like SOAP
+            that supports more flexible metadata than the REST API. For example, using
+            SOAP, you can create metadata whose values are not legal HTTP headers.
+        Metadata:
+          $ref: '#/components/schemas/Metadata'
+          description: A map of metadata to store with the object in S3.
+        ObjectLockMode:
+          $ref: '#/components/schemas/ObjectLockMode'
+          description: Indicates whether an object stored in Amazon S3 has Object
+            Lock enabled. For more information about S3 Object Lock, see [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html).
+        ObjectLockLegalHoldStatus:
+          $ref: '#/components/schemas/ObjectLockLegalHoldStatus'
+          description: Indicates whether an object stored in Amazon S3 has an active
+            legal hold.
+        ObjectLockRetainUntilDate:
+          $ref: '#/components/schemas/ObjectLockRetainUntilDate'
+          description: The date and time when Object Lock is configured to expire.
+        PartsCount:
+          $ref: '#/components/schemas/PartsCount'
+          description: The count of parts this object has.
+        ReplicationStatus:
+          $ref: '#/components/schemas/ReplicationStatus'
+          description: Indicates if request involves bucket that is either a source
+            or destination in a Replication rule. For more information about S3 Replication,
+            see [Replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html).
+        RequestCharged:
+          $ref: '#/components/schemas/RequestCharged'
+        Restore:
+          $ref: '#/components/schemas/Restore'
+          description: Provides information about object restoration operation and
+            expiration time of the restored object copy.
+        ServerSideEncryption:
+          $ref: '#/components/schemas/ServerSideEncryption'
+          description: 'The server-side encryption algorithm used when storing requested
+            object in Amazon S3 or Amazon FSx.
+
+
+            When accessing data stored in Amazon FSx file systems using S3 access
+            points, the only valid server side encryption option is `aws:fsx`.'
+        SSECustomerAlgorithm:
+          $ref: '#/components/schemas/SSECustomerAlgorithm'
+          description: Encryption algorithm used if server-side encryption with a
+            customer-provided encryption key was specified for object stored in Amazon
+            S3.
+        SSEKMSKeyId:
+          $ref: '#/components/schemas/SSEKMSKeyId'
+          description: If present, specifies the ID (Key ID, Key ARN, or Key Alias)
+            of the Amazon Web Services Key Management Service (Amazon Web Services
+            KMS) symmetric encryption customer managed key that was used for stored
+            in Amazon S3 object.
+        SSECustomerKeyMD5:
+          $ref: '#/components/schemas/SSECustomerKeyMD5'
+          description: 128-bit MD5 digest of customer-provided encryption key used
+            in Amazon S3 to encrypt data stored in S3. For more information, see [Protecting
+            data using server-side encryption with customer-provided encryption keys
+            (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).
+        StorageClass:
+          $ref: '#/components/schemas/StorageClass'
+          description: 'Provides storage class information of the object. Amazon S3
+            returns this header for all objects except for S3 Standard storage class
+            objects.
+
+
+            For more information, see [Storage Classes](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html).'
+        TagCount:
+          $ref: '#/components/schemas/TagCount'
+          description: The number of tags, if any, on the object.
+        VersionId:
+          $ref: '#/components/schemas/ObjectVersionId'
+          description: An ID used to reference a specific version of the object.
+        BucketKeyEnabled:
+          $ref: '#/components/schemas/BucketKeyEnabled'
+          description: Indicates whether the object stored in Amazon S3 uses an S3
+            bucket key for server-side encryption with Amazon Web Services KMS (SSE-KMS).
+      required:
+      - RequestRoute
+      - RequestToken
+    WriteOffsetBytes:
+      type: integer
+      format: int64
+    Years:
+      type: integer
+    metadatavalue:
+      type: object
+      description: Schema definition for metadatavalue (auto-generated placeholder)
+      x-orphaned: true
+  x-stackQL-resources:
+    bucket_acls:
+      id: aws.s3.bucket_acls
+      name: bucket_acls
+      title: Bucket Acls
+      methods:
+        get_bucket_acl:
+          operation:
+            $ref: '#/paths/~1?acl/get'
+          response:
+            mediaType: text/xml
+            openAPIDocKey: '200'
+        put_bucket_acl:
+          operation:
+            $ref: '#/paths/~1?acl/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+          request:
+            mediaType: application/xml
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/bucket_acls/methods/get_bucket_acl'
+        insert: []
+        update: []
+        delete: []
+x-stackQL-config:
+  auth:
+    type: aws_signing_v4
+    credentialsenvvar: AWS_SECRET_ACCESS_KEY
+    keyIDenvvar: AWS_ACCESS_KEY_ID
+  pagination:
+    requestToken:
+      key: ContinuationToken
+      location: query
+    responseToken:
+      key: ContinuationToken
+      location: body


### PR DESCRIPTION
Closes #242 

### Summary:
Add comprehensive unit tests for the methodselect package, covering all core functions:
 - `GetMethodForAction`: Tests supported actions (SELECT, mixed case), unsupported actions, and error handling.
 - `GetMethod`: Tests retrieval of existing and non-existent methods.
 - `getMethodByNameAndParameters`: Tests method lookup with and without parameters.
 - `NewMethodSelector`: Tests initialization for supported and unsupported providers.
All tests use the aws provider and bucket_acls resource for consistency.

<img width="1092" height="137" alt="image" src="https://github.com/user-attachments/assets/16355bd0-ba91-4f16-ba40-633f8b1f74b7" />
