### PR TITLE
Add MCP surface fuzz pass to CI

### DIFF
--- a/.github/workflows/mcp-fuzz.yml
+++ b/.github/workflows/mcp-fuzz.yml
@@ -1,0 +1,41 @@
+name: MCP Fuzz
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - version*
+
+jobs:
+  mcp-fuzz:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4.1.1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: '1.25.3'
+          cache: true
+
+      - name: Pull mcp-fuzzer image
+        run: docker pull princekrroshan01/mcp-fuzzer:v0.4.0
+
+      - name: Run MCP surface fuzz pass
+        run: bash scripts/fuzz-mcp-surface.sh
+        env:
+          MCP_FUZZER_IMAGE: princekrroshan01/mcp-fuzzer:v0.4.0
+          MCP_FUZZ_RUNS: 2
+          MCP_FUZZ_TIMEOUT: 20
+
+      - name: Upload fuzz report
+        if: always()
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: mcp-fuzz-report
+          path: fuzz-output/
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ mcp-audit-*.log
 
 ## Generic sink default name (used by pkg/sink tests / non-MCP callers)
 sink_*.log
+
+fuzz-output/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Common commands (run from repo root):
 - Unit tests: `python cicd/python/build.py --test` (CI uses `go test -timeout 1200s --tags "sqlite_stackql" -v ./...`).
 - Robot tests: `python cicd/python/build.py --robot-test` (requires the binary from the build step).
 - Lint: `golangci-lint run` (CI pins the version in [`.github/workflows/lint.yml`](/.github/workflows/lint.yml); config in [`.golangci.yml`](/.golangci.yml)).
+- MCP fuzz (local): `bash scripts/fuzz-mcp-surface.sh` (see [docs/mcp-fuzz.md](/docs/mcp-fuzz.md)).
 
 ## Coding Style & Naming Conventions
 

--- a/docs/mcp-fuzz.md
+++ b/docs/mcp-fuzz.md
@@ -1,0 +1,33 @@
+# MCP security fuzzing
+
+StackQL exposes MCP over streamable HTTP (see [docs/mcp.md](mcp.md)). This repo includes a lightweight fuzz fixture and script that exercise the MCP tool surface without cloud credentials.
+
+## Local run
+
+```bash
+bash scripts/fuzz-mcp-surface.sh
+```
+
+Reports land in `./fuzz-output/`. Override behavior with environment variables:
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `MCP_FUZZER_IMAGE` | `princekrroshan01/mcp-fuzzer:v0.4.0` | Docker image tag |
+| `MCP_FUZZ_RUNS` | `3` | Fuzz iterations per tool |
+| `MCP_FUZZ_TIMEOUT` | `30` | Per-request timeout (seconds) |
+| `MCP_FUZZ_PORT` | `19992` | Fixture listen port |
+| `MCP_FUZZ_OUTPUT` | `./fuzz-output` | Host directory mounted at `/output` |
+
+The fixture (`scripts/fuzz_mcp_fixture/`) boots `pkg/mcp_server` over HTTP in `read_only` mode with representative tool responses so `mcp-fuzzer` can list and call the canonical StackQL MCP tools (`server_info`, `list_providers`, query tools, etc.).
+
+## CI
+
+The `mcp-fuzz` workflow (`.github/workflows/mcp-fuzz.yml`) runs on pull requests and pushes to `main` / `version*`, uploading `fuzz-output/` as an artifact with a smaller run budget (`MCP_FUZZ_RUNS=2`).
+
+## What gets exercised
+
+- Streamable HTTP transport in `pkg/mcp_server/server.go`
+- Tool registration, rendering, and mode gating (`read_only` fixture)
+- MCP query-tool argument handling (`validate_select_query`, `run_select_query`, hierarchy tools)
+
+This is a smoke-level pass on the MCP server package, not a substitute for robot tests against a full `stackql mcp` deployment with live provider mocks.

