### PR TITLE
mcp: fix empty-result + nullable-render bugs, add list_registry/pul_provider

### DIFF
--- a/internal/stackql/mcpbackend/mcp_reverse_proxy_backend_service.go
+++ b/internal/stackql/mcpbackend/mcp_reverse_proxy_backend_service.go
@@ -220,3 +220,19 @@ func (b *stackqlMCPReverseProxyService) ListMethods(ctx context.Context, hI dto.
 	}
 	return b.query(ctx, q, hI.RowLimit)
 }
+
+func (b *stackqlMCPReverseProxyService) ListRegistry(ctx context.Context, input dto.RegistryInput) ([]map[string]interface{}, error) {
+	q, qErr := b.interrogator.GetRegistryList(input.Provider)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.query(ctx, q, unlimitedRowLimit)
+}
+
+func (b *stackqlMCPReverseProxyService) PullProvider(ctx context.Context, input dto.RegistryInput) (map[string]any, error) {
+	q, qErr := b.interrogator.GetRegistryPull(input.Provider, input.Version)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.ExecQuery(ctx, q)
+}

--- a/internal/stackql/mcpbackend/mcp_service_stackql.go
+++ b/internal/stackql/mcpbackend/mcp_service_stackql.go
@@ -90,7 +90,14 @@ type StackqlInterrogator interface {
 	GetDescribeResource(dto.HierarchyInput) (string, error)
 	GetDescribeMethod(dto.HierarchyInput) (string, error)
 	GetQueryJSON(dto.QueryJSONInput) (string, error)
+	GetRegistryList(provider string) (string, error)
+	GetRegistryPull(provider, version string) (string, error)
 }
+
+// forbiddenRegistryCharacters guards against injection into REGISTRY LIST /
+// REGISTRY PULL commands where the operand is interpolated as a bare token
+// rather than a quoted literal.
+const forbiddenRegistryCharacters = ";\"'`\n\r\t "
 
 type simpleStackqlInterrogator struct{}
 
@@ -190,6 +197,39 @@ func (s *simpleStackqlInterrogator) GetQueryJSON(qI dto.QueryJSONInput) (string,
 		return "", fmt.Errorf("no SQL provided")
 	}
 	return qI.SQL, nil
+}
+
+func (s *simpleStackqlInterrogator) GetRegistryList(provider string) (string, error) {
+	if strings.ContainsAny(provider, forbiddenRegistryCharacters) {
+		return "", fmt.Errorf("invalid provider identifier")
+	}
+	sb := strings.Builder{}
+	sb.WriteString("REGISTRY LIST")
+	if provider != "" {
+		sb.WriteString(" ")
+		sb.WriteString(provider)
+	}
+	return sb.String(), nil
+}
+
+func (s *simpleStackqlInterrogator) GetRegistryPull(provider, version string) (string, error) {
+	if provider == "" {
+		return "", fmt.Errorf("provider not specified")
+	}
+	if strings.ContainsAny(provider, forbiddenRegistryCharacters) {
+		return "", fmt.Errorf("invalid provider identifier")
+	}
+	if strings.ContainsAny(version, forbiddenRegistryCharacters) {
+		return "", fmt.Errorf("invalid version identifier")
+	}
+	sb := strings.Builder{}
+	sb.WriteString("REGISTRY PULL ")
+	sb.WriteString(provider)
+	if version != "" {
+		sb.WriteString(" ")
+		sb.WriteString(version)
+	}
+	return sb.String(), nil
 }
 
 type stackqlMCPService struct {
@@ -344,7 +384,7 @@ func (b *stackqlMCPService) extractQueryResults(query string, rowLimit int) ([]m
 			}
 		}
 	}
-	return rv, (ok && len(rv) > 0)
+	return rv, ok
 }
 
 func (b *stackqlMCPService) DescribeResource(ctx context.Context, hI dto.HierarchyInput) ([]map[string]interface{}, error) {
@@ -393,4 +433,20 @@ func (b *stackqlMCPService) ListMethods(ctx context.Context, hI dto.HierarchyInp
 		return nil, qErr
 	}
 	return b.runPreprocessedQueryJSON(ctx, q, unlimitedRowLimit)
+}
+
+func (b *stackqlMCPService) ListRegistry(ctx context.Context, input dto.RegistryInput) ([]map[string]interface{}, error) {
+	q, qErr := b.interrogator.GetRegistryList(input.Provider)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.runPreprocessedQueryJSON(ctx, q, unlimitedRowLimit)
+}
+
+func (b *stackqlMCPService) PullProvider(_ context.Context, input dto.RegistryInput) (map[string]any, error) {
+	q, qErr := b.interrogator.GetRegistryPull(input.Provider, input.Version)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.execQuery(q)
 }

