### PR TITLE
mcp: fix empty-result + nullable-render bugs, add list_registry/pull_provider

### DIFF
--- a/internal/stackql/mcpbackend/mcp_reverse_proxy_backend_service.go
+++ b/internal/stackql/mcpbackend/mcp_reverse_proxy_backend_service.go
@@ -220,3 +220,19 @@ func (b *stackqlMCPReverseProxyService) ListMethods(ctx context.Context, hI dto.
 	}
 	return b.query(ctx, q, hI.RowLimit)
 }
+
+func (b *stackqlMCPReverseProxyService) ListRegistry(ctx context.Context, rI dto.RegistryInput) ([]map[string]interface{}, error) {
+	q, qErr := b.interrogator.GetRegistryList(rI.Provider)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.query(ctx, q, unlimitedRowLimit)
+}
+
+func (b *stackqlMCPReverseProxyService) PullProvider(ctx context.Context, rI dto.RegistryInput) (map[string]any, error) {
+	q, qErr := b.interrogator.GetRegistryPull(rI.Provider, rI.Version)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.ExecQuery(ctx, q)
+}

--- a/internal/stackql/mcpbackend/mcp_service_stackql.go
+++ b/internal/stackql/mcpbackend/mcp_service_stackql.go
@@ -21,6 +21,10 @@ var (
 
 const (
 	unlimitedRowLimit int = -1
+	// forbiddenRegistryCharacters rejects shell/SQL metacharacters in
+	// REGISTRY LIST/PULL arguments; these flow into raw SQL strings so
+	// validation belongs at the interrogator boundary.
+	forbiddenRegistryCharacters = " \t\n\r;'\"`\\"
 )
 
 // serverBuildInfo carries the runtime + build-time metadata reported by the
@@ -90,6 +94,8 @@ type StackqlInterrogator interface {
 	GetDescribeResource(dto.HierarchyInput) (string, error)
 	GetDescribeMethod(dto.HierarchyInput) (string, error)
 	GetQueryJSON(dto.QueryJSONInput) (string, error)
+	GetRegistryList(provider string) (string, error)
+	GetRegistryPull(provider, version string) (string, error)
 }
 
 type simpleStackqlInterrogator struct{}
@@ -190,6 +196,39 @@ func (s *simpleStackqlInterrogator) GetQueryJSON(qI dto.QueryJSONInput) (string,
 		return "", fmt.Errorf("no SQL provided")
 	}
 	return qI.SQL, nil
+}
+
+func (s *simpleStackqlInterrogator) GetRegistryList(provider string) (string, error) {
+	if strings.ContainsAny(provider, forbiddenRegistryCharacters) {
+		return "", fmt.Errorf("invalid character in provider name")
+	}
+	sb := strings.Builder{}
+	sb.WriteString("REGISTRY LIST")
+	if provider != "" {
+		sb.WriteString(" ")
+		sb.WriteString(provider)
+	}
+	return sb.String(), nil
+}
+
+func (s *simpleStackqlInterrogator) GetRegistryPull(provider, version string) (string, error) {
+	if provider == "" {
+		return "", fmt.Errorf("provider not specified")
+	}
+	if strings.ContainsAny(provider, forbiddenRegistryCharacters) {
+		return "", fmt.Errorf("invalid character in provider name")
+	}
+	if strings.ContainsAny(version, forbiddenRegistryCharacters) {
+		return "", fmt.Errorf("invalid character in version")
+	}
+	sb := strings.Builder{}
+	sb.WriteString("REGISTRY PULL ")
+	sb.WriteString(provider)
+	if version != "" {
+		sb.WriteString(" ")
+		sb.WriteString(version)
+	}
+	return sb.String(), nil
 }
 
 type stackqlMCPService struct {
@@ -344,7 +383,7 @@ func (b *stackqlMCPService) extractQueryResults(query string, rowLimit int) ([]m
 			}
 		}
 	}