--- a/scripts/fuzz-mcp-surface.sh
+++ b/scripts/fuzz-mcp-surface.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Start the MCP fuzz fixture and run mcp-fuzzer against the streamable HTTP surface.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FUZZ_IMAGE="${MCP_FUZZER_IMAGE:-princekrroshan01/mcp-fuzzer:v0.4.0}"
+FUZZ_RUNS="${MCP_FUZZ_RUNS:-3}"
+FUZZ_TIMEOUT="${MCP_FUZZ_TIMEOUT:-30}"
+FUZZ_PORT="${MCP_FUZZ_PORT:-19992}"
+OUTPUT_DIR="${MCP_FUZZ_OUTPUT:-$ROOT/fuzz-output}"
+SERVER_LOG="${TMPDIR:-/tmp}/stackql-fuzz-server-$$.log"
+
+mkdir -p "$OUTPUT_DIR"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -f "$SERVER_LOG"
+}
+trap cleanup EXIT
+
+echo "starting StackQL MCP fuzz fixture on port ${FUZZ_PORT}..."
+MCP_FUZZ_PORT="$FUZZ_PORT" go run ./scripts/fuzz_mcp_fixture/ >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+READY_JSON=""
+for _ in $(seq 1 60); do
+  if READY_JSON="$(grep -E '^\{.*"endpoint".*\}$' "$SERVER_LOG" 2>/dev/null | tail -1)"; then
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "fuzz fixture server exited before ready:" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ -z "$READY_JSON" ]]; then
+  echo "timed out waiting for fuzz fixture server (60s)" >&2
+  cat "$SERVER_LOG" >&2
+  exit 1
+fi
+
+MCP_ENDPOINT="$(node -e 'console.log(JSON.parse(process.argv[1]).endpoint)' "$READY_JSON")"
+echo "mcp endpoint: $MCP_ENDPOINT"
+
+DOCKER_ARGS=(--rm)
+if [[ "$(uname -s)" == "Linux" ]]; then
+  DOCKER_ARGS+=(--network host)
+else
+  MCP_ENDPOINT="${MCP_ENDPOINT//localhost/host.docker.internal}"
+  MCP_ENDPOINT="${MCP_ENDPOINT//127.0.0.1/host.docker.internal}"
+fi
+
+echo "pulling $FUZZ_IMAGE"
+docker pull "$FUZZ_IMAGE"
+
+echo "running mcp-fuzzer (runs=$FUZZ_RUNS timeout=${FUZZ_TIMEOUT}s)"
+docker run "${DOCKER_ARGS[@]}" \
+  -v "$OUTPUT_DIR:/output:rw" \
+  "$FUZZ_IMAGE" \
+  --mode all \
+  --protocol streamablehttp \
+  --endpoint "$MCP_ENDPOINT" \
+  --auth-audit \
+  --security-audit \
+  --fail-if-no-tools \
+  --runs "$FUZZ_RUNS" \
+  --timeout "$FUZZ_TIMEOUT" \
+  --output-dir /output
+
+echo "fuzz complete; reports in $OUTPUT_DIR"

