### PR TITLE
pg-wire-extended-query-support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -198,6 +198,13 @@ linters:
         path: mcp_client\/cmd\/.*\.go
       - linters:
           - revive
+          - unparam
+        path: internal\/stackql\/driver\/.*\.go
+      - linters:
+          - stylecheck
+        path: internal\/stackql\/queryshape\/.*\.go
+      - linters:
+          - revive
         path: internal\/stackql\/acid\/tsm_physio\/.*\.go
       - linters: 
           - staticcheck

--- a/internal/stackql/driver/driver.go
+++ b/internal/stackql/driver/driver.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stackql/stackql/internal/stackql/acid/tsm_physio"
 	"github.com/stackql/stackql/internal/stackql/handler"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stackql/stackql/internal/stackql/paramdecoder"
+	"github.com/stackql/stackql/internal/stackql/queryshape"
 	"github.com/stackql/stackql/internal/stackql/responsehandler"
 	"github.com/stackql/stackql/internal/stackql/util"
 	"github.com/stackql/stackql/pkg/txncounter"
@@ -19,9 +21,10 @@ import (
 )
 
 var (
-	_ StackQLDriver                = &basicStackQLDriver{}
-	_ sqlbackend.SQLBackendFactory = &basicStackQLDriverFactory{}
-	_ StackQLDriverFactory         = &basicStackQLDriverFactory{}
+	_ StackQLDriver                    = &basicStackQLDriver{}
+	_ sqlbackend.IExtendedQueryBackend = &basicStackQLDriver{}
+	_ sqlbackend.SQLBackendFactory     = &basicStackQLDriverFactory{}
+	_ StackQLDriverFactory             = &basicStackQLDriverFactory{}
 )
 
 type StackQLDriverFactory interface {
@@ -66,6 +69,10 @@ func (sdf *basicStackQLDriverFactory) newSQLDriver() (StackQLDriver, error) {
 		debugBuf:        buf,
 		handlerCtx:      clonedCtx,
 		txnOrchestrator: txnOrchestrator,
+		shapeInferrer:   queryshape.NewInferrer(clonedCtx),
+		paramDecoder:    paramdecoder.NewDecoder(),
+		stmtCache:       make(map[string]*stmtMeta),
+		portalCache:     make(map[string]*portalMeta),
 	}
 	return rv, nil
 }
@@ -125,10 +132,24 @@ func (dr *basicStackQLDriver) ProcessQuery(query string) {
 	}
 }
 