-	return rv, (ok && len(rv) > 0)
+	return rv, ok
 }
 
 func (b *stackqlMCPService) DescribeResource(ctx context.Context, hI dto.HierarchyInput) ([]map[string]interface{}, error) {
@@ -393,4 +432,20 @@ func (b *stackqlMCPService) ListMethods(ctx context.Context, hI dto.HierarchyInp
 		return nil, qErr
 	}
 	return b.runPreprocessedQueryJSON(ctx, q, unlimitedRowLimit)
+}
+
+func (b *stackqlMCPService) ListRegistry(ctx context.Context, rI dto.RegistryInput) ([]map[string]interface{}, error) {
+	q, qErr := b.interrogator.GetRegistryList(rI.Provider)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.runPreprocessedQueryJSON(ctx, q, unlimitedRowLimit)
+}
+
+func (b *stackqlMCPService) PullProvider(_ context.Context, rI dto.RegistryInput) (map[string]any, error) {
+	q, qErr := b.interrogator.GetRegistryPull(rI.Provider, rI.Version)
+	if qErr != nil {
+		return nil, qErr
+	}
+	return b.execQuery(q)
 }

--- a/pkg/mcp_server/backend.go
+++ b/pkg/mcp_server/backend.go
@@ -44,6 +44,16 @@ type Backend interface {
 
 	// DescribeMethod returns the full I/O contract for one method.
 	DescribeMethod(ctx context.Context, hI dto.HierarchyInput) ([]map[string]any, error)
+
+	// ListRegistry lists providers (and optionally their versions) available
+	// in the provider registry. Distinct from ListProviders, which lists
+	// providers already pulled into the local approot cache.
+	ListRegistry(ctx context.Context, rI dto.RegistryInput) ([]map[string]any, error)
+
+	// PullProvider installs a provider (optionally pinned to a version) into
+	// the approot cache so subsequent queries can resolve it. Writes only
+	// local state, no cloud control/data-plane effect.
+	PullProvider(ctx context.Context, rI dto.RegistryInput) (map[string]any, error)
 }
 
 // QueryResult represents the result of a query execution.

--- a/pkg/mcp_server/dto/dto.go
+++ b/pkg/mcp_server/dto/dto.go
@@ -9,6 +9,14 @@ type HierarchyInput struct {
 	RowLimit int    `json:"row_limit,omitempty" yaml:"row_limit,omitempty"`
 }
 
+// RegistryInput identifies a provider (and optionally a version) within the
+// provider registry.  Used by both list_registry (provider optional) and
+// pull_provider (provider required).
+type RegistryInput struct {
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Version  string `json:"version,omitempty" yaml:"version,omitempty"`
+}
+
 // ServerInfoOutput is the backend-facing server info payload.
 // ReadOnly (JSON tag `is_read_only`) is kept for back-compat with PR1
 // consumers; new consumers should prefer the Mode field.

--- a/pkg/mcp_server/example_backend.go
+++ b/pkg/mcp_server/example_backend.go
@@ -61,6 +61,14 @@ func (b *ExampleBackend) ListResources(ctx context.Context, hI dto.HierarchyInpu
 	return []map[string]any{}, nil
 }
 
