### PR TITLE
restore-shell-readlines-semicolon

### DIFF
--- a/internal/stackql/cmd/shell.go
+++ b/internal/stackql/cmd/shell.go
@@ -233,11 +233,10 @@ var shellCmd = &cobra.Command{
 						if i == len(splitQueries)-1 && !hasRHSSemiColon {
 							// Last piece has no trailing semicolon;
 							// accumulate for multi-line continuation.
-							sb.Reset()
-							sb.WriteString(s)
+							sb.WriteString(" " + s)
 							continue
 						}
-						sb.WriteString(" " + s)
+						sb.WriteString(" " + s + ";")
 						rawQuery := sb.String()
 						queryToExecute, qErr := entryutil.PreprocessInline(runtimeCtx, rawQuery)
 						if qErr != nil {

--- a/test/python/stackql_test_tooling/StackQLInterfaces.py
+++ b/test/python/stackql_test_tooling/StackQLInterfaces.py
@@ -550,7 +550,7 @@ class StackQLInterfaces(OperatingSystem, Process, BuiltIn, Collections):
     if approot:
       supplied_args.append(f'--approot={approot}')
     else:
-      supplied_args.append(f'--approot="{_TEST_APP_CACHE_ROOT}"')
+      supplied_args.append(f'--approot={_TEST_APP_CACHE_ROOT}')
     supplied_args.append(f"--execution.concurrency.limit={self._concurrency_limit}")
     supplied_args = supplied_args + list(args)
     stdout = cfg.get('stdout', subprocess.PIPE)

--- a/test/python/stackql_test_tooling/stackql_context.py
+++ b/test/python/stackql_test_tooling/stackql_context.py
@@ -1099,6 +1099,8 @@ def get_variables(
     'SHELL_SESSION_SIMPLE_EXPECTED':                                          get_shell_welcome_stdout(execution_env) + SELECT_GITHUB_BRANCHES_NAMES_DESC_EXPECTED,
     'SHELL_SESSION_MULTI_STMT_INLINE_COMMANDS':                               [ "SELECT * FROM stackql_repositories; " + SELECT_GITHUB_BRANCHES_NAMES_DESC ],
     'SHELL_SESSION_MULTI_LINE_THEN_MULTI_STMT_COMMANDS':                      [ "select name", "from github.repos.branches where owner = 'dummyorg' and repo = 'dummyapp.io' order by name desc;", "SELECT * FROM stackql_repositories; " + SELECT_GITHUB_BRANCHES_NAMES_DESC ],
+    'SHELL_SESSION_MULTI_LINE_SEMICOLON_TERMINATED_COMMANDS':                 [ "select name", "from github.repos.branches", "where owner = 'dummyorg' and repo = 'dummyapp.io'", "order by name desc", ";" ],
+    'SHELL_SESSION_MULTI_LINE_SEMICOLON_TERMINATED_EXPECTED':                 get_shell_welcome_stdout(execution_env) + SELECT_GITHUB_BRANCHES_NAMES_DESC_EXPECTED,
     'SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR':                   SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR,
     'SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR':                   SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR,
     'SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR_EXPECTED':          SHOW_INSERT_GOOGLE_COMPUTE_INSTANCE_IAM_POLICY_ERROR_EXPECTED,

--- a/test/robot/functional/stackql_sessions.robot
+++ b/test/robot/functional/stackql_sessions.robot
@@ -45,6 +45,11 @@ Shell Session Multiple Statements Inline
     ...    ${SHELL_SESSION_MULTI_STMT_INLINE_COMMANDS}
     ...    dummyapp.io
     ...    stdout=${CURDIR}/tmp/Shell-Session-Multiple-Statements-Inline.tmp
+    # Verify readline history preserves trailing semicolons
+    Pass Execution If    "${EXECUTION_PLATFORM}" == "docker"    Skipping readline verification in docker
+    ${readline_content} =    Get File    ${REPOSITORY_ROOT}${/}test${/}.stackql${/}readline${/}readline.tmp
+    Should Contain    ${readline_content}    stackql_repositories;
+    Should Contain    ${readline_content}    order by name desc;
     [Teardown]    Stackql Per Test Teardown
 
 Shell Session Multi Line Then Multi Statement
@@ -60,6 +65,21 @@ Shell Session Multi Line Then Multi Statement
     ...    ${SHELL_SESSION_MULTI_LINE_THEN_MULTI_STMT_COMMANDS}
     ...    dummyapp.io
     ...    stdout=${CURDIR}/tmp/Shell-Session-Multi-Line-Then-Multi-Statement.tmp
+    [Teardown]    Stackql Per Test Teardown
+
+Shell Session Multi Line Semicolon Terminated
+    Pass Execution If    "${IS_WINDOWS}" == "1"    Skipping session test in windows
+    Should StackQL Shell Inline Equal
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${SHELL_SESSION_MULTI_LINE_SEMICOLON_TERMINATED_COMMANDS}
+    ...    ${SHELL_SESSION_MULTI_LINE_SEMICOLON_TERMINATED_EXPECTED}
+    ...    stdout=${CURDIR}/tmp/Shell-Session-Multi-Line-Semicolon-Terminated.tmp
     [Teardown]    Stackql Per Test Teardown
 
 PG Session GC Manual Behaviour Canonical


### PR DESCRIPTION
## Description

- Restore semicolons to appropriate places in `readlines` buffer from `stackql shell` sessions.
- Fix multiline query handling.
- `--approot` passing in test fix, in support of `readlines` buffer checking. `readlines` check skipped for `docker` tests.
- Added robot test `Shell Session Multi Line Then Multi Statement`.
- Tested correct semicolon placement in enhanced robot test `Shell Session Multiple Statements Inline`.
- Skip `readline` verification in docker for now.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- Added robot test `Shell Session Multi Line Then Multi Statement`.
- Tested correct semicolon placement in enhanced robot test `Shell Session Multiple Statements Inline`.

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
