### PR TITLE
view-string-concatenation

### DIFF
--- a/internal/stackql/astvisit/query_rewriting.go
+++ b/internal/stackql/astvisit/query_rewriting.go
@@ -109,6 +109,15 @@ func (v *standardQueryRewriteAstVisitor) isJSONEachCompatible(col parserutil.Col
 	return isJSONEachCompatibleRegexp.MatchString(s)
 }
 
+func (v *standardQueryRewriteAstVisitor) isAnonymous(col parserutil.ColumnHandle) bool {
+	switch col.Expr.(type) {
+	case *sqlparser.OrExpr:
+		return true
+	default:
+		return false
+	}
+}
+
 // TODO: introduce dependency on RDBMS
 func (v *standardQueryRewriteAstVisitor) getTypeFromParserType(t sqlparser.ValType) string {
 	//nolint:exhaustive // acceptable
@@ -693,7 +702,7 @@ func (v *standardQueryRewriteAstVisitor) Visit(node sqlparser.SQLNode) error {
 					} else {
 						r, ok := indirect.GetColumnByName(col.Name)
 						if !ok {
-							if !v.isJSONEachCompatible(col) {
+							if !v.isJSONEachCompatible(col) && !v.isAnonymous(col) {
 								return fmt.Errorf("query rewriting for indirection: cannot find col = '%s'", col.Name)
 							}
 							relationalCol = typing.NewRelationalColumn(col.Name, "").WithDecorated(col.DecoratedColumn) // TOOO: clean this up

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -4268,6 +4268,27 @@ Filtered Projection Detail Resource Level View of Cloud Control Resource Returns
     ...    ${outputStr}
     ...    ${CURDIR}/tmp/Filtered-Projection-Detail-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
 
+View String Concatenation Filtered Projection Detail Resource Level View of Cloud Control Resource Returns Expected Result
+    ${inputStr} =    Catenate
+    ...    select domain_name, 'Descriptor:' || arn as descriptor from aws.pseudo_s3.s3_bucket_detail where data__Identifier = 'stackql-testing-bucket-01';
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    |--------------------------------------------|---------------------------------------------------|
+    ...    |${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}domain_name${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}descriptor${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}${SPACE}|
+    ...    |--------------------------------------------|---------------------------------------------------|
+    ...    |${SPACE}stackql-testing-bucket-01.s3.amazonaws.com${SPACE}|${SPACE}Descriptor:arn:aws:s3:::stackql-testing-bucket-01${SPACE}|
+    ...    |--------------------------------------------|---------------------------------------------------|
+    Should Horrid Query StackQL Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}    
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${CURDIR}/tmp/View-String-Concatenation-Filtered-Projection-Detail-Resource-Level-View-of-Cloud-Control-Resource-Returns-Expected-Result.tmp
+
 Filtered Star Resource Level View of Cloud Control Resource Returns Expected Result
     Should Horrid Query StackQL Inline Equal
     ...    ${STACKQL_EXE}


### PR DESCRIPTION
## Description

- Support for basic view string concatenation.
- Added robot test `View String Concatenation Filtered Projection Detail Resource Level View of Cloud Control Resource Returns Expected Result`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

Closes #623

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `View String Concatenation Filtered Projection Detail Resource Level View of Cloud Control Resource Returns Expected Result`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