+func (b *ExampleBackend) ListRegistry(ctx context.Context, rI dto.RegistryInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
+}
+
+func (b *ExampleBackend) PullProvider(ctx context.Context, rI dto.RegistryInput) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
 // NewExampleBackend creates a new example backend instance.
 func NewExampleBackend(connectionString string) Backend {
 	return &ExampleBackend{

--- a/pkg/mcp_server/gate.go
+++ b/pkg/mcp_server/gate.go
@@ -63,6 +63,23 @@ func extractArgsFromHierarchy(args any) map[string]any {
 	return hierarchyToMap(v)
 }
 
+// extractArgsFromRegistryInput returns {provider, version} for audit recording
+// of list_registry / pull_provider calls.
+func extractArgsFromRegistryInput(args any) map[string]any {
+	v, ok := args.(dto.RegistryInput)
+	if !ok {
+		return nil
+	}
+	out := map[string]any{}
+	if v.Provider != "" {
+		out["provider"] = v.Provider
+	}
+	if v.Version != "" {
+		out["version"] = v.Version
+	}
+	return out
+}
+
 func hierarchyToMap(v dto.HierarchyInput) map[string]any {
 	out := map[string]any{}
 	if v.Provider != "" {

--- a/pkg/mcp_server/render/render.go
+++ b/pkg/mcp_server/render/render.go
@@ -3,11 +3,50 @@ package render
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 )
 
 const noResults = "**no results**"
+
+// unwrap returns the underlying scalar for sql.Null* wrappers (and pointers
+// to them).  Genuinely nil inputs are preserved.  An invalid (Valid==false)
+// wrapper collapses to the empty string, matching the substitution the
+// reverse-proxy backend applies during column-type scanning.
+//
+// Reflection-based to remain agnostic to which Null* shape arrives (string,
+// bool, int64, int32, float64, time, byte, or the Go 1.22+ generic
+// sql.Null[T]): any struct with a `Valid bool` field plus exactly one other
+// exported field is treated as a nullable wrapper.
+func unwrap(v any) any {
+	if v == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return v
+	}
+	validField := rv.FieldByName("Valid")
+	if !validField.IsValid() || validField.Kind() != reflect.Bool {
+		return v
+	}
+	if !validField.Bool() {
+		return ""
+	}
+	for i := 0; i < rv.NumField(); i++ {
+		if rv.Type().Field(i).Name != "Valid" {
+			return rv.Field(i).Interface()
+		}
+	}
+	return v
+}
 
 // RenderTable renders a uniform multi-row result set as a markdown table.
 // Column order is stable: the union of keys across all rows, sorted alphabetically.
@@ -44,7 +83,7 @@ func RenderKV(title string, records []map[string]any) string {
 		sb.WriteString(fmt.Sprintf("## Record %d\n\n", i+1))
 		keys := sortedKeys(rec)
 		for _, k := range keys {
-			sb.WriteString(fmt.Sprintf("%s: %v\n", k, rec[k]))
+			sb.WriteString(fmt.Sprintf("%s: %v\n", k, unwrap(rec[k])))
 		}
 		if i < len(records)-1 {
 			sb.WriteString("\n")
@@ -103,7 +142,7 @@ func dataRow(columns []string, row map[string]any) string {
 			sb.WriteString("|  ")
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("| %v ", v))
+		sb.WriteString(fmt.Sprintf("| %v ", unwrap(v)))
 	}
 	sb.WriteString("|")
 	return sb.String()

--- a/pkg/mcp_server/render/render_test.go
+++ b/pkg/mcp_server/render/render_test.go
@@ -1,6 +1,7 @@
 package render_test
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 
@@ -46,5 +47,59 @@ func TestRenderKV_Empty(t *testing.T) {
 	got := render.RenderKV("Empty", nil)
 	if !strings.Contains(got, "no results") {
 		t.Fatalf("expected 'no results' message: %q", got)
+	}
+}
+
+// TestRenderTable_UnwrapsNullableWrappers covers the literal/expression-column
+// regression: cells whose value is a pointer-to-nullable wrapper used to
+// render as `&{ok true}`.  Unwrap should yield the scalar.
+func TestRenderTable_UnwrapsNullableWrappers(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"status": &sql.NullString{String: "ok", Valid: true},
+			"n":      &sql.NullInt64{Int64: 1, Valid: true},
+		},
+	}
+	got := render.RenderTable(rows)
+	if strings.Contains(got, "&{") {
+		t.Fatalf("unwrap failed; got raw Go format %q", got)
+	}
+	if !strings.Contains(got, "| ok |") || !strings.Contains(got, "| 1 |") {
+		t.Fatalf("expected unwrapped scalars; got %q", got)
+	}
+}
+
+func TestRenderKV_UnwrapsNullableWrappers(t *testing.T) {
+	rec := []map[string]any{
+		{
+			"status":  sql.NullString{String: "ok", Valid: true},
+			"enabled": sql.NullBool{Bool: true, Valid: true},
+		},
+	}
+	got := render.RenderKV("Test", rec)
+	if strings.Contains(got, "&{") || strings.Contains(got, "{ok true}") {
+		t.Fatalf("unwrap failed; got raw Go format %q", got)
+	}
+	if !strings.Contains(got, "status: ok") {
+		t.Fatalf("expected 'status: ok'; got %q", got)
+	}
+	if !strings.Contains(got, "enabled: true") {
+		t.Fatalf("expected 'enabled: true'; got %q", got)
+	}
+}
+
+// TestRender_InvalidNullableRendersAsEmpty: invalid (Valid==false) wrappers
+// collapse to an empty cell, matching the reverse-proxy backend's
+// zero-value substitution.
+func TestRender_InvalidNullableRendersAsEmpty(t *testing.T) {
+	rows := []map[string]any{
+		{"col": sql.NullString{Valid: false}},
+	}
+	got := render.RenderTable(rows)
+	if strings.Contains(got, "&{") || strings.Contains(got, "false") {
+		t.Fatalf("invalid wrapper should render as empty; got %q", got)
+	}
+	if !strings.Contains(got, "|  |") {
+		t.Fatalf("expected empty cell; got %q", got)
 	}
 }

--- a/pkg/mcp_server/server.go
+++ b/pkg/mcp_server/server.go
@@ -205,6 +205,18 @@ func queryGate(name string) toolGate {
 	}
 }
 
