### PR TITLE
best-effort-integration-testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -745,6 +745,42 @@ jobs:
       run: |
         cat ./test/robot/integration-traffic-lights/tmp/* || true
     
+    - name: Run foreign traffic light robot integration tests
+      if: ((startsWith(github.ref_name, 'build-traffic-lights') && github.ref_type == 'tag') || (github.repository == 'stackql/stackql' && github.event_name == 'push' && github.ref == 'refs/heads/main')) && matrix.registry == 'test/registry'
+      env:
+        PYTHONPATH: '${{ env.PYTHONPATH }}:${{ github.workspace }}/test/python'
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_INTEGRATION_TESTING_SUB_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_FOREIGN_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_FOREIGN_SECRET_ACCESS_KEY }}
+        STACKQL_AUDIT_ROLE_ARN: ${{ secrets.STACKQL_AUDIT_ROLE_ARN }}
+        GODEBUG: netdns=go
+      run: |
+        echo "## Stray flask apps to be killed before robot tests ##"
+        pgrep -f flask | xargs kill -9 || true
+        echo "## End ##"
+        if python cicd/python/build.py --robot-test-foreign-traffic-lights-integration; then
+          echo "✅ Foreign traffic light robot integration tests **all** passed"
+        else
+          rv="$?"
+          echo "🟡 **some** foreign traffic light robot integration tests failed code = $rv"
+        fi
+        {
+          echo "FOREIGN_TRAFFIC_LIGHTS_COMPLETED=true"
+        } >> "$GITHUB_ENV"
+
+    - name: Output from foreign traffic lights integration tests
+      if: env.FOREIGN_TRAFFIC_LIGHTS_COMPLETED == 'true'
+      run: |
+        cat ./test/robot/reports-foreign-integration-traffic-lights/output.xml || true
+
+    - name: Output from foreign traffic lights tmp dir
+      if: env.FOREIGN_TRAFFIC_LIGHTS_COMPLETED == 'true'
+      run: |
+        cat ./test/robot/foreign-integration-traffic-lights/tmp/* || true
+    
     - name: Generate rewritten registry for simulations
       if: ${{ matrix.registry  != 'test/registry' }}
       run: |

--- a/cicd/python/build.py
+++ b/cicd/python/build.py
@@ -82,6 +82,16 @@ def run_robot_integration_traffic_lights_tests_stackql(*args, **kwargs) -> int:
         shell=True
     )
 
+def run_robot_foreign_integration_traffic_lights_tests_stackql(*args, **kwargs) -> int:
+    variables = ' '.join([f'--variable {key}:{sanitise_val(value)} ' for key, value in kwargs.get("variables", {}).items()])
+    return subprocess.call(
+        'robot '
+        f'{variables} ' 
+        '-d test/robot/reports-foreign-integration-traffic-lights '
+        'test/robot/foreign-integration-traffic-lights',
+        shell=True
+    )
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--verbose', action='store_true')
@@ -91,6 +101,7 @@ def main():
     parser.add_argument('--robot-test', action='store_true')
     parser.add_argument('--robot-test-integration', action='store_true')
     parser.add_argument('--robot-test-traffic-lights-integration', action='store_true')
+    parser.add_argument('--robot-test-foreign-traffic-lights-integration', action='store_true')
     parser.add_argument('--config', type=json.loads, default={})
     args = parser.parse_args()
     ret_code = 0
@@ -116,6 +127,10 @@ def main():
             exit(ret_code)
     if args.robot_test_traffic_lights_integration:
         ret_code = run_robot_integration_traffic_lights_tests_stackql(**args.config)
+        if ret_code != 0:
+            exit(ret_code)
+    if args.robot_test_foreign_traffic_lights_integration:
+        ret_code = run_robot_foreign_integration_traffic_lights_tests_stackql(**args.config)
         if ret_code != 0:
             exit(ret_code)
     exit(ret_code)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -44,8 +44,11 @@ The `--auth` `json` string can be configured for assuming a foriegn role.  Tis, 
 {"aws": {"type": "aws_assume_role", "keyIDenvvar": "AWS_ACCESS_KEY_ID", "credentialsenvvar": "AWS_SECRET_ACCESS_KEY", "aws_role_arn": "arn:aws:iam::123456789012:role/MyRole"}}
 ```
 
-Eg:
+Eg, presuming the source scripts constains the cited env vars:
 
 ```bash
-stackql --auth '{"aws":{"type":"aws_assume_role","keyIDenvvar":"AWS_ACCESS_KEY_ID","credentialsenvvar":"AWS_SECRET_ACCESS_KEY", "aws_role_arn": "arn:aws:iam::123456789012:role/MyRole"}}' shell
+
+source cicd/vol/vendor-secrets/ryuk_to_stackql_user.sh
+
+stackql --auth '{"aws":{"type":"aws_assume_role","keyIDenvvar":"AWS_ACCESS_KEY_ID","credentialsenvvar":"AWS_SECRET_ACCESS_KEY", "aws_role_arn": "'${STACKQL_AUDIT_ROLE_ARN}'"}}' shell
 ```

--- a/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
+++ b/test/registry/src/aws/v0.1.0/services/pseudo_s3.yaml
@@ -455,6 +455,37 @@ components:
           type: string
       type: object
   x-stackQL-resources:
+    buckets_list_only:
+      name: buckets_list_only
+      id: aws.pseudo_s3.buckets_list_only
+      x-cfn-schema-name: Bucket
+      x-cfn-type-name: AWS::S3::Bucket
+      x-identifiers:
+        - BucketName
+      x-type: cloud_control_view
+      methods: {}
+      sqlVerbs:
+        insert: []
+        delete: []
+        update: []
+      config:
+        views:
+          select:
+            predicate: sqlDialect == "sqlite3"
+            ddl: |-
+              SELECT
+              region,
+              JSON_EXTRACT(Properties, '$.BucketName') as bucket_name
+              FROM aws.cloud_control.resources WHERE data__TypeName = 'AWS::S3::Bucket'
+              AND region = 'us-east-1'
+            fallback:
+              predicate: sqlDialect == "postgres"
+              ddl: |-
+                SELECT
+                region,
+                json_extract_path_text(Properties, 'BucketName') as bucket_name
+                FROM aws.cloud_control.resources WHERE data__TypeName = 'AWS::S3::Bucket'
+                AND region = 'us-east-1'
     s3_bucket_listing:
       name: s3_bucket_listing
       id: aws.pseudo_s3.s3_bucket_listing

--- a/test/robot/README.md
+++ b/test/robot/README.md
@@ -20,6 +20,12 @@ From the repository root:
 env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot -d test/robot/reports test/robot/functional
 ```
 
+In particular, some integration tests may be unstable in some cloud and CI environments, so you may want to check locally, eg (after sourcing requisite env vars):
+
+```bash
+env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot --outputdir results test/robot/foreign-integration-traffic-lights
+```
+
 ### Running actual integration tests
 
 From the repository root:

--- a/test/robot/foreign-integration-traffic-lights/__init__.robot
+++ b/test/robot/foreign-integration-traffic-lights/__init__.robot
@@ -1,0 +1,4 @@
+*** Settings ***
+Resource          ${CURDIR}/stackql.resource
+
+

--- a/test/robot/foreign-integration-traffic-lights/stackql.resource
+++ b/test/robot/foreign-integration-traffic-lights/stackql.resource
@@ -1,0 +1,21 @@
+*** Variables ***
+${LOCAL_LIB_HOME}               ${CURDIR}${/}..${/}..${/}python
+${REPOSITORY_ROOT}              ${CURDIR}${/}..${/}..${/}..
+${EXECUTION_PLATFORM}           native   # to be overridden from command line, eg "docker"
+${SQL_BACKEND}                  sqlite_embedded   # to be overridden from command line, eg "postgres_tcp"
+${IS_WSL}                       false   # to be overridden from command line, with string "true"
+${USE_STACKQL_PREINSTALLED}     false   # to be overridden from command line, with string "true"
+${SUNDRY_CONFIG}                {}  # to be overridden from command line, with string value
+${STACKQL_INTERFACE_LIBRARY}    stackql_test_tooling.StackQLInterfaces
+${CLOUD_INTEGRATION_LIBRARY}    stackql_test_tooling.CloudIntegration
+
+*** Settings ***
+Library           Process
+Library           OperatingSystem 
+Variables         ${LOCAL_LIB_HOME}/stackql_test_tooling/stackql_context.py    ${REPOSITORY_ROOT}    ${EXECUTION_PLATFORM}    ${SQL_BACKEND}    ${USE_STACKQL_PREINSTALLED}
+...               ${SUNDRY_CONFIG}
+Library           Process
+Library           OperatingSystem
+Library           String
+Library           ${STACKQL_INTERFACE_LIBRARY}    ${EXECUTION_PLATFORM}    ${SQL_BACKEND}
+Library           ${CLOUD_INTEGRATION_LIBRARY}

--- a/test/robot/foreign-integration-traffic-lights/stackql_foreign_traffic_light_integration_from_cmd_line.robot
+++ b/test/robot/foreign-integration-traffic-lights/stackql_foreign_traffic_light_integration_from_cmd_line.robot
@@ -1,0 +1,29 @@
+
+
+
+*** Settings ***
+Resource          ${CURDIR}/stackql.resource
+
+*** Test Cases ***
+
+Foreign AWS S3 Buckets List
+    Sleep    2s
+    ${awsRoleArn} =    OperatingSystem.Get Environment Variable    STACKQL_AUDIT_ROLE_ARN
+    Should Not Be Empty    ${awsRoleArn}
+    ${awsAuthCfg} =    Catenate
+    ...    { "aws": { "type":"aws_assume_role", "keyIDenvvar": "AWS_ACCESS_KEY_ID", "credentialsenvvar": "AWS_SECRET_ACCESS_KEY", "aws_role_arn": "${awsRoleArn}" } }
+    ${bucketsListQuery} =    Catenate
+    ...    select * from aws.pseudo_s3.buckets_list_only where region = 'ap-southeast-2';
+   ${result} =    Run Process
+    ...    ${STACKQL_EXE}
+    ...    \-\-auth
+    ...    ${awsAuthCfg}
+    ...    \-\-registry
+    ...    { "url": "file://${REPOSITORY_ROOT}/test/registry", "localDocRoot": "${REPOSITORY_ROOT}/test/registry", "verifyConfig": { "nopVerify": true } }
+    ...    exec
+    ...    ${bucketsListQuery}
+    ...    cwd=${REPOSITORY_ROOT}
+    ...    stdout=${CURDIR}/tmp/AWS-S3-Buckets-List.tmp
+    ...    stderr=${CURDIR}/tmp/AWS-S3-Buckets-List-stderr.tmp
+    Should Be Equal As Integers    ${result.rc}           0
+    Should Contain                 ${result.stdout}       stackql\-trial\-bucket\-02

--- a/test/robot/foreign-integration-traffic-lights/tmp/.gitignore
+++ b/test/robot/foreign-integration-traffic-lights/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/robot/reports-foreign-integration-traffic-lights/.gitignore
+++ b/test/robot/reports-foreign-integration-traffic-lights/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Description

- Better documentation for aws assume role auth model.
- Added replica best effort `robot` integration test suite for foreign tests.
- `aws` tests only to begin with.
- Added traffic light robot test `Foreign AWS S3 Buckets List`.



<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

- New `foreign-integration-traffic-lights` `robot` test suite. 
- Run by `Run foreign traffic light robot integration tests` github action step. 
- Added traffic light robot test `Foreign AWS S3 Buckets List`.

It seems `sts` auth is unstable from `github`-hosted CI runners, so please see locally run `robot` testing in Figure R-1.


<img width="628" height="310" alt="Screenshot 2026-05-26 at 5 48 16 PM" src="https://github.com/user-attachments/assets/59fb2528-6209-49cc-b7c5-a56682467d53" />



**Figure R-1**:  Foreign `aws` integration test works locally.


---


<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
