### PR TITLE
extended-foreign-auth-testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -749,13 +749,14 @@ jobs:
       if: ((startsWith(github.ref_name, 'build-traffic-lights') && github.ref_type == 'tag') || (github.repository == 'stackql/stackql' && github.event_name == 'push' && github.ref == 'refs/heads/main')) && matrix.registry == 'test/registry'
       env:
         PYTHONPATH: '${{ env.PYTHONPATH }}:${{ github.workspace }}/test/python'
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_FOREIGN_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_FOREIGN_CLIENT_SECRET }}
         AZURE_INTEGRATION_TESTING_SUB_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_FOREIGN_TENANT_ID }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_FOREIGN_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_FOREIGN_SECRET_ACCESS_KEY }}
         STACKQL_AUDIT_ROLE_ARN: ${{ secrets.STACKQL_AUDIT_ROLE_ARN }}
+        GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_FOREIGN_SERVICE_ACCOUNT_KEY }}
         GODEBUG: netdns=go
       run: |
         echo "## Stray flask apps to be killed before robot tests ##"

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -34,21 +34,35 @@ k8s supports an adaptable auth flow [client-go credential plugins](https://kuber
 
 ## Foreign auth patterns
 
+### AWS Cross-Account Access
 
-### aws STS for foreign role
+We implemented standard AWS cross-account access using `sts:AssumeRole`. The client account/user/runner is granted permission to assume a read-only audit role in the target account, while the target role trusts the client principal via a trust policy, optionally guarded by `ExternalId`. The target role was granted `SecurityAudit`, S3 read permissions, and Cloud Control (`cloudformation:ListResources`, `cloudformation:GetResource`, etc.) permissions so StackQL can perform live control-plane audits using temporary STS credentials rather than long-lived target-account keys. Docs: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
 
-
-The `--auth` `json` string can be configured for assuming a foriegn role.  Tis, of course, relies on assume role being configured in the target tenancy.
+The `--auth` JSON string can be configured to assume a foreign role. This relies on assume-role access being configured in the target tenancy/account.
 
 ```json
-{"aws": {"type": "aws_assume_role", "keyIDenvvar": "AWS_ACCESS_KEY_ID", "credentialsenvvar": "AWS_SECRET_ACCESS_KEY", "aws_role_arn": "arn:aws:iam::123456789012:role/MyRole"}}
-```
+{"aws":{"type":"aws_assume_role","keyIDenvvar":"AWS_ACCESS_KEY_ID","credentialsenvvar":"AWS_SECRET_ACCESS_KEY","aws_role_arn":"arn:aws:iam::123456789012:role/MyRole"}}
+````
 
-Eg, presuming the source scripts constains the cited env vars:
+### Azure Cross-Tenant Access
+
+We implemented Azure cross-tenant access using a multitenant App Registration in the client tenant. The target tenant admin granted consent to the application, which created an Enterprise Application/service principal inside the target tenant. The target tenant then assigned the built-in `Reader` role to that enterprise application at the subscription or management-group scope. StackQL authenticates using the client application's `client_id` and `client_secret`, but requests tokens from the target tenant authority to audit target Azure resources. Docs: https://learn.microsoft.com/en-us/entra/identity-platform/howto-convert-app-to-be-multi-tenant
+
+No change to canonical Azure configuration is needed; use the client app ID/secret, the target tenant ID, and the target subscription ID.
+
+### GCP Cross-Organization Access
+
+We implemented GCP cross-organization access by creating a service account in the client project and granting that foreign service account IAM roles directly in the target organization/project. The target org/project granted roles such as `Viewer`, `Security Reviewer`, and `Folder Viewer` to the client-owned service account principal, allowing StackQL to audit the target environment while authenticating only with the client-side service account key. Docs: https://cloud.google.com/iam/docs/granting-changing-revoking-access
+
+There is no change to existing Google auth for this.
+
+### Overall
+
+Example, presuming the sourced script contains the cited env vars:
 
 ```bash
+source cicd/vol/vendor-secrets/foreign_to_stackql_user.sh
 
-source cicd/vol/vendor-secrets/ryuk_to_stackql_user.sh
-
-stackql --auth '{"aws":{"type":"aws_assume_role","keyIDenvvar":"AWS_ACCESS_KEY_ID","credentialsenvvar":"AWS_SECRET_ACCESS_KEY", "aws_role_arn": "'${STACKQL_AUDIT_ROLE_ARN}'"}}' shell
+stackql --auth '{"aws":{"type":"aws_assume_role","keyIDenvvar":"AWS_ACCESS_KEY_ID","credentialsenvvar":"AWS_SECRET_ACCESS_KEY","aws_role_arn":"'"${STACKQL_AUDIT_ROLE_ARN}"'"}}' shell
 ```
+

--- a/test/robot/README.md
+++ b/test/robot/README.md
@@ -20,12 +20,6 @@ From the repository root:
 env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot -d test/robot/reports test/robot/functional
 ```
 
-In particular, some integration tests may be unstable in some cloud and CI environments, so you may want to check locally, eg (after sourcing requisite env vars):
-
-```bash
-env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot --outputdir results test/robot/foreign-integration-traffic-lights
-```
-
 ### Running actual integration tests
 
 From the repository root:
@@ -48,6 +42,14 @@ env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot -d test/robot/integration 
   -v AWS_CREDENTIALS:"$(cat ${HOME}/stack/stackql-devel/cicd/keys/integration/aws-auth-val.txt)" \
   -v AZURE_CREDENTIALS:"$(cat /path/to/azure/credentials)" \
   test/robot/integration
+```
+
+In particular, for the foreign auth integration tests, some tests may be unstable in some cloud and CI environments, so you may want to check locally, eg (after sourcing requisite env vars):
+
+```bash
+# source cicd/vol/vendor-secrets/foreign_to_stackql_user.sh
+
+env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot --outputdir test/robot/reports-integration-traffic-lights test/robot/foreign-integration-traffic-lights
 ```
 
 

--- a/test/robot/foreign-integration-traffic-lights/stackql_foreign_traffic_light_integration_from_cmd_line.robot
+++ b/test/robot/foreign-integration-traffic-lights/stackql_foreign_traffic_light_integration_from_cmd_line.robot
@@ -26,4 +26,45 @@ Foreign AWS S3 Buckets List
     ...    stdout=${CURDIR}/tmp/AWS-S3-Buckets-List.tmp
     ...    stderr=${CURDIR}/tmp/AWS-S3-Buckets-List-stderr.tmp
     Should Be Equal As Integers    ${result.rc}           0
+    Should Be Empty                ${result.stderr}
     Should Contain                 ${result.stdout}       stackql\-trial\-bucket\-02
+
+
+Foreign Azure VNETs List
+    Sleep    2s
+    ${azureTargetSubscription} =    OperatingSystem.Get Environment Variable    AZURE_TARGET_SUBSCRIPTION_ID
+    Should Not Be Empty    ${azureTargetSubscription}
+    ${bucketsListQuery} =    Catenate
+    ...    select location, name from azure.network.virtual_networks where subscriptionId = '${azureTargetSubscription}';
+   ${result} =    Run Process
+    ...    ${STACKQL_EXE}
+    ...    \-\-registry
+    ...    { "url": "file://${REPOSITORY_ROOT}/test/registry", "localDocRoot": "${REPOSITORY_ROOT}/test/registry", "verifyConfig": { "nopVerify": true } }
+    ...    exec
+    ...    ${bucketsListQuery}
+    ...    cwd=${REPOSITORY_ROOT}
+    ...    stdout=${CURDIR}/tmp/Azure-VNETs-List.tmp
+    ...    stderr=${CURDIR}/tmp/Azure-VNETs-List-stderr.tmp
+    Should Be Equal As Integers    ${result.rc}           0
+    Should Be Empty                ${result.stderr}
+    Should Contain                 ${result.stdout}       inspector\-network
+
+
+Foreign Google Buckets List
+    Sleep    2s
+    ${gcpServiceAccountKey} =    OperatingSystem.Get Environment Variable    GCP_SERVICE_ACCOUNT_KEY
+    Should Not Be Empty    ${gcpServiceAccountKey}
+    ${bucketsListQuery} =    Catenate
+    ...    select location, name from google.storage.buckets where project = 'stackql-demo';
+   ${result} =    Run Process
+    ...    ${STACKQL_EXE}
+    ...    \-\-registry
+    ...    { "url": "file://${REPOSITORY_ROOT}/test/registry", "localDocRoot": "${REPOSITORY_ROOT}/test/registry", "verifyConfig": { "nopVerify": true } }
+    ...    exec
+    ...    ${bucketsListQuery}
+    ...    cwd=${REPOSITORY_ROOT}
+    ...    stdout=${CURDIR}/tmp/Google-Buckets-List.tmp
+    ...    stderr=${CURDIR}/tmp/Google-Buckets-List-stderr.tmp
+    Should Be Equal As Integers    ${result.rc}           0
+    Should Be Empty                ${result.stderr}
+    Should Contain                 ${result.stdout}       stackql\-demo\-bucket


### PR DESCRIPTION
## Description

- Improved foreign auth doumentation.
- Added robot test `Foreign Azure VNETs List`.
- Added robot test `Foreign Google Buckets List`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [x] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

N/A.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence


- Added robot test `Foreign Azure VNETs List`.
- Added robot test `Foreign Google Buckets List`.
- Tests work locally per Figure T-1.


<img width="557" height="295" alt="Screenshot 2026-05-26 at 10 29 34 PM" src="https://github.com/user-attachments/assets/392b2d7d-0d58-4df0-b5c9-aefdc15ab691" />

**Figure T-1**: Foreign auth tests work locally.

---

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is introduced in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