+// registryGate is the toolGate for list_registry / pull_provider.  Decision
+// is Allow under every mode: list_registry is a pure read, and pull_provider
+// only writes the local approot cache (no cloud control/data-plane effect).
+// The audit record is still written through the standard gate path.
+func registryGate(name string) toolGate {
+	return toolGate{
+		toolName:     name,
+		defaultClass: policy.QueryClassSelect,
+		extractArgs:  extractArgsFromRegistryInput,
+	}
+}
+
 //nolint:funlen,gocognit // tool registrations are inherently long and branchy
 func registerTools(server *mcp.Server, cfg *Config, backend Backend, logger *logrus.Logger, auditSink sink.Sink) {
 	addToolWithGate(
@@ -417,6 +429,38 @@ func registerTools(server *mcp.Server, cfg *Config, backend Backend, logger *log
 				return nil, nil, err
 			}
 			text := render.RenderKV("Lifecycle Result", []map[string]any{res})
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, res, nil
+		},
+	)
+
+	addToolWithGate(
+		server, cfg, auditSink, registryGate("list_registry"),
+		&mcp.Tool{
+			Name:        "list_registry",
+			Description: "Providers and versions available in the provider registry (not yet installed locally). Distinct from list_providers, which lists only providers already pulled into the approot cache. Optional provider input lists versions for that provider.",
+		},
+		func(ctx context.Context, _ *mcp.CallToolRequest, args dto.RegistryInput) (*mcp.CallToolResult, dto.QueryResultDTO, error) {
+			rows, err := backend.ListRegistry(ctx, args)
+			if err != nil {
+				return nil, dto.QueryResultDTO{}, err
+			}
+			out := dto.QueryResultDTO{Rows: rows}
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: render.RenderTable(rows)}}}, out, nil
+		},
+	)
+
+	addToolWithGate(
+		server, cfg, auditSink, registryGate("pull_provider"),
+		&mcp.Tool{
+			Name:        "pull_provider",
+			Description: "Install a provider into the local approot cache so subsequent queries resolve. Writes only local state - does not touch any cloud control/data plane. Requires provider; version optional.",
+		},
+		func(ctx context.Context, _ *mcp.CallToolRequest, args dto.RegistryInput) (*mcp.CallToolResult, map[string]any, error) {
+			res, err := backend.PullProvider(ctx, args)
+			if err != nil {
+				return nil, nil, err
+			}
+			text := render.RenderKV("Pull Result", []map[string]any{res})
 			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, res, nil
 		},
 	)

--- a/pkg/mcp_server/tools_test.go
+++ b/pkg/mcp_server/tools_test.go
@@ -25,12 +25,15 @@ type testBackend struct {
 	validateOut      []map[string]any
 	validateErr      error
 	execOut          map[string]any
+	listRegistryOut  []map[string]any
+	pullProviderOut  map[string]any
 
 	// Capture last inputs for assertions
 	lastHierarchy   dto.HierarchyInput
 	lastQueryJSON   dto.QueryJSONInput
 	lastExecQuery   string
 	lastValidateSQL string
+	lastRegistry    dto.RegistryInput
 }
 
 func (b *testBackend) Ping(_ context.Context) error { return nil }
@@ -77,6 +80,17 @@ func (b *testBackend) DescribeResource(_ context.Context, h dto.HierarchyInput) 
 func (b *testBackend) DescribeMethod(_ context.Context, h dto.HierarchyInput) ([]map[string]any, error) {
 	b.lastHierarchy = h
 	return nilOrEmpty(b.describeMethOut), nil
+}
+func (b *testBackend) ListRegistry(_ context.Context, r dto.RegistryInput) ([]map[string]any, error) {
+	b.lastRegistry = r
+	return nilOrEmpty(b.listRegistryOut), nil
+}
+func (b *testBackend) PullProvider(_ context.Context, r dto.RegistryInput) (map[string]any, error) {
+	b.lastRegistry = r
+	if b.pullProviderOut == nil {
+		return map[string]any{}, nil
+	}
+	return b.pullProviderOut, nil
 }
 
 // nilOrEmpty ensures we return a non-nil slice so the SDK's schema validation