--- a/pkg/mcp_server/backend.go
+++ b/pkg/mcp_server/backend.go
@@ -44,6 +44,17 @@ type Backend interface {
 
 	// DescribeMethod returns the full I/O contract for one method.
 	DescribeMethod(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error)
+
+	// ListRegistry lists providers (and optionally versions) available in the
+	// registry, distinct from ListProviders which lists only locally installed
+	// providers.  When input.Provider is empty, all available providers are
+	// returned; when set, the versions available for that provider are returned.
+	ListRegistry(ctx context.Context, input dto.RegistryInput) ([]map[string]any, error)
+
+	// PullProvider installs a single provider into the local approot cache so
+	// subsequent queries resolve.  Version is optional; if empty the registry's
+	// default selection applies.
+	PullProvider(ctx context.Context, input dto.RegistryInput) (map[string]any, error)
 }
 
 // QueryResult represents the result of a query execution.

--- a/pkg/mcp_server/dto/dto.go
+++ b/pkg/mcp_server/dto/dto.go
@@ -53,3 +53,12 @@ type ValidationResultDTO struct {
 	Valid  bool     `json:"valid"`
 	Errors []string `json:"errors,omitempty"`
 }
+
+// RegistryInput is the input shape for list_registry and pull_provider.
+// Provider is optional for list_registry (omit to list all available providers).
+// Provider is required for pull_provider; Version is optional (omit to pull
+// the latest version).
+type RegistryInput struct {
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Version  string `json:"version,omitempty" yaml:"version,omitempty"`
+}

--- a/pkg/mcp_server/example_backend.go
+++ b/pkg/mcp_server/example_backend.go
@@ -61,6 +61,14 @@ func (b *ExampleBackend) ListResources(ctx context.Context, hI dto.HierarchyInpu
 	return []map[string]any{}, nil
 }
 