+type stmtMeta struct {
+	query     string
+	paramOIDs []uint32
+	columns   []sqldata.ISQLColumn
+}
+
+type portalMeta struct {
+	stmtName string
+}
+
 type basicStackQLDriver struct {
 	debugBuf        *bytes.Buffer
 	handlerCtx      handler.HandlerContext
 	txnOrchestrator tsm_physio.Orchestrator
+	shapeInferrer   queryshape.Inferrer
+	paramDecoder    paramdecoder.Decoder
+	stmtCache       map[string]*stmtMeta
+	portalCache     map[string]*portalMeta
 }
 
 func (dr *basicStackQLDriver) GetDebugStr() string {
@@ -191,7 +212,86 @@ func NewStackQLDriver(handlerCtx handler.HandlerContext) (StackQLDriver, error) 
 	return &basicStackQLDriver{
 		handlerCtx:      handlerCtx,
 		txnOrchestrator: txnOrchestrator,
+		shapeInferrer:   queryshape.NewInferrer(handlerCtx),
+		paramDecoder:    paramdecoder.NewDecoder(),
+		stmtCache:       make(map[string]*stmtMeta),
+		portalCache:     make(map[string]*portalMeta),
 	}, nil
+}
+
+func (dr *basicStackQLDriver) HandleParse(
+	ctx context.Context, stmtName string, query string, paramOIDs []uint32,
+) ([]uint32, error) {
+	// Infer result columns at parse time and cache for Describe/Execute.
+	columns := dr.shapeInferrer.InferResultColumns(query)
+	dr.stmtCache[stmtName] = &stmtMeta{
+		query:     query,
+		paramOIDs: paramOIDs,
+		columns:   columns,
+	}
+	return paramOIDs, nil
+}
+
+func (dr *basicStackQLDriver) HandleBind(
+	ctx context.Context, portalName string, stmtName string,
+	paramFormats []int16, paramValues [][]byte, resultFormats []int16,
+) error {
+	dr.portalCache[portalName] = &portalMeta{
+		stmtName: stmtName,
+	}
+	return nil
+}
+
+func (dr *basicStackQLDriver) HandleDescribeStatement(
+	ctx context.Context, stmtName string, query string, paramOIDs []uint32,
+) ([]uint32, []sqldata.ISQLColumn, error) {
+	if cached, ok := dr.stmtCache[stmtName]; ok {
+		return cached.paramOIDs, cached.columns, nil
+	}
+	// Fallback: infer on the fly (shouldn't happen if Parse was called first).
+	columns := dr.shapeInferrer.InferResultColumns(query)
+	return paramOIDs, columns, nil
+}
+
+func (dr *basicStackQLDriver) HandleDescribePortal(
+	ctx context.Context, portalName string, stmtName string, query string, paramOIDs []uint32,
+) ([]sqldata.ISQLColumn, error) {
+	if portal, portalFound := dr.portalCache[portalName]; portalFound {
+		if cached, stmtFound := dr.stmtCache[portal.stmtName]; stmtFound {
+			return cached.columns, nil
+		}
+	}
+	return dr.shapeInferrer.InferResultColumns(query), nil
+}
+
+func (dr *basicStackQLDriver) HandleExecute(
+	ctx context.Context, portalName string, stmtName string, query string,
+	paramFormats []int16, paramValues [][]byte, resultFormats []int16, maxRows int32,
+) (sqldata.ISQLResultStream, error) {
+	// Look up cached param OIDs for format-aware decoding.
+	var paramOIDs []uint32
+	if portal, portalFound := dr.portalCache[portalName]; portalFound {
+		if cached, stmtFound := dr.stmtCache[portal.stmtName]; stmtFound {
+			paramOIDs = cached.paramOIDs
+		}
+	}
+	// Decode params (handles both text and binary formats).
+	decodedStrings, err := dr.paramDecoder.DecodeParams(paramOIDs, paramFormats, paramValues)
+	if err != nil {
+		return nil, fmt.Errorf("parameter decoding error: %w", err)
+	}
+	resolved := queryshape.SubstituteDecodedParams(query, decodedStrings)
+	return dr.HandleSimpleQuery(ctx, resolved)
+}
+
+func (dr *basicStackQLDriver) HandleCloseStatement(ctx context.Context, stmtName string) error {
+	delete(dr.stmtCache, stmtName)
+	return nil
+}
+
+func (dr *basicStackQLDriver) HandleClosePortal(ctx context.Context, portalName string) error {
+	delete(dr.portalCache, portalName)
+	return nil
 }
 
 func (dr *basicStackQLDriver) processQueryOrQueries(

--- a/internal/stackql/paramdecoder/paramdecoder.go
+++ b/internal/stackql/paramdecoder/paramdecoder.go
@@ -1,0 +1,147 @@
+// Package paramdecoder decodes parameter values from their wire format
+// (text or binary) into string representations suitable for SQL substitution.
+package paramdecoder
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/lib/pq/oid"
+)
+
+// Decoder decodes raw parameter bytes according to their format codes
+// and OIDs, returning string representations for each.
+type Decoder interface {
+	DecodeParams(paramOIDs []uint32, paramFormats []int16, paramValues [][]byte) ([]string, error)
+}
+
+// NewDecoder creates a new parameter decoder.
+func NewDecoder() Decoder {
+	return &standardDecoder{}
+}
+
+type standardDecoder struct{}
+
+func (d *standardDecoder) DecodeParams(
+	paramOIDs []uint32, paramFormats []int16, paramValues [][]byte,
+) ([]string, error) {
+	result := make([]string, len(paramValues))
+	for i, val := range paramValues {
+		if val == nil {
+			result[i] = "NULL"
+			continue
+		}
+		format := resolveFormat(paramFormats, i)
+		paramOID := oid.Oid(0)
+		if i < len(paramOIDs) {
+			paramOID = oid.Oid(paramOIDs[i])
+		}
+		decoded, err := decodeParam(paramOID, format, val)
+		if err != nil {
+			return nil, fmt.Errorf("parameter $%d: %w", i+1, err)
+		}
+		result[i] = decoded
+	}
+	return result, nil
+}
+
+// resolveFormat returns the format code for parameter at index i.
+// Per postgres protocol: empty = all text, length 1 = applies to all,
+// otherwise per-parameter.
+func resolveFormat(formats []int16, i int) int16 {
+	if len(formats) == 0 {
+		return 0 // text
+	}
+	if len(formats) == 1 {
+		return formats[0]
+	}
+	if i < len(formats) {
+		return formats[i]
+	}
+	return 0 // text
+}
+
+// decodeParam decodes a single parameter value.
+// Format 0 = text (bytes are UTF-8), format 1 = binary (OID-specific encoding).
+func decodeParam(paramOID oid.Oid, format int16, val []byte) (string, error) {
+	if format == 0 {
+		// Text format: raw bytes are the UTF-8 string representation.
+		return string(val), nil
+	}
+	// Binary format: decode based on OID.
+	return decodeBinary(paramOID, val)
+}
+
+// Binary wire sizes for fixed-width postgres types.
+const (
+	boolSize      = 1
+	int2Size      = 2
+	int4Size      = 4
+	int8Size      = 8
+	float4Size    = 4
+	float8Size    = 8
+	timestampSize = 8
+)
+
+// decodeBinary decodes a binary-encoded parameter value to its string representation.
+//
+//nolint:cyclop,exhaustive // switch over OIDs is inherently branchy; only common types handled
+func decodeBinary(paramOID oid.Oid, val []byte) (string, error) {
+	switch paramOID {
+	case oid.T_bool:
+		if len(val) != boolSize {
+			return "", fmt.Errorf("bool: expected %d byte, got %d", boolSize, len(val))
+		}
+		if val[0] != 0 {
+			return "true", nil
+		}
+		return "false", nil
+	case oid.T_int2:
+		if len(val) != int2Size {
+			return "", fmt.Errorf("int2: expected %d bytes, got %d", int2Size, len(val))
+		}
+		v := int16(binary.BigEndian.Uint16(val)) //nolint:gosec // deliberate narrowing
+		return strconv.FormatInt(int64(v), 10), nil
+	case oid.T_int4:
+		if len(val) != int4Size {
+			return "", fmt.Errorf("int4: expected %d bytes, got %d", int4Size, len(val))
+		}
+		v := int32(binary.BigEndian.Uint32(val)) //nolint:gosec // deliberate narrowing
+		return strconv.FormatInt(int64(v), 10), nil
+	case oid.T_int8:
+		if len(val) != int8Size {
+			return "", fmt.Errorf("int8: expected %d bytes, got %d", int8Size, len(val))
+		}
+		v := int64(binary.BigEndian.Uint64(val)) //nolint:gosec // deliberate conversion
+		return strconv.FormatInt(v, 10), nil
+	case oid.T_float4:
+		if len(val) != float4Size {
+			return "", fmt.Errorf("float4: expected %d bytes, got %d", float4Size, len(val))
+		}
+		bits := binary.BigEndian.Uint32(val)
+		return strconv.FormatFloat(float64(math.Float32frombits(bits)), 'f', -1, 32), nil
+	case oid.T_float8:
+		if len(val) != float8Size {
+			return "", fmt.Errorf("float8: expected %d bytes, got %d", float8Size, len(val))
+		}
+		bits := binary.BigEndian.Uint64(val)
+		return strconv.FormatFloat(math.Float64frombits(bits), 'f', -1, 64), nil
+	case oid.T_timestamp, oid.T_timestamptz:
+		if len(val) != timestampSize {
+			return "", fmt.Errorf("timestamp: expected %d bytes, got %d", timestampSize, len(val))
+		}
+		// Postgres binary timestamp: microseconds since 2000-01-01 00:00:00 UTC.
+		microseconds := int64(binary.BigEndian.Uint64(val)) //nolint:gosec // deliberate conversion
+		pgEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+		ts := pgEpoch.Add(time.Duration(microseconds) * time.Microsecond)
+		return ts.Format("2006-01-02 15:04:05.999999"), nil
+	case oid.T_text, oid.T_varchar, oid.T_name:
+		return string(val), nil
+	default:
+		// Unknown OID: treat as text (safe fallback).
+		return string(val), nil
+	}
+}