--- a/scripts/fuzz_mcp_fixture/main.go
+++ b/scripts/fuzz_mcp_fixture/main.go
@@ -1,0 +1,124 @@
+// Boot a streamable HTTP MCP server with the pkg/mcp_server example backend for
+// mcp-fuzzer smoke tests. Prints one JSON line with the endpoint, then blocks.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/stackql/stackql/pkg/mcp_server"
+	"github.com/stackql/stackql/pkg/mcp_server/dto"
+)
+
+type fuzzBackend struct{}
+
+func (fuzzBackend) Ping(context.Context) error { return nil }
+func (fuzzBackend) Close() error               { return nil }
+
+func (fuzzBackend) ServerInfo(context.Context, any) (dto.ServerInfoOutput, error) {
+	return dto.ServerInfoOutput{
+		Version:          "fuzz-fixture",
+		Commit:           "local",
+		Platform:         "fuzz/ci",
+		Transport:        "http",
+		SQLBackend:       "sqlite3",
+		ProviderRegistry: "test://registry-mocked",
+		ReadOnly:         true,
+	}, nil
+}
+
+func (fuzzBackend) ListProviders(context.Context) ([]map[string]any, error) {
+	return []map[string]any{
+		{"name": "google", "version": "v25.11.00355"},
+		{"name": "github", "version": "v25.07.00320"},
+	}, nil
+}
+
+func (fuzzBackend) ListServices(context.Context, dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{{"id": "compute:v1", "name": "compute", "title": "Compute Engine API"}}, nil
+}
+
+func (fuzzBackend) ListResources(context.Context, dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{{"name": "networks"}}, nil
+}
+
+func (fuzzBackend) ListMethods(context.Context, dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{
+		{"MethodName": "list", "RequiredParams": "project", "SQLVerb": "SELECT"},
+	}, nil
+}
+
+func (fuzzBackend) DescribeResource(context.Context, dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{{"name": "name", "type": "string"}}, nil
+}
+
+func (fuzzBackend) DescribeMethod(context.Context, dto.HierarchyInput) ([]map[string]any, error) {
+	return []map[string]any{{"name": "project", "type": "string", "param_type": "input_required"}}, nil
+}
+
+func (fuzzBackend) ValidateQuery(context.Context, string) ([]map[string]any, error) {
+	return []map[string]any{}, nil
+}
+
+func (fuzzBackend) RunQueryJSON(context.Context, dto.QueryJSONInput) ([]map[string]any, error) {
+	return []map[string]any{{"name": "fuzz-network"}}, nil
+}
+
+func (fuzzBackend) ExecQuery(context.Context, string) (map[string]any, error) {
+	return map[string]any{"messages": []string{"ok"}}, nil
+}
+
+func (fuzzBackend) ListRegistry(context.Context, dto.RegistryInput) ([]map[string]any, error) {
+	return []map[string]any{}, nil
+}
+
+func (fuzzBackend) PullProvider(context.Context, dto.RegistryInput) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
+func main() {
+	port := os.Getenv("MCP_FUZZ_PORT")
+	if port == "" {
+		port = "19992"
+	}
+	address := "127.0.0.1:" + port
+	endpoint := "http://" + address
+
+	cfg := mcp_server.DefaultHTTPConfig()
+	cfg.Server.Address = address
+	cfg.Server.Mode = "read_only"
+	cfg.Server.Audit.Disabled = true
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	server, err := mcp_server.NewAgnosticBackendServer(fuzzBackend{}, cfg, logger)
+	if err != nil {
+		log.Fatalf("create mcp server: %v", err)
+	}
+
+	out, err := json.Marshal(map[string]string{"endpoint": endpoint, "address": address})
+	if err != nil {
+		log.Fatalf("marshal ready json: %v", err)
+	}
+	fmt.Println(string(out))
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	go func() {
+		if startErr := server.Start(ctx); startErr != nil && ctx.Err() == nil {
+			log.Fatalf("mcp server exited: %v", startErr)
+		}
+	}()
+
+	<-ctx.Done()
+	_ = server.Stop()
+}


### PR DESCRIPTION
## Summary

- Add `bash scripts/fuzz-mcp-surface.sh` to boot a streamable HTTP MCP fixture and run [mcp-fuzzer](https://github.com/Agent-Hellboy/mcp-server-fuzzer) against the canonical StackQL tool surface
- Fixture in `scripts/fuzz_mcp_fixture/` uses `pkg/mcp_server` in `read_only` mode with representative tool responses (no cloud credentials)
- Add `mcp-fuzz` workflow that uploads `fuzz-output/` and pins `princekrroshan01/mcp-fuzzer:v0.4.0`
- Document usage in `docs/mcp-fuzz.md`

The pass exercises MCP tool registration, query-tool argument handling, and streamable HTTP transport in `pkg/mcp_server`. It is a smoke-level check, not a replacement for robot tests against a full `stackql mcp` deployment with provider mocks.

## Evidence

Local verification (2026-06-19):

- `go build ./scripts/fuzz_mcp_fixture/` — OK
- `docker pull princekrroshan01/mcp-fuzzer:v0.4.0` — OK
- `MCP_FUZZ_RUNS=2 MCP_FUZZ_TIMEOUT=25 bash scripts/fuzz-mcp-surface.sh` — OK
- Endpoint: `http://127.0.0.1:19992` (streamable HTTP)
- All 11 canonical MCP tools discovered and fuzzed (`--fail-if-no-tools` passed)
- Report artifact: `fuzz-output/findings.json`

## Test plan

- [x] Fixture builds and fuzz script completes locally
- [ ] CI `mcp-fuzz` job green on this PR

## Checklist variations

- Robot tests not added: this is optional security smoke tooling layered on `pkg/mcp_server`, not a change to query execution behavior covered by existing robot suites.