+func (b *ExampleBackend) ListRegistry(ctx context.Context, input dto.RegistryInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
+}
+
+func (b *ExampleBackend) PullProvider(ctx context.Context, input dto.RegistryInput) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
 // NewExampleBackend creates a new example backend instance.
 func NewExampleBackend(connectionString string) Backend {
 	return &ExampleBackend{

--- a/pkg/mcp_server/gate.go
+++ b/pkg/mcp_server/gate.go
@@ -63,6 +63,23 @@ func extractArgsFromHierarchy(args any) map[string]any {
 	return hierarchyToMap(v)
 }
 
+// extractArgsFromRegistryInput returns {provider, version} for audit recording
+// against list_registry and pull_provider.
+func extractArgsFromRegistryInput(args any) map[string]any {
+	v, ok := args.(dto.RegistryInput)
+	if !ok {
+		return nil
+	}
+	out := map[string]any{}
+	if v.Provider != "" {
+		out["provider"] = v.Provider
+	}
+	if v.Version != "" {
+		out["version"] = v.Version
+	}
+	return out
+}
+
 func hierarchyToMap(v dto.HierarchyInput) map[string]any {
 	out := map[string]any{}
 	if v.Provider != "" {

--- a/pkg/mcp_server/render/render.go
+++ b/pkg/mcp_server/render/render.go
@@ -2,12 +2,92 @@
 package render
 
 import (
+	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
 )
 
 const noResults = "**no results**"
+
+// unwrap returns the scalar contents of a database/sql nullable wrapper
+// (or a pointer to one) so cells render as the underlying value rather than
+// the wrapper's struct form (eg `&{ok true}`).  Invalid wrappers collapse to
+// the empty string, matching the zero-value substitution the reverse-proxy
+// backend performs upstream.  Non-wrapper values pass through unchanged.
+func unwrap(v any) any {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case sql.NullString:
+		if !x.Valid {
+			return ""
+		}
+		return x.String
+	case *sql.NullString:
+		if x == nil {
+			return nil
+		}
+		if !x.Valid {
+			return ""
+		}
+		return x.String
+	case sql.NullBool:
+		if !x.Valid {
+			return ""
+		}
+		return x.Bool
+	case *sql.NullBool:
+		if x == nil {
+			return nil
+		}
+		if !x.Valid {
+			return ""
+		}
+		return x.Bool
+	case sql.NullInt64:
+		if !x.Valid {
+			return ""
+		}
+		return x.Int64
+	case *sql.NullInt64:
+		if x == nil {
+			return nil
+		}
+		if !x.Valid {
+			return ""
+		}
+		return x.Int64
+	case sql.NullInt32:
+		if !x.Valid {
+			return ""
+		}
+		return x.Int32
+	case *sql.NullInt32:
+		if x == nil {
+			return nil
+		}
+		if !x.Valid {
+			return ""
+		}
+		return x.Int32
+	case sql.NullFloat64:
+		if !x.Valid {
+			return ""
+		}
+		return x.Float64
+	case *sql.NullFloat64:
+		if x == nil {
+			return nil
+		}
+		if !x.Valid {
+			return ""
+		}
+		return x.Float64
+	default:
+		return v
+	}
+}
 
 // RenderTable renders a uniform multi-row result set as a markdown table.
 // Column order is stable: the union of keys across all rows, sorted alphabetically.
@@ -44,7 +124,7 @@ func RenderKV(title string, records []map[string]any) string {
 		sb.WriteString(fmt.Sprintf("## Record %d\n\n", i+1))
 		keys := sortedKeys(rec)
 		for _, k := range keys {
-			sb.WriteString(fmt.Sprintf("%s: %v\n", k, rec[k]))
+			sb.WriteString(fmt.Sprintf("%s: %v\n", k, unwrap(rec[k])))
 		}
 		if i < len(records)-1 {
 			sb.WriteString("\n")
@@ -103,7 +183,7 @@ func dataRow(columns []string, row map[string]any) string {
 			sb.WriteString("|  ")
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("| %v ", v))
+		sb.WriteString(fmt.Sprintf("| %v ", unwrap(v)))
 	}
 	sb.WriteString("|")
 	return sb.String()

--- a/pkg/mcp_server/render/render_test.go
+++ b/pkg/mcp_server/render/render_test.go
@@ -1,6 +1,7 @@
 package render_test
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 
@@ -46,5 +47,55 @@ func TestRenderKV_Empty(t *testing.T) {
 	got := render.RenderKV("Empty", nil)
 	if !strings.Contains(got, "no results") {
 		t.Fatalf("expected 'no results' message: %q", got)
+	}
+}
+
+// TestRenderTable_UnwrapsNullableWrappers asserts that database/sql nullable
+// wrappers (and pointers to them) render as the underlying scalar rather than
+// the Go struct form (eg `&{ok true}`).  Repro from the bug report: SELECT 1
+// as n, 'ok' as status used to render `| &{ok true} | &{1 true} |`.
+func TestRenderTable_UnwrapsNullableWrappers(t *testing.T) {
+	rows := []map[string]any{{
+		"n":      &sql.NullInt64{Int64: 1, Valid: true},
+		"status": &sql.NullString{String: "ok", Valid: true},
+	}}
+	got := render.RenderTable(rows)
+	if strings.Contains(got, "&{") {
+		t.Fatalf("expected wrappers to be unwrapped, got %q", got)
+	}
+	if !strings.Contains(got, "| ok ") || !strings.Contains(got, "| 1 ") {
+		t.Fatalf("expected unwrapped scalars in cells, got %q", got)
+	}
+}
+
+// TestRenderKV_UnwrapsNullableWrappers exercises the parallel path in
+// RenderKV.  ServerInfo uses RenderKV, and other tools route here too.
+func TestRenderKV_UnwrapsNullableWrappers(t *testing.T) {
+	got := render.RenderKV("Pull Result", []map[string]any{{
+		"messages":  &sql.NullString{String: "ok", Valid: true},
+		"timestamp": sql.NullString{String: "2026-05-29", Valid: true},
+		"flag":      sql.NullBool{Bool: true, Valid: true},
+	}})
+	if strings.Contains(got, "&{") {
+		t.Fatalf("expected wrappers to be unwrapped, got %q", got)
+	}
+	for _, want := range []string{"messages: ok", "timestamp: 2026-05-29", "flag: true"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got %q", want, got)
+		}
+	}
+}
+
+// TestRender_InvalidNullableRendersAsEmpty asserts an invalid wrapper renders
+// as the empty string, matching the reverse-proxy backend's zero-value
+// substitution (z.String / z.Bool / z.Int64 on invalid wrappers).  Without
+// the substitution the cell would render as `false` / `0` / a wrapper struct
+// form and surface false information to the client.
+func TestRender_InvalidNullableRendersAsEmpty(t *testing.T) {
+	got := render.RenderKV("Sparse", []map[string]any{{
+		"absent": &sql.NullString{Valid: false},
+	}})
+	if !strings.Contains(got, "absent: \n") {
+		t.Fatalf("expected invalid wrapper to render as empty, got %q", got)
 	}
 }

--- a/pkg/mcp_server/server.go
+++ b/pkg/mcp_server/server.go
@@ -205,6 +205,18 @@ func queryGate(name string) toolGate {
 	}
 }
 
+// registryGate is the toolGate shape for the registry tools (list_registry,
+// pull_provider).  Decision is Allow under every mode: list is read-only, and
+// pull only fetches remote content into the local approot cache - it does not
+// touch any cloud control or data plane.  The audit record still gets written.
+func registryGate(name string) toolGate {
+	return toolGate{
+		toolName:     name,
+		defaultClass: policy.QueryClassSelect,
+		extractArgs:  extractArgsFromRegistryInput,
+	}
+}
+
 //nolint:funlen,gocognit // tool registrations are inherently long and branchy
 func registerTools(server *mcp.Server, cfg *Config, backend Backend, logger *logrus.Logger, auditSink sink.Sink) {
 	addToolWithGate(
@@ -306,6 +318,38 @@ func registerTools(server *mcp.Server, cfg *Config, backend Backend, logger *log
 			}
 			out := dto.QueryResultDTO{Rows: rows}
 			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: render.RenderTable(rows)}}}, out, nil
+		},
+	)
+
+	addToolWithGate(
+		server, cfg, auditSink, registryGate("list_registry"),
+		&mcp.Tool{
+			Name:        "list_registry",
+			Description: "Providers (and optional versions) available in the registry to pull. Distinct from list_providers which lists only locally installed providers. Optional provider lists its versions; omitted lists all available providers.",
+		},
+		func(ctx context.Context, _ *mcp.CallToolRequest, args dto.RegistryInput) (*mcp.CallToolResult, dto.QueryResultDTO, error) {
+			rows, err := backend.ListRegistry(ctx, args)
+			if err != nil {
+				return nil, dto.QueryResultDTO{}, err
+			}
+			out := dto.QueryResultDTO{Rows: rows}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: render.RenderTable(rows)}}}, out, nil
+		},
+	)
+
+	addToolWithGate(
+		server, cfg, auditSink, registryGate("pull_provider"),
+		&mcp.Tool{
+			Name:        "pull_provider",
+			Description: "Install a single provider into the local approot cache so subsequent queries resolve. Requires provider; version optional. Allowed in all modes (writes only local state, not a cloud mutation).",
+		},
+		func(ctx context.Context, _ *mcp.CallToolRequest, args dto.RegistryInput) (*mcp.CallToolResult, map[string]any, error) {
+			res, err := backend.PullProvider(ctx, args)
+			if err != nil {
+				return nil, nil, err
+			}
+			text := render.RenderKV("Pull Result", []map[string]any{res})
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, res, nil
 		},
 	)
 