--- a/internal/stackql/paramdecoder/paramdecoder_test.go
+++ b/internal/stackql/paramdecoder/paramdecoder_test.go
@@ -1,0 +1,138 @@
+package paramdecoder_test
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/lib/pq/oid"
+	"github.com/stackql/stackql/internal/stackql/paramdecoder"
+)
+
+func TestDecodeTextParams(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	results, err := d.DecodeParams(
+		[]uint32{uint32(oid.T_text), uint32(oid.T_text)},
+		[]int16{0}, // all text
+		[][]byte{[]byte("hello"), []byte("world")},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "hello" || results[1] != "world" {
+		t.Errorf("got %v", results)
+	}
+}
+
+func TestDecodeNullParam(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	results, err := d.DecodeParams(
+		[]uint32{uint32(oid.T_text)},
+		nil,
+		[][]byte{nil},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "NULL" {
+		t.Errorf("got %q, want NULL", results[0])
+	}
+}
+
+func TestDecodeBinaryInt4(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	val := make([]byte, 4)
+	binary.BigEndian.PutUint32(val, uint32(42))
+	results, err := d.DecodeParams(
+		[]uint32{uint32(oid.T_int4)},
+		[]int16{1}, // binary
+		[][]byte{val},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "42" {
+		t.Errorf("got %q, want 42", results[0])
+	}
+}
+
+func TestDecodeBinaryInt8(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	val := make([]byte, 8)
+	binary.BigEndian.PutUint64(val, uint64(9999999999))
+	results, err := d.DecodeParams(
+		[]uint32{uint32(oid.T_int8)},
+		[]int16{1},
+		[][]byte{val},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "9999999999" {
+		t.Errorf("got %q, want 9999999999", results[0])
+	}
+}
+
+func TestDecodeBinaryFloat8(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	val := make([]byte, 8)
+	binary.BigEndian.PutUint64(val, math.Float64bits(3.14))
+	results, err := d.DecodeParams(
+		[]uint32{uint32(oid.T_float8)},
+		[]int16{1},
+		[][]byte{val},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "3.14" {
+		t.Errorf("got %q, want 3.14", results[0])
+	}
+}
+
+func TestDecodeBinaryBool(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	results, err := d.DecodeParams(
+		[]uint32{uint32(oid.T_bool), uint32(oid.T_bool)},
+		[]int16{1},
+		[][]byte{{1}, {0}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "true" || results[1] != "false" {
+		t.Errorf("got %v", results)
+	}
+}
+
+func TestDecodeMixedFormats(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	int4Val := make([]byte, 4)
+	binary.BigEndian.PutUint32(int4Val, uint32(100))
+	results, err := d.DecodeParams(
+		[]uint32{uint32(oid.T_text), uint32(oid.T_int4)},
+		[]int16{0, 1}, // first text, second binary
+		[][]byte{[]byte("hello"), int4Val},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "hello" || results[1] != "100" {
+		t.Errorf("got %v", results)
+	}
+}
+
+func TestDecodeUnknownOIDBinaryFallsBackToText(t *testing.T) {
+	d := paramdecoder.NewDecoder()
+	results, err := d.DecodeParams(
+		[]uint32{99999},
+		[]int16{1}, // binary
+		[][]byte{[]byte("raw-bytes")},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0] != "raw-bytes" {
+		t.Errorf("got %q, want raw-bytes", results[0])
+	}
+}

--- a/internal/stackql/plan/plan.go
+++ b/internal/stackql/plan/plan.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackql/stackql/internal/stackql/acid/binlog"
 	"github.com/stackql/stackql/internal/stackql/primitivegraph"
+	"github.com/stackql/stackql/internal/stackql/typing"
 
 	"github.com/stackql/stackql-parser/go/vt/sqlparser"
 )
@@ -29,6 +30,10 @@ type Plan interface {
 	GetRedoLog() (binlog.LogEntry, bool)
 	// Get the undo log entry.
 	GetUndoLog() (binlog.LogEntry, bool)
+
+	// Column metadata from query planning (available after plan build, before execution).
+	GetColumnMetadata() []typing.ColumnMetadata
+	SetColumnMetadata(columns []typing.ColumnMetadata)
 
 	// Setters
 	SetType(t sqlparser.StatementType)
@@ -59,13 +64,14 @@ type standardPlan struct {
 	// Stores BindVars needed to be provided as part of expression rewriting
 	sqlparser.BindVarNeeds
 
-	ExecCount    uint64        // Count of times this plan was executed
-	ExecTime     time.Duration // Total execution time
-	ShardQueries uint64        // Total number of shard queries
-	Rows         uint64        // Total number of rows
-	Errors       uint64        // Total number of errors
-	isCacheable  bool
-	isReadOnly   bool
+	ExecCount      uint64        // Count of times this plan was executed
+	ExecTime       time.Duration // Total execution time
+	ShardQueries   uint64        // Total number of shard queries
+	Rows           uint64        // Total number of rows
+	Errors         uint64        // Total number of errors
+	isCacheable    bool
+	isReadOnly     bool
+	columnMetadata []typing.ColumnMetadata
 }
 
 func NewPlan(
@@ -169,4 +175,12 @@ func (p *standardPlan) IsCacheable() bool {
 
 func (p *standardPlan) SetCacheable(isCacheable bool) {
 	p.isCacheable = isCacheable
+}
+
+func (p *standardPlan) GetColumnMetadata() []typing.ColumnMetadata {
+	return p.columnMetadata
+}
+
+func (p *standardPlan) SetColumnMetadata(columns []typing.ColumnMetadata) {
+	p.columnMetadata = columns
 }

--- a/internal/stackql/planbuilder/entrypoint.go
+++ b/internal/stackql/planbuilder/entrypoint.go
@@ -181,6 +181,12 @@ func (pb *standardPlanBuilder) BuildPlanFromContext(handlerCtx handler.HandlerCo
 
 	qPlan.SetInstructions(pGBuilder.getPlanGraphHolder())
 
+	// Extract column metadata from the plan for extended query protocol Describe support.
+	//nolint:lll // acceptable
+	if selCtx := pGBuilder.getRootPrimitiveGenerator().GetPrimitiveComposer().GetSelectPreparedStatementCtx(); selCtx != nil {
+		qPlan.SetColumnMetadata(selCtx.GetNonControlColumns())
+	}
+
 	if qPlan.GetInstructions() != nil {
 		err = qPlan.GetInstructions().GetPrimitiveGraph().Optimise()
 		if err != nil {

--- a/internal/stackql/planbuilder/plan_builder.go
+++ b/internal/stackql/planbuilder/plan_builder.go
@@ -50,6 +50,7 @@ func isPlanCacheEnabled() bool {
 
 type planGraphBuilder interface {
 	setRootPrimitiveGenerator(primitivegenerator.PrimitiveGenerator)
+	getRootPrimitiveGenerator() primitivegenerator.PrimitiveGenerator
 	pgInternal(planbuilderinput.PlanBuilderInput) error
 	createInstructionFor(planbuilderinput.PlanBuilderInput) error
 	nop(planbuilderinput.PlanBuilderInput) error
@@ -76,6 +77,10 @@ func (pgb *standardPlanGraphBuilder) setPrebuiltIndirect(builderz []primitivebui
 func (pgb *standardPlanGraphBuilder) setRootPrimitiveGenerator(
 	primitiveGenerator primitivegenerator.PrimitiveGenerator) {
 	pgb.rootPrimitiveGenerator = primitiveGenerator
+}
+
+func (pgb *standardPlanGraphBuilder) getRootPrimitiveGenerator() primitivegenerator.PrimitiveGenerator {
+	return pgb.rootPrimitiveGenerator
 }
 
 func (pgb *standardPlanGraphBuilder) getPlanGraphHolder() primitivegraph.PrimitiveGraphHolder {

--- a/internal/stackql/psqlwire/psqlwire.go
+++ b/internal/stackql/psqlwire/psqlwire.go
@@ -98,6 +98,12 @@ func ExtractRowElement(column sqldata.ISQLColumn, src interface{}, ci *pgtype.Co
 		processedElement = shimNumericElement(src)
 	}
 	// end hack
+	// NOTE: coerceForOID is available for binary format encoding (Phase 4).
+	// For text format (current default), string values pass through to
+	// pgtype's text encoder which handles all types correctly.
+	// Coercing to native Go types here would change the text encoding
+	// format (e.g. bool: "t"→"true", int: quoted→unquoted).
+
 	err := typed.Value.Set(processedElement)
 	if err != nil {
 		return nil, err

--- a/internal/stackql/queryshape/queryshape.go
+++ b/internal/stackql/queryshape/queryshape.go
@@ -1,0 +1,233 @@
+// Package queryshape provides result column metadata inference for SQL queries
+// without executing them.
+//
+// Type inference sources vary by relation kind:
+//
+//   - Materialized views and user space tables: column metadata is stored
+//     alongside the DDL in system tables (__iql__.materialized_views.columns,
+//     __iql__.tables.columns).  OIDs, widths, and types are directly available.
+//
+//   - Views: the view DDL (a SELECT) is stored in __iql__.views.  Parsing the
+//     DDL and recursively analysing the projection list yields column shapes.
+//     This currently delegates to the plan builder.
+//
+//   - Direct queries and subqueries: column types are a function of provider
+//     method schemas, applied SQL function signatures, and RDBMS expression
+//     rules.  This currently delegates to the plan builder.
+package queryshape
+
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/lib/pq/oid"
+	"github.com/stackql/psql-wire/pkg/sqldata"
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+	"github.com/stackql/stackql/internal/stackql/handler"
+	"github.com/stackql/stackql/internal/stackql/planbuilder"
+	"github.com/stackql/stackql/internal/stackql/sql_system"
+	"github.com/stackql/stackql/internal/stackql/typing"
+)
+
+// Inferrer analyses SQL queries and returns result column metadata
+// without executing them.
+type Inferrer interface {
+	// InferResultColumns returns wire-protocol column metadata for the
+	// given query.  Returns nil when columns cannot be derived (DDL,
+	// mutations, planning failures).
+	InferResultColumns(query string) []sqldata.ISQLColumn
+}
+
+// NewInferrer creates a new query shape inferrer backed by the given
+// handler context.
+func NewInferrer(handlerCtx handler.HandlerContext) Inferrer {
+	return &standardInferrer{
+		handlerCtx: handlerCtx,
+		sqlSystem:  handlerCtx.GetSQLSystem(),
+	}
+}
+
+type standardInferrer struct {
+	handlerCtx handler.HandlerContext
+	sqlSystem  sql_system.SQLSystem
+}
+
+func (si *standardInferrer) InferResultColumns(query string) []sqldata.ISQLColumn {
+	// Try stored relation metadata first (cheapest path).
+	if cols := si.inferFromStoredRelation(query); cols != nil {
+		return cols
+	}
+	// Fall back to plan-based inference for direct queries, subqueries,
+	// and views whose columns require provider schema resolution.
+	return si.inferFromPlan(query)
+}
+
+// inferFromStoredRelation checks whether the query is a simple
+// SELECT against a single materialized view or user space table
+// whose column metadata is already stored.  If so, the columns
+// are returned directly from the DTO without planning.
+func (si *standardInferrer) inferFromStoredRelation(query string) []sqldata.ISQLColumn {
+	tableName := extractSingleTableName(query)
+	if tableName == "" {
+		return nil
+	}
+	// Materialized views carry stored column metadata with OIDs.
+	if dto, ok := si.sqlSystem.GetMaterializedViewByName(tableName); ok {
+		return relationalColumnsToSQLColumns(dto.GetColumns())
+	}
+	// User space tables also carry stored column metadata.
+	if dto, ok := si.sqlSystem.GetPhysicalTableByName(tableName); ok {
+		return relationalColumnsToSQLColumns(dto.GetColumns())
+	}
+	return nil
+}
+
+// inferFromPlan builds a query plan (without executing) and extracts
+// column metadata from it.  This handles views, subqueries, and
+// direct provider queries where types derive from method schemas
+// and SQL function signatures.
+func (si *standardInferrer) inferFromPlan(query string) []sqldata.ISQLColumn {
+	clonedCtx := si.handlerCtx.Clone()
+	clonedCtx.SetQuery(query)
+	clonedCtx.SetRawQuery(query)
+	pb := planbuilder.NewPlanBuilder(nil)
+	qPlan, err := pb.BuildPlanFromContext(clonedCtx)
+	if err != nil || qPlan == nil {
+		return nil
+	}
+	colMeta := qPlan.GetColumnMetadata()
+	if len(colMeta) == 0 {
+		return nil
+	}
+	return columnMetadataToSQLColumns(colMeta)
+}
+
+// extractSingleTableName does a lightweight parse to detect queries
+// of the form "SELECT ... FROM <single_table> ..." and returns the
+// table name.  Returns "" for anything more complex (joins, subqueries, etc).
+func extractSingleTableName(query string) string {
+	stmt, err := sqlparser.Parse(query)
+	if err != nil {
+		return ""
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok || sel == nil {
+		return ""
+	}
+	if len(sel.From) != 1 {
+		return ""
+	}
+	aliased, ok := sel.From[0].(*sqlparser.AliasedTableExpr)
+	if !ok {
+		return ""
+	}
+	tableName, ok := aliased.Expr.(sqlparser.TableName)
+	if !ok {
+		return ""
+	}
+	// Only unqualified table names (no provider.service.resource).
+	if !tableName.Qualifier.IsEmpty() {
+		return ""
+	}
+	return tableName.Name.GetRawVal()
+}
+
+// relationalColumnsToSQLColumns converts stored RelationalColumn
+// metadata to wire protocol ISQLColumn objects.
+func relationalColumnsToSQLColumns(cols []typing.RelationalColumn) []sqldata.ISQLColumn {
+	if len(cols) == 0 {
+		return nil
+	}
+	table := sqldata.NewSQLTable(0, "")
+	result := make([]sqldata.ISQLColumn, len(cols))
+	for i, col := range cols {
+		colOID := oid.T_text
+		if storedOID, ok := col.GetOID(); ok {
+			colOID = storedOID
+		}
+		w := col.GetWidth()
+		if w > math.MaxInt16 || w < math.MinInt16 {
+			w = -1
+		}
+		result[i] = sqldata.NewSQLColumn(
+			table,
+			col.GetIdentifier(),
+			0,
+			uint32(colOID),
+			int16(w), //nolint:gosec // bounds checked above
+			0,
+			"text",
+		)
+	}
+	return result
+}
+
+// columnMetadataToSQLColumns converts internal ColumnMetadata to
+// wire protocol ISQLColumn objects.
+func columnMetadataToSQLColumns(cols []typing.ColumnMetadata) []sqldata.ISQLColumn {
+	table := sqldata.NewSQLTable(0, "")
+	result := make([]sqldata.ISQLColumn, len(cols))
+	for i, col := range cols {
+		result[i] = sqldata.NewSQLColumn(
+			table,
+			col.GetIdentifier(),
+			0,
+			uint32(col.GetColumnOID()),
+			-1,
+			0,
+			"text",
+		)
+	}
+	return result
+}
+
+var paramPlaceholderRegex = regexp.MustCompile(`\$(\d+)`)
+
+// SubstituteParams replaces $1, $2, ... placeholders with their bound values.
+// NULL parameters (nil entries in paramValues) are substituted as the literal NULL.
+// String values are single-quote escaped.
+//
+//nolint:revive // paramFormats retained for future binary format support
+func SubstituteParams(query string, paramFormats []int16, paramValues [][]byte) string { //nolint:revive // future use
+	if len(paramValues) == 0 {
+		return query
+	}
+	return paramPlaceholderRegex.ReplaceAllStringFunc(query, func(match string) string {
+		idxStr := match[1:] // strip leading $
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil || idx < 1 || idx > len(paramValues) {
+			return match // leave unrecognised placeholders as-is
+		}
+		val := paramValues[idx-1]
+		if val == nil {
+			return "NULL"
+		}
+		text := string(val)
+		escaped := strings.ReplaceAll(text, "'", "''")
+		return "'" + escaped + "'"
+	})
+}
+
+// SubstituteDecodedParams replaces $1, $2, ... placeholders with
+// pre-decoded string values.  "NULL" values are substituted unquoted;
+// all other values are single-quote escaped.
+func SubstituteDecodedParams(query string, decodedValues []string) string {
+	if len(decodedValues) == 0 {
+		return query
+	}
+	return paramPlaceholderRegex.ReplaceAllStringFunc(query, func(match string) string {
+		idxStr := match[1:]
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil || idx < 1 || idx > len(decodedValues) {
+			return match
+		}
+		val := decodedValues[idx-1]
+		if val == "NULL" {
+			return "NULL"
+		}
+		escaped := strings.ReplaceAll(val, "'", "''")
+		return "'" + escaped + "'"
+	})
+}

--- a/internal/stackql/queryshape/queryshape_test.go
+++ b/internal/stackql/queryshape/queryshape_test.go
@@ -1,0 +1,70 @@
+package queryshape //nolint:testpackage // tests unexported extractSingleTableName
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+type extractTableCase struct {
+	Description string `json:"description"`
+	Query       string `json:"query"`
+	Expected    string `json:"expected"`
+}
+
+func TestExtractSingleTableName(t *testing.T) {
+	data, err := os.ReadFile("testdata/extract_table_cases.json")
+	if err != nil {
+		t.Fatalf("failed to read testdata: %v", err)
+	}
+	var cases []extractTableCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("failed to parse testdata: %v", err)
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got := extractSingleTableName(tc.Query)
+			if got != tc.Expected {
+				t.Errorf("extractSingleTableName(%q) = %q, want %q", tc.Query, got, tc.Expected)
+			}
+		})
+	}
+}
+
+type SubstituteParamsCase struct {
+	Description string    `json:"description"`
+	Query       string    `json:"query"`
+	ParamValues []*string `json:"paramValues"` // nil entries represent SQL NULL
+	Expected    string    `json:"expected"`
+}
+
+func (c *SubstituteParamsCase) toByteSlices() [][]byte {
+	result := make([][]byte, len(c.ParamValues))
+	for i, v := range c.ParamValues {
+		if v == nil {
+			result[i] = nil
+		} else {
+			result[i] = []byte(*v)
+		}
+	}
+	return result
+}
+
+func TestSubstituteParams(t *testing.T) {
+	data, err := os.ReadFile("testdata/substitute_params_cases.json")
+	if err != nil {
+		t.Fatalf("failed to read testdata: %v", err)
+	}
+	var cases []SubstituteParamsCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("failed to parse testdata: %v", err)
+	}
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got := SubstituteParams(tc.Query, nil, tc.toByteSlices())
+			if got != tc.Expected {
+				t.Errorf("SubstituteParams(%q, ...) = %q, want %q", tc.Query, got, tc.Expected)
+			}
+		})
+	}
+}

--- a/internal/stackql/queryshape/testdata/extract_table_cases.json
+++ b/internal/stackql/queryshape/testdata/extract_table_cases.json
@@ -1,0 +1,82 @@
+[
+  {
+    "description": "simple unqualified SELECT",
+    "query": "SELECT * FROM my_table",
+    "expected": "my_table"
+  },
+  {
+    "description": "SELECT with WHERE clause",
+    "query": "SELECT name FROM my_view WHERE x = 1",
+    "expected": "my_view"
+  },
+  {
+    "description": "SELECT with alias",
+    "query": "SELECT t.name FROM my_table t WHERE t.id = 5",
+    "expected": "my_table"
+  },
+  {
+    "description": "JOIN returns empty (multi-table)",
+    "query": "SELECT * FROM a JOIN b ON a.id = b.id",
+    "expected": ""
+  },
+  {
+    "description": "subquery returns empty",
+    "query": "SELECT * FROM (SELECT 1) sq",
+    "expected": ""
+  },
+  {
+    "description": "INSERT returns empty",
+    "query": "INSERT INTO foo VALUES (1)",
+    "expected": ""
+  },
+  {
+    "description": "CREATE VIEW returns empty",
+    "query": "CREATE VIEW v AS SELECT 1",
+    "expected": ""
+  },
+  {
+    "description": "qualified provider.service.resource returns empty",
+    "query": "SELECT * FROM google.compute.instances WHERE project = 'x'",
+    "expected": ""
+  },
+  {
+    "description": "qualified local_templated provider returns empty",
+    "query": "SELECT * FROM local_openssl.keys.x509 WHERE cert_file = 'foo.pem'",
+    "expected": ""
+  },
+  {
+    "description": "SELECT with ORDER BY",
+    "query": "SELECT name, url FROM mv_repos ORDER BY name DESC",
+    "expected": "mv_repos"
+  },
+  {
+    "description": "SELECT with dollar param in WHERE",
+    "query": "SELECT name FROM my_table WHERE id = $1",
+    "expected": "my_table"
+  },
+  {
+    "description": "SELECT with multiple dollar params",
+    "query": "SELECT name FROM my_table WHERE id = $1 AND region = $2",
+    "expected": "my_table"
+  },
+  {
+    "description": "LEFT OUTER JOIN returns empty",
+    "query": "SELECT v1.name FROM vw_repos v1 LEFT OUTER JOIN mv_repos mv ON v1.name = mv.name",
+    "expected": ""
+  },
+  {
+    "description": "CTE extracts inner table name (harmless; won't match stored relations)",
+    "query": "WITH cte AS (SELECT 1) SELECT * FROM cte",
+    "expected": "cte"
+  },
+  {
+    "description": "empty string returns empty",
+    "query": "",
+    "expected": ""
+  },
+  {
+    "description": "garbage returns empty",
+    "query": "NOT VALID SQL AT ALL",
+    "expected": ""
+  }
+]

--- a/internal/stackql/queryshape/testdata/substitute_params_cases.json
+++ b/internal/stackql/queryshape/testdata/substitute_params_cases.json
@@ -1,0 +1,68 @@
+[
+  {
+    "description": "no params returns query unchanged",
+    "query": "SELECT name FROM my_table",
+    "paramValues": [],
+    "expected": "SELECT name FROM my_table"
+  },
+  {
+    "description": "single text param",
+    "query": "SELECT * FROM t WHERE name = $1",
+    "paramValues": ["hello"],
+    "expected": "SELECT * FROM t WHERE name = 'hello'"
+  },
+  {
+    "description": "multiple params",
+    "query": "SELECT * FROM t WHERE name = $1 AND region = $2",
+    "paramValues": ["hello", "us-east-1"],
+    "expected": "SELECT * FROM t WHERE name = 'hello' AND region = 'us-east-1'"
+  },
+  {
+    "description": "NULL param",
+    "query": "SELECT * FROM t WHERE name = $1",
+    "paramValues": [null],
+    "expected": "SELECT * FROM t WHERE name = NULL"
+  },
+  {
+    "description": "mixed NULL and text",
+    "query": "SELECT * FROM t WHERE a = $1 AND b = $2",
+    "paramValues": ["val", null],
+    "expected": "SELECT * FROM t WHERE a = 'val' AND b = NULL"
+  },
+  {
+    "description": "numeric param as text",
+    "query": "SELECT * FROM t WHERE id = $1",
+    "paramValues": ["42"],
+    "expected": "SELECT * FROM t WHERE id = '42'"
+  },
+  {
+    "description": "param with embedded single quote",
+    "query": "SELECT * FROM t WHERE name = $1",
+    "paramValues": ["O'Brien"],
+    "expected": "SELECT * FROM t WHERE name = 'O''Brien'"
+  },
+  {
+    "description": "param index out of range left as-is",
+    "query": "SELECT * FROM t WHERE a = $1 AND b = $3",
+    "paramValues": ["val"],
+    "expected": "SELECT * FROM t WHERE a = 'val' AND b = $3"
+  },
+  {
+    "description": "SELECT literal expression with params",
+    "query": "SELECT $1::text, $2::int",
+    "paramValues": ["hello", "42"],
+    "expected": "SELECT 'hello'::text, '42'::int"
+  },
+  {
+    "description": "no placeholders returns query unchanged even with params",
+    "query": "SELECT 1",
+    "paramValues": ["unused"],
+    "expected": "SELECT 1"
+  },
+  {
+    "description": "empty string param",
+    "query": "SELECT * FROM t WHERE name = $1",
+    "paramValues": [""],
+    "expected": "SELECT * FROM t WHERE name = ''"
+  }
+]

--- a/internal/stackql/typing/oid_mapping_test.go
+++ b/internal/stackql/typing/oid_mapping_test.go
@@ -1,0 +1,50 @@
+package typing //nolint:testpackage // tests exported functions in same package for simplicity
+
+import (
+	"testing"
+
+	"github.com/lib/pq/oid"
+	"github.com/stackql/stackql-parser/go/vt/sqlparser"
+)
+
+func TestGetOidForParserColType(t *testing.T) {
+	tests := []struct {
+		colType  string
+		expected oid.Oid
+	}{
+		{"int", oid.T_numeric},
+		{"integer", oid.T_numeric},
+		{"int4", oid.T_numeric},
+		{"int8", oid.T_numeric},
+		{"bigint", oid.T_numeric},
+		{"numeric", oid.T_numeric},
+		{"decimal", oid.T_numeric},
+		{"float", oid.T_numeric},
+		{"float8", oid.T_numeric},
+		{"double precision", oid.T_numeric},
+		{"bool", oid.T_bool},
+		{"boolean", oid.T_bool},
+		{"text", oid.T_text},
+		{"varchar", oid.T_text},
+		{"string", oid.T_text},
+		{"timestamp", oid.T_timestamp},
+		{"json", oid.T_text},
+		{"jsonb", oid.T_text},
+		{"uuid", oid.T_text},
+	}
+	for _, tt := range tests {
+		t.Run(tt.colType, func(t *testing.T) {
+			got := GetOidForParserColType(sqlparser.ColumnType{Type: tt.colType})
+			if got != tt.expected {
+				t.Errorf("GetOidForParserColType(%q) = %d, want %d", tt.colType, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetOidForSchemaNil(t *testing.T) {
+	got := GetOidForSchema(nil)
+	if got != oid.T_text {
+		t.Errorf("GetOidForSchema(nil) = %d, want %d (T_text)", got, oid.T_text)
+	}
+}

--- a/internal/stackql/typing/relayed_column_metadata.go
+++ b/internal/stackql/typing/relayed_column_metadata.go
@@ -53,8 +53,6 @@ func (cd *relayedColumnMetadata) getOidForRelationalType(relType string) oid.Oid
 	switch relType {
 	case "object", "array", "text":
 		return oid.T_text
-	// case "integer":
-	// 	return oid.T_numeric
 	case "boolean", "bool":
 		return oid.T_text
 	case "number", "decimal", "numeric", "real":

--- a/internal/stackql/typing/standard_column_metadata.go
+++ b/internal/stackql/typing/standard_column_metadata.go
@@ -81,8 +81,6 @@ func getOidForSchema(colSchema formulation.Schema) oid.Oid {
 	switch colSchema.GetType() {
 	case "object", "array":
 		return oid.T_text
-	// case "integer":
-	// 	return oid.T_numeric
 	case "boolean", "bool":
 		return oid.T_text
 	case "number":

--- a/test/python/stackql_test_tooling/StackQLInterfaces.py
+++ b/test/python/stackql_test_tooling/StackQLInterfaces.py
@@ -726,6 +726,35 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
 
 
   @keyword
+  def should_PG_client_column_descriptions_equal(self, conn_str :str, query :str, expected_descriptions :typing.List[typing.Dict], **kwargs):
+    """Execute a query via psycopg2 and verify column descriptions (name + type_code OID)."""
+    client = PsycoPG2Client(conn_str)
+    result = client.get_column_descriptions(query)
+    self.log(f"Column descriptions: {result}")
+    return self.lists_should_be_equal(result, expected_descriptions)
+
+
+  @keyword
+  def should_PG_client_prepared_query_results_contain(self, conn_str :str, query :str, params :typing.Tuple, expected_value :str, **kwargs):
+    """Execute a parameterised query via psycopg2 (extended query protocol) and verify results contain a value."""
+    client = PsycoPG2Client(conn_str)
+    result = client.exec_prepared_query(query, params)
+    self.log(f"Prepared query results: {result}")
+    result_str = str(result)
+    if expected_value not in result_str:
+      raise AssertionError(f"Expected '{expected_value}' in results but got: {result_str}")
+
+
+  @keyword
+  def should_PG_client_prepared_query_results_have_length(self, conn_str :str, query :str, params :typing.Tuple, expected_length :int, **kwargs):
+    """Execute a parameterised query via psycopg2 (extended query protocol) and verify result count."""
+    client = PsycoPG2Client(conn_str)
+    result = client.exec_prepared_query(query, params)
+    self.log(f"Prepared query results ({len(result)} rows): {result}")
+    return self.should_be_equal(len(result), expected_length)
+
+
+  @keyword
   def should_PG_client_V2_session_inline_equal(self, conn_str :str, queries :typing.List[str], expected_output :typing.List[typing.Dict], **kwargs):
     client = PsycoPG2Client(conn_str)
     result =  client.run_queries(

--- a/test/python/stackql_test_tooling/psycopg2_client.py
+++ b/test/python/stackql_test_tooling/psycopg2_client.py
@@ -37,3 +37,32 @@ class PsycoPG2Client(object):
   def run_queries(self, queries :typing.List[str]) -> typing.List[typing.Dict]:
     return self._run_queries(queries)
 
+
+  def get_column_descriptions(self, query :str) -> typing.List[typing.Dict]:
+    """Execute a query and return column metadata from cursor.description.
+
+    Each entry is a dict with keys: name, type_code.
+    type_code is the PostgreSQL OID for the column type.
+    """
+    with self._connection.cursor() as cur:
+      cur.execute(query)
+      if cur.description is None:
+        return []
+      return [
+        {'name': col.name, 'type_code': col.type_code}
+        for col in cur.description
+      ]
+
+
+  def exec_prepared_query(self, query :str, params :tuple) -> typing.List[typing.Dict]:
+    """Execute a parameterised query (extended query protocol) and return rows as dicts."""
+    with self._connection.cursor(cursor_factory=RealDictCursor) as cur:
+      cur.execute(query, params)
+      rv = []
+      try:
+        for r in cur:
+          rv.append(dict(r))
+      except Exception:
+        pass
+      return rv
+

--- a/test/robot/functional/stackql_sessions_postgres.robot
+++ b/test/robot/functional/stackql_sessions_postgres.robot
@@ -56,7 +56,7 @@ PG Extended Query Prepared Statement Returns Rows
     ${params} =    Evaluate    ('dummyapp.io',)
     Should PG Client Prepared Query Results Contain
     ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
-    ...    SELECT name, url FROM stackql_repositories WHERE name = %s
+    ...    SELECT name, url FROM stackql_repositories WHERE name \= %s
     ...    ${params}
     ...    dummyapp.io
     ...    stdout=${CURDIR}/tmp/PG-Extended-Query-Prepared-Statement-Returns-Rows.tmp
@@ -67,7 +67,7 @@ PG Extended Query Prepared Statement NULL Param Returns Zero Rows
     ${params} =    Evaluate    (None,)
     Should PG Client Prepared Query Results Have Length
     ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
-    ...    SELECT name FROM stackql_repositories WHERE name = %s
+    ...    SELECT name FROM stackql_repositories WHERE name \= %s
     ...    ${params}
     ...    ${0}
     ...    stdout=${CURDIR}/tmp/PG-Extended-Query-Prepared-Statement-NULL-Param.tmp

--- a/test/robot/functional/stackql_sessions_postgres.robot
+++ b/test/robot/functional/stackql_sessions_postgres.robot
@@ -40,6 +40,39 @@ SQLAlchemy Session Postgres Intel Views Exist
     ...    stdout=${CURDIR}/tmp/SQLAlchemy-Session-Postgres-Intel-Views-Exist.tmp
     [Teardown]    NONE
 
+PG Extended Query Column Descriptions Available
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    This is a postgres only test
+    ${expectedDescriptions} =    Evaluate
+    ...    [{'name': 'name', 'type_code': 25}, {'name': 'url', 'type_code': 25}]
+    Should PG Client Column Descriptions Equal
+    ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
+    ...    select name, url from stackql_repositories order by name
+    ...    ${expectedDescriptions}
+    ...    stdout=${CURDIR}/tmp/PG-Extended-Query-Column-Descriptions-Available.tmp
+    [Teardown]    NONE
+
+PG Extended Query Prepared Statement Returns Rows
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    This is a postgres only test
+    ${params} =    Evaluate    ('dummyapp.io',)
+    Should PG Client Prepared Query Results Contain
+    ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
+    ...    SELECT name, url FROM stackql_repositories WHERE name = %s
+    ...    ${params}
+    ...    dummyapp.io
+    ...    stdout=${CURDIR}/tmp/PG-Extended-Query-Prepared-Statement-Returns-Rows.tmp
+    [Teardown]    NONE
+
+PG Extended Query Prepared Statement NULL Param Returns Zero Rows
+    Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    This is a postgres only test
+    ${params} =    Evaluate    (None,)
+    Should PG Client Prepared Query Results Have Length
+    ...    ${POSTGRES_URL_UNENCRYPTED_CONN}
+    ...    SELECT name FROM stackql_repositories WHERE name = %s
+    ...    ${params}
+    ...    ${0}
+    ...    stdout=${CURDIR}/tmp/PG-Extended-Query-Prepared-Statement-NULL-Param.tmp
+    [Teardown]    NONE
+
 SQLAlchemy Session Materialized View Lifecycle
     Pass Execution If    "${SQL_BACKEND}" != "postgres_tcp"    This is a postgres only test
     ${inputStr} =    Catenate


### PR DESCRIPTION
## Description

- Support for the `postgres` extended query pattern.
- Safe integer casting for runtime vs RDBMS type conversions.
- Added robot test `PG Extended Query Column Descriptions Available`.
- Added robot test `PG Extended Query Prepared Statement Returns Rows`.
- Added robot test `PG Extended Query Prepared Statement NULL Param Returns Zero Rows`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `PG Extended Query Column Descriptions Available`.
- Added robot test `PG Extended Query Prepared Statement Returns Rows`.
- Added robot test `PG Extended Query Prepared Statement NULL Param Returns Zero Rows`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
