### PR TITLE
testing-materials-assembly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -661,29 +661,6 @@ jobs:
           echo "BUILDMINORVERSION=${BUILDMINORVERSION}"
           echo "BUILDPATCHVERSION=${BUILDPATCHVERSION}"
         } >> "${GITHUB_ENV}"
-        
-        if [ "${{ matrix.registry }}" = "test/registry" ]; then
-          python3 test/python/stackql_test_tooling/tcp_lb.py --generate-hosts-entries | sudo tee -a /etc/hosts
-          python3 test/python/stackql_test_tooling/tcp_lb.py --generate-nginx-lb > test/tcp/reverse-proxy/nginx/dynamic-sni-proxy.conf
-        fi
-
-
-    - name: Install testing dependencies
-      run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends postgresql-client
-          if [ "${{ matrix.registry }}" = "test/registry" ]; then
-            sudo apt-get install -y curl gnupg2 ca-certificates lsb-release ubuntu-keyring
-            curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
-              | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-            gpg --dry-run --quiet --no-keyring --import --import-options import-show /usr/share/keyrings/nginx-archive-keyring.gpg
-            echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-              http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" \
-                  | sudo tee /etc/apt/sources.list.d/nginx.list
-            sudo apt-get update
-            sudo apt-get install nginx
-            sudo nginx -c "$(pwd)/test/tcp/reverse-proxy/nginx/dynamic-sni-proxy.conf"
-          fi
 
     - name: Install Python dependencies
       run: |
@@ -751,7 +728,7 @@ jobs:
         PYTHONPATH: '${{ env.PYTHONPATH }}:${{ github.workspace }}/test/python'
         AZURE_CLIENT_ID: ${{ secrets.AZURE_FOREIGN_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_FOREIGN_CLIENT_SECRET }}
-        AZURE_INTEGRATION_TESTING_SUB_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
+        AZURE_TARGET_SUBSCRIPTION_ID: ${{ secrets.AZURE_INTEGRATION_TESTING_SUB_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_FOREIGN_TENANT_ID }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_FOREIGN_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_FOREIGN_SECRET_ACCESS_KEY }}
@@ -781,6 +758,37 @@ jobs:
       if: env.FOREIGN_TRAFFIC_LIGHTS_COMPLETED == 'true'
       run: |
         cat ./test/robot/foreign-integration-traffic-lights/tmp/* || true
+    
+    - name: Generate hosts file and nginx materials
+      env:
+        BUILDCOMMITSHA: ${{github.sha}}
+        BUILDBRANCH: ${{github.ref}}
+        BUILDPLATFORM: ${{runner.os}}
+        BUILDPATCHVERSION: ${{github.run_number}}
+        CGO_ENABLED: 1
+        CGO_LDFLAGS: '-static'
+      run: |
+        if [ "${{ matrix.registry }}" = "test/registry" ]; then
+          python3 test/python/stackql_test_tooling/tcp_lb.py --generate-hosts-entries | sudo tee -a /etc/hosts
+          python3 test/python/stackql_test_tooling/tcp_lb.py --generate-nginx-lb > test/tcp/reverse-proxy/nginx/dynamic-sni-proxy.conf
+        fi
+
+    - name: Install testing dependencies
+      run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends postgresql-client
+          if [ "${{ matrix.registry }}" = "test/registry" ]; then
+            sudo apt-get install -y curl gnupg2 ca-certificates lsb-release ubuntu-keyring
+            curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
+              | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+            gpg --dry-run --quiet --no-keyring --import --import-options import-show /usr/share/keyrings/nginx-archive-keyring.gpg
+            echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+              http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" \
+                  | sudo tee /etc/apt/sources.list.d/nginx.list
+            sudo apt-get update
+            sudo apt-get install nginx
+            sudo nginx -c "$(pwd)/test/tcp/reverse-proxy/nginx/dynamic-sni-proxy.conf"
+          fi
     
     - name: Generate rewritten registry for simulations
       if: ${{ matrix.registry  != 'test/registry' }}

--- a/test/robot/README.md
+++ b/test/robot/README.md
@@ -44,12 +44,20 @@ env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot -d test/robot/integration 
   test/robot/integration
 ```
 
+For the vanilla traffic lights, eg (after sourcing requisite env vars):
+
+```bash
+# source cicd/vol/vendor-secrets/secrets.sh
+
+env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot --outputdir test/robot/reports-integration-traffic-lights test/robot/integration-traffic-lights
+```
+
 In particular, for the foreign auth integration tests, some tests may be unstable in some cloud and CI environments, so you may want to check locally, eg (after sourcing requisite env vars):
 
 ```bash
 # source cicd/vol/vendor-secrets/foreign_to_stackql_user.sh
 
-env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot --outputdir test/robot/reports-integration-traffic-lights test/robot/foreign-integration-traffic-lights
+env PYTHONPATH="$PYTHONPATH:$(pwd)/test/python" robot --outputdir test/robot/reports-foreign-integration-traffic-lights test/robot/foreign-integration-traffic-lights
 ```
 
 


### PR DESCRIPTION
## Description

- Run traffic lights integration tests *prior* to host file and mocked hosts routing.
- This prevents mocks from being engaged, and therefore fixes:
    - Robot tests `Run traffic light robot integration tests`.
    - Robot tests `Run foreign traffic light robot integration tests`.




<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

The vanilla inegration tests were working prior, due to coincidental mock invocation.  Now that server routing is post test, they now work against live targets per Figure T-1.  The foreign auth tests, which had no mocks, were broken pior and now work against live targets, per Figure T-2.



<img width="572" height="517" alt="Screenshot 2026-05-27 at 7 48 16 AM" src="https://github.com/user-attachments/assets/7b480ace-8044-4482-999e-51f4137c1e41" />



**Figure T-1**: Integration tests now working.

---


<img width="573" height="437" alt="Screenshot 2026-05-27 at 7 47 44 AM" src="https://github.com/user-attachments/assets/9d85ddbd-482d-4a56-9ff1-551f652a3bf5" />


**Figure T-2**: Foreign integration tests now working.

---


<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [x] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [x] The changes are covered with functional and/or integration robot testing.
- [x] The changes work on all supported platforms.
- [x] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [x] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [x] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

N/A.

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

No technical debt is added in this change.

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