--- a/pkg/mcp_server/tools_test.go
+++ b/pkg/mcp_server/tools_test.go
@@ -19,6 +19,8 @@ type testBackend struct {
 	listServicesOut  []map[string]any
 	listResourcesOut []map[string]any
 	listMethodsOut   []map[string]any
+	listRegistryOut  []map[string]any
+	pullProviderOut  map[string]any
 	describeRsrcOut  []map[string]any
 	describeMethOut  []map[string]any
 	runJSONOut       []map[string]any
@@ -28,6 +30,7 @@ type testBackend struct {
 
 	// Capture last inputs for assertions
 	lastHierarchy   dto.HierarchyInput
+	lastRegistry    dto.RegistryInput
 	lastQueryJSON   dto.QueryJSONInput
 	lastExecQuery   string
 	lastValidateSQL string
@@ -77,6 +80,17 @@ func (b *testBackend) DescribeResource(_ context.Context, h dto.HierarchyInput) 
 func (b *testBackend) DescribeMethod(_ context.Context, h dto.HierarchyInput) ([]map[string]any, error) {
 	b.lastHierarchy = h
 	return nilOrEmpty(b.describeMethOut), nil
+}
+func (b *testBackend) ListRegistry(_ context.Context, in dto.RegistryInput) ([]map[string]any, error) {
+	b.lastRegistry = in
+	return nilOrEmpty(b.listRegistryOut), nil
+}
+func (b *testBackend) PullProvider(_ context.Context, in dto.RegistryInput) (map[string]any, error) {
+	b.lastRegistry = in
+	if b.pullProviderOut == nil {
+		return map[string]any{}, nil
+	}
+	return b.pullProviderOut, nil
 }
 
 // nilOrEmpty ensures we return a non-nil slice so the SDK's schema validation
@@ -384,10 +398,74 @@ func TestRegistration_EnabledToolsFilters(t *testing.T) {
 	if !names["server_info"] {
 		t.Errorf("server_info should be present")
 	}
-	for _, denied := range []string{"list_providers", "run_select_query", "run_mutation_query"} {
+	for _, denied := range []string{"list_providers", "run_select_query", "run_mutation_query", "list_registry", "pull_provider"} {
 		if names[denied] {
 			t.Errorf("%s should be filtered out, tools: %v", denied, names)
 		}
+	}
+}
+
+func TestTool_ListRegistry_RendersTableAndForwardsProvider(t *testing.T) {
+	be := &testBackend{listRegistryOut: []map[string]any{
+		{"provider": "google", "version": "v0.1.2"},
+		{"provider": "google", "version": "v0.1.3"},
+	}}
+	cs := connectInProcess(t, DefaultConfig(), be)
+
+	res := callTool(t, cs, "list_registry", map[string]any{"provider": "google"})
+	text := firstText(t, res)
+	if !strings.Contains(text, "| provider |") || !strings.Contains(text, "| version |") {
+		t.Errorf("missing table header: %q", text)
+	}
+	if be.lastRegistry.Provider != "google" {
+		t.Errorf("provider not forwarded: %+v", be.lastRegistry)
+	}
+	out := structuredAs[dto.QueryResultDTO](t, res)
+	if len(out.Rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(out.Rows))
+	}
+}
+
+func TestTool_ListRegistry_AllowedInReadOnly(t *testing.T) {
+	be := &testBackend{listRegistryOut: []map[string]any{{"provider": "google"}}}
+	cs := connectInProcess(t, readOnlyConfig(), be)
+	res := callTool(t, cs, "list_registry", map[string]any{})
+	if res.IsError {
+		t.Errorf("list_registry should be allowed in read_only mode, got error: %+v", res)
+	}
+}
+
+func TestTool_PullProvider_RendersKVAndForwardsArgs(t *testing.T) {
+	be := &testBackend{pullProviderOut: map[string]any{
+		"messages":  []string{"pulled"},
+		"timestamp": "2026-05-29T00:00:00Z",
+	}}
+	cs := connectInProcess(t, DefaultConfig(), be)
+
+	res := callTool(t, cs, "pull_provider", map[string]any{
+		"provider": "google", "version": "v0.1.3",
+	})
+	text := firstText(t, res)
+	if !strings.Contains(text, "# Pull Result") {
+		t.Errorf("expected KV title 'Pull Result', got %q", text)
+	}
+	if !strings.Contains(text, "timestamp: 2026-05-29T00:00:00Z") {
+		t.Errorf("missing timestamp key, got %q", text)
+	}
+	if be.lastRegistry.Provider != "google" || be.lastRegistry.Version != "v0.1.3" {
+		t.Errorf("registry input not forwarded: %+v", be.lastRegistry)
+	}
+}
+
+func TestTool_PullProvider_AllowedInReadOnly(t *testing.T) {
+	be := &testBackend{pullProviderOut: map[string]any{"timestamp": "now"}}
+	cs := connectInProcess(t, readOnlyConfig(), be)
+	res := callTool(t, cs, "pull_provider", map[string]any{"provider": "google"})
+	if res.IsError {
+		t.Errorf("pull_provider should be allowed in read_only mode (local cache only), got error: %+v", res)
+	}
+	if be.lastRegistry.Provider != "google" {
+		t.Errorf("provider not forwarded: %+v", be.lastRegistry)
 	}
 }
 

--- a/test/robot/functional/mcp.robot
+++ b/test/robot/functional/mcp.robot
@@ -876,3 +876,79 @@ MCP HTTP Audit Disabled Writes No File
     Should Be Equal As Integers    ${sel.rc}    0
     ${after}=    Run Process    sh    -c    ls stackql_mcp_server_*.log 2>/dev/null | wc -l
     Should Be Equal    ${before.stdout}    ${after.stdout}
+
+# ===========================================================================
+# Render fixes: empty result, literal-column unwrap (#661)
+# ===========================================================================
+
+MCP HTTP Empty Result Renders Cleanly
+    [Documentation]    A SELECT that yields zero rows must render the empty-result marker
+    ...                rather than failing with "failed to extract query results" (#661 fix 1).
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-exec.action      run_select_query
+    ...                  \-\-exec.args        {"sql":"SELECT name FROM google.storage.buckets WHERE project \= 'stackql\-demo' AND name \= '__definitely_missing__';"}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-EmptyResult-select.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-EmptyResult-select-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    Should Not Contain    ${result.stdout}    failed to extract query results
+    Should Not Contain    ${result.stderr}    failed to extract query results
+
+MCP HTTP Literal Select Renders Unwrapped Scalars
+    [Documentation]    SELECT of literal/expression columns must render scalars in cells,
+    ...                not the Go nullable-wrapper struct form (eg `&{ok true}`) (#661 fix 2).
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9914
+    ...                  \-\-exec.action      run_select_query
+    ...                  \-\-exec.args        {"sql":"SELECT 1 as n, 'ok' as status"}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-LiteralSelect.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-LiteralSelect-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    Should Not Contain    ${result.stdout}    &{
+
+# ===========================================================================
+# Registry tools: list_registry, pull_provider (#661 features 1 & 2)
+# ===========================================================================
+
+MCP HTTP List Registry Returns Available Providers
+    [Documentation]    list_registry returns a non-empty set of providers available in the
+    ...                test registry, distinct from list_providers' installed-only view.
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-exec.action      list_registry
+    ...                  \-\-exec.args        {}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-ListRegistry.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-ListRegistry-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    ${result_obj}=    Parse MCP JSON Output    ${result.stdout}
+    Dictionary Should Contain Key    ${result_obj}    rows
+    Should Not Be Empty        ${result_obj['rows']}
+
+MCP HTTP Pull Provider Installs Known Provider
+    [Documentation]    pull_provider for a known provider returns a payload that carries
+    ...                a timestamp, matching the shape of run_lifecycle_operation.
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-exec.action      pull_provider
+    ...                  \-\-exec.args        {"provider": "google"}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-PullProvider.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-PullProvider-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    ${result_obj}=    Parse MCP JSON Output    ${result.stdout}
+    Dictionary Should Contain Key    ${result_obj}    timestamp


### PR DESCRIPTION
Fix 1: extractQueryResults returns (rv, ok) instead of (rv, ok && len(rv) > 0) so zero-row SELECTs are no longer mis-reported as extraction failures; the renderer's no-results branch handles empty.

Fix 2: render.unwrap handles database/sql nullable wrappers (and pointers to them) so cells render as scalars rather than the Go struct form (eg "&{ok true}"). Applied in dataRow and the RenderKV loop. Invalid wrappers collapse to the empty string, matching the reverse-proxy backend's zero-value substitution.

New tool list_registry: providers/versions available in the registry, distinct from list_providers' installed-only view. Read-only, allowed in every mode.

New tool pull_provider: installs a single provider into the local approot cache. Allowed in every mode (writes only local state, not a cloud mutation - per the issue rationale). Renamed from pull_providers per review: only one provider can be pulled at a time.

Closes #661.