@@ -384,10 +398,76 @@ func TestRegistration_EnabledToolsFilters(t *testing.T) {
 	if !names["server_info"] {
 		t.Errorf("server_info should be present")
 	}
-	for _, denied := range []string{"list_providers", "run_select_query", "run_mutation_query"} {
+	for _, denied := range []string{"list_providers", "run_select_query", "run_mutation_query", "list_registry", "pull_provider"} {
 		if names[denied] {
 			t.Errorf("%s should be filtered out, tools: %v", denied, names)
 		}
+	}
+}
+
+func TestTool_ListRegistry_RendersTableAndForwardsProvider(t *testing.T) {
+	be := &testBackend{listRegistryOut: []map[string]any{
+		{"provider": "google", "version": "v1"},
+		{"provider": "aws", "version": "v2"},
+	}}
+	cs := connectInProcess(t, DefaultConfig(), be)
+
+	res := callTool(t, cs, "list_registry", map[string]any{"provider": "google"})
+	if be.lastRegistry.Provider != "google" {
+		t.Errorf("provider not forwarded: %+v", be.lastRegistry)
+	}
+	text := firstText(t, res)
+	if !strings.Contains(text, "| provider |") || !strings.Contains(text, "| version |") {
+		t.Errorf("missing table header: %q", text)
+	}
+	if !strings.Contains(text, "| google |") || !strings.Contains(text, "| aws |") {
+		t.Errorf("missing data rows: %q", text)
+	}
+	out := structuredAs[dto.QueryResultDTO](t, res)
+	if len(out.Rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(out.Rows))
+	}
+}
+
+func TestTool_ListRegistry_AllowedInReadOnly(t *testing.T) {
+	be := &testBackend{listRegistryOut: []map[string]any{{"provider": "google"}}}
+	cs := connectInProcess(t, readOnlyConfig(), be)
+	// Should succeed under read_only mode (registry list is a read op).
+	callTool(t, cs, "list_registry", map[string]any{})
+	if be.lastRegistry.Provider != "" {
+		t.Errorf("registry input should be empty for unfiltered call: %+v", be.lastRegistry)
+	}
+}
+
+func TestTool_PullProvider_RendersKVAndForwardsArgs(t *testing.T) {
+	be := &testBackend{pullProviderOut: map[string]any{
+		"messages":  []string{"pulled google v1"},
+		"timestamp": "now",
+	}}
+	cs := connectInProcess(t, DefaultConfig(), be)
+	res := callTool(t, cs, "pull_provider", map[string]any{
+		"provider": "google", "version": "v1",
+	})
+	if be.lastRegistry.Provider != "google" || be.lastRegistry.Version != "v1" {
+		t.Errorf("args not forwarded: %+v", be.lastRegistry)
+	}
+	text := firstText(t, res)
+	if !strings.Contains(text, "# Pull Result") {
+		t.Errorf("expected KV title 'Pull Result'; got %q", text)
+	}
+	if !strings.Contains(text, "timestamp: now") {
+		t.Errorf("expected timestamp in rendered output; got %q", text)
+	}
+}
+
+func TestTool_PullProvider_AllowedInReadOnly(t *testing.T) {
+	be := &testBackend{pullProviderOut: map[string]any{"timestamp": "now"}}
+	cs := connectInProcess(t, readOnlyConfig(), be)
+	// pull_provider writes only local approot state, never a cloud op, so it
+	// must succeed under every mode.
+	callTool(t, cs, "pull_provider", map[string]any{"provider": "google"})
+	if be.lastRegistry.Provider != "google" {
+		t.Errorf("pull_provider should have reached the backend under read_only: %+v", be.lastRegistry)
 	}
 }
 

--- a/test/robot/functional/mcp.robot
+++ b/test/robot/functional/mcp.robot
@@ -858,6 +858,78 @@ MCP HTTP Audit Basic Records Tool Calls
     Should Contain    ${log_contents}    "decision":"allow"
     Should Contain    ${log_contents}    "mode":"full_access"
 
