### PR TITLE
boolean-comparisons

### DIFF
--- a/internal/stackql/astvisit/param_extract.go
+++ b/internal/stackql/astvisit/param_extract.go
@@ -722,6 +722,16 @@ func (v *standardParserParamAstVisitor) Visit(node sqlparser.SQLNode) error {
 					rt,
 					v.getNextOrdinal(),
 				))
+			case sqlparser.BoolVal:
+				k, err := parserutil.NewUnknownTypeColumnarReference(lt)
+				if err != nil {
+					return err
+				}
+				v.params.Set(k, parserutil.NewComparisonParameterMetadata(
+					node,
+					rt,
+					v.getNextOrdinal(),
+				))
 			case *sqlparser.ColName:
 				k, err := parserutil.NewUnknownTypeColumnarReference(lt)
 				if err != nil {

--- a/internal/stackql/astvisit/placeholder_param_extract.go
+++ b/internal/stackql/astvisit/placeholder_param_extract.go
@@ -742,6 +742,16 @@ func (v *standardParserPlaceholderParamAstVisitor) Visit(node sqlparser.SQLNode)
 					rt,
 					0,
 				))
+			case sqlparser.BoolVal:
+				k, err := parserutil.NewUnknownTypeColumnarReference(lt)
+				if err != nil {
+					return err
+				}
+				v.params.SetIntolerant(k, parserutil.NewComparisonParameterMetadata(
+					node,
+					rt,
+					0,
+				))
 			default:
 			}
 		default:

--- a/internal/stackql/primitivegenerator/statement_analyzer.go
+++ b/internal/stackql/primitivegenerator/statement_analyzer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -444,9 +445,14 @@ func (pb *standardPrimitiveGenerator) whereComparisonExprCopyAndReWrite(
 	}
 	if symTabErr == nil && symTabEntry.In != "server" {
 		if !(requiredParamPresent || optionalParamPresent) {
+			rightExpr := expr.Right
+			if boolVal, ok := expr.Right.(sqlparser.BoolVal); ok {
+				// Provider-backed rows are often materialized as text, so normalize bool literals.
+				rightExpr = &sqlparser.SQLVal{Type: sqlparser.StrVal, Val: []byte(strconv.FormatBool(bool(boolVal)))}
+			}
 			return &sqlparser.ComparisonExpr{
 				Left:     expr.Left,
-				Right:    expr.Right,
+				Right:    rightExpr,
 				Operator: expr.Operator,
 				Escape:   expr.Escape,
 			}, colName, nil

--- a/internal/stackql/primitivegenerator/statement_analyzer.go
+++ b/internal/stackql/primitivegenerator/statement_analyzer.go
@@ -446,7 +446,7 @@ func (pb *standardPrimitiveGenerator) whereComparisonExprCopyAndReWrite(
 	if symTabErr == nil && symTabEntry.In != "server" {
 		if !(requiredParamPresent || optionalParamPresent) {
 			rightExpr := expr.Right
-			if boolVal, ok := expr.Right.(sqlparser.BoolVal); ok {
+			if boolVal, boolOk := expr.Right.(sqlparser.BoolVal); boolOk {
 				// Provider-backed rows are often materialized as text, so normalize bool literals.
 				rightExpr = &sqlparser.SQLVal{Type: sqlparser.StrVal, Val: []byte(strconv.FormatBool(bool(boolVal)))}
 			}

--- a/internal/stackql/util/plan_utility.go
+++ b/internal/stackql/util/plan_utility.go
@@ -151,6 +151,8 @@ func ExtractSQLNodeParams(
 					case *sqlparser.SQLVal:
 						val := string(r.Val)
 						paramMap[key] = val
+					case sqlparser.BoolVal:
+						paramMap[key] = strconv.FormatBool(bool(r))
 					case *sqlparser.ColName:
 						kr := r.Name.GetRawVal()
 						paramMap[key] = kr
@@ -198,6 +200,8 @@ func TransformSQLRawParameters(input map[string]interface{}, ignoreTuples bool) 
 
 func extractRaw(raw interface{}, ignoreTuples bool) (interface{}, error) {
 	switch r := raw.(type) {
+	case sqlparser.BoolVal:
+		return strconv.FormatBool(bool(r)), nil
 	case *sqlparser.SQLVal:
 		switch r.Type { //nolint:exhaustive // TODO: review
 		case sqlparser.StrVal:

--- a/test/python/stackql_test_tooling/stackql_context.py
+++ b/test/python/stackql_test_tooling/stackql_context.py
@@ -26,13 +26,6 @@ _BUILD_MAJOR_VERSION = os.environ.get('BUILDMAJORVERSION', '1')
 _BUILD_MINOR_VERSION = os.environ.get('BUILDMINORVERSION', '1')
 _BUILD_PATCH_VERSION = os.environ.get('BUILDPATCHVERSION', '1')
 
-_SHELL_WELCOME_MSG = """
-""" + f"stackql Command Shell {_BUILD_MAJOR_VERSION}.{_BUILD_MINOR_VERSION}.{_BUILD_PATCH_VERSION}" + """
-Copyright (c) 2021, stackql studios. All rights reserved.
-Welcome to the interactive shell for running stackql commands.
----
-"""
-
 def get_shell_welcome_stdout(env: str) -> str:
   return ''
 

--- a/test/robot/functional/stackql_mocked_from_cmd_line.robot
+++ b/test/robot/functional/stackql_mocked_from_cmd_line.robot
@@ -179,6 +179,27 @@ AWS EC2 Volumes Select Simple
     ...    ${SELECT_AWS_VOLUMES}
     ...    ${SELECT_AWS_VOLUMES_ASC_EXPECTED}
 
+AWS EC2 Volumes Boolean Predicate Literal and String Equivalence
+    ${inputStr} =    Catenate
+    ...    select volumeId, encrypted, size from aws.ec2.volumes where region = 'ap-southeast-1' and encrypted = false order by volumeId asc;
+    ...    select volumeId, encrypted, size from aws.ec2.volumes where region = 'ap-southeast-1' and encrypted = 'false' order by volumeId asc;
+    ${outputStr} =    Catenate    SEPARATOR=\n
+    ...    ${SELECT_AWS_VOLUMES_ASC_EXPECTED}
+    ...    ${SELECT_AWS_VOLUMES_ASC_EXPECTED}
+    Should Stackql Exec Inline Equal Both Streams
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    ${inputStr}
+    ...    ${outputStr}
+    ...    ${EMPTY}
+    ...    stdout=${CURDIR}/tmp/AWS-EC2-Volumes-Boolean-Predicate-Literal-and-String-Equivalence-stdout.tmp
+    ...    stderr=${CURDIR}/tmp/AWS-EC2-Volumes-Boolean-Predicate-Literal-and-String-Equivalence-stderr.tmp
+
 AWS IAM Users Select Simple
     Should Horrid Query StackQL Inline Equal
     ...    ${STACKQL_EXE}


### PR DESCRIPTION
## Description

- Support for boolean comparisons.
- Added robot test `AWS EC2 Volumes Boolean Predicate Literal and String Equivalence`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