+MCP HTTP Empty Result Renders Cleanly
+    [Documentation]    Issue #661 fix 1: empty result sets used to be reported as
+    ...                "failed to extract query results".  A SELECT that legitimately
+    ...                returns zero rows must succeed and render the empty marker.
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-exec.action      run_select_query
+    ...                  \-\-exec.args        {"sql":"SELECT name FROM google.storage.buckets WHERE project \= 'no-such-project-xyz-stackql-test';"}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-EmptyResult.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-EmptyResult-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    Should Not Contain    ${result.stderr}    failed to extract query results
+
+MCP HTTP Literal Select Renders Unwrapped Scalars
+    [Documentation]    Issue #661 fix 2: literal/expression columns used to render as
+    ...                Go nullable wrappers (eg `&{ok true}`).  Cells must contain the
+    ...                unwrapped scalar.
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9914
+    ...                  \-\-exec.action      run_select_query
+    ...                  \-\-exec.args        {"sql":"SELECT 1 as n, 'ok' as status;"}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-LiteralSelect.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-LiteralSelect-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    Should Not Contain    ${result.stdout}    &{
+    Should Contain        ${result.stdout}    ok
+
+MCP HTTP List Registry Returns Available Providers
+    [Documentation]    Issue #661 feature 1: list_registry must return the providers
+    ...                published in the registry (distinct from list_providers, which
+    ...                only lists pulled providers).
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-exec.action      list_registry
+    ...                  \-\-exec.args        {}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-ListRegistry.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-ListRegistry-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    ${obj}=    Parse MCP JSON Output    ${result.stdout}
+    Dictionary Should Contain Key    ${obj}    rows
+    Should Not Be Empty    ${obj['rows']}
+
+MCP HTTP Pull Provider Installs Known Provider
+    [Documentation]    Issue #661 feature 2: pull_provider must successfully install a
+    ...                known provider and return a timestamp.  Allowed under every mode
+    ...                (writes only local approot state).
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    Sleep         5s
+    ${result}=    Run Process          ${STACKQL_MCP_CLIENT_EXE}
+    ...                  exec
+    ...                  \-\-client\-type\=http
+    ...                  \-\-url\=http://127.0.0.1:9912
+    ...                  \-\-exec.action      pull_provider
+    ...                  \-\-exec.args        {"provider":"local_openssl"}
+    ...                  stdout=${CURDIR}${/}tmp${/}MCP-PullProvider.txt
+    ...                  stderr=${CURDIR}${/}tmp${/}MCP-PullProvider-stderr.txt
+    Should Be Equal As Integers    ${result.rc}    0
+    ${obj}=    Parse MCP JSON Output    ${result.stdout}
+    Dictionary Should Contain Key    ${obj}    timestamp
+
 MCP HTTP Audit Disabled Writes No File
     [Documentation]    The 9912 server has audit.disabled=true.  Running a query should not
     ...                produce any audit log file in cwd.  We assert by listing cwd before and


### PR DESCRIPTION
Closes #661.

- Fix 1: extractQueryResults now returns (rv, ok); zero-row results are valid and no longer mis-reported as extraction failures.
- Fix 2: refactored render.unwrap as a reflection-based helper (cognitive complexity ~11, well under the 20 gocognit threshold) applied in dataRow and the RenderKV loop.  sql.Null* wrappers (and pointers to them) render as scalars; invalid wrappers collapse to "" matching the reverse-proxy backend's zero-value substitution.
- New tool list_registry: providers/versions available in the registry, distinct from list_providers (which lists only pulled providers).
- New tool pull_provider (singular): installs a single provider into the approot cache.  Allowed under every mode (writes only local state).


## Description

<!-- Please provide a description of the change(s) implemented. -->

## Type of change

- [ ] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [ ] Other (eg: documentation change).  **Please explain**.

## Issues referenced.

<!-- Please add deep links to any issues impacted by this PR. -->

## Evidence

<!-- Please add evidence (eg: test results, screen captures) that the changes are fit for purpose. -->

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [ ] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [ ] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

<!-- Please add fulsome explanations for any variations to the checklist. -->

## Tech Debt

<!-- If zero technical debt results from this change set, then please assert same here.  If, however, technical debt does result from this change set (the **strong** preference is that it does **not**), then please specify and justify.  Once assent is given in the PR conversation for the tech debt to be accrued, please include a link to an issue devoted to the tech debt, in the above issues section.  This should be done prior to merge. -->
