### PR TITLE
Install doc updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ on:
       - 'test-get-app.sh'
       - 'packaging/**'
       - '.github/workflows/mcp-packaging.yml'
+      - '.github/workflows/mcp-registry-publish.yml'
   pull_request:
     branches:
       - main
@@ -49,6 +50,7 @@ on:
       - 'test-get-app.sh'
       - 'packaging/**'
       - '.github/workflows/mcp-packaging.yml'
+      - '.github/workflows/mcp-registry-publish.yml'
 env:
   GOTESTCMD: "go test -timeout 1200s --tags \"sqlite_stackql\" -v ./..."
   TESTSCRIPT: "test/deprecated/python/main.py"

--- a/.github/workflows/mcp-packaging.yml
+++ b/.github/workflows/mcp-packaging.yml
@@ -6,7 +6,9 @@
 # push tag -> create release -> attach signed assets -> dispatch.
 # The npm / PyPI wrappers need interactive (2FA) credentials and are
 # published from a local clone - see step 7 of docs/stackql release process.md.
-# The MCP Registry entry is published here via GitHub Actions OIDC (no secret).
+# The MCP Registry entry is published LAST, via the separate
+# mcp-registry-publish workflow: the registry validates that the npm/PyPI/OCI
+# packages already exist at the exact version, so it cannot run from here.
 
 name: mcp-packaging
 
@@ -223,36 +225,3 @@ jobs:
           echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker buildx create --use
           make oci-push VERSION=${{ needs.version.outputs.version }}
-
-  # Publish server.json to the Official MCP Registry.  Auth is GitHub Actions
-  # OIDC: the registry grants io.github.<repository_owner>/* to OIDC tokens,
-  # so no secret is needed - just id-token: write.  Runs after 'publish' and
-  # renders from the RELEASE .sha256 assets (not run artifacts) because the
-  # sign step regenerates checksums before upload.
-  registry-publish:
-    name: publish to MCP registry
-    if: needs.version.outputs.is_publish == 'true'
-    needs: [version, publish]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-      - name: Fetch published bundle checksums from the release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p dist
-          gh release download "v${{ needs.version.outputs.version }}" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern 'stackql-mcp-*.mcpb.sha256' \
-            --dir dist
-      - name: Install mcp-publisher
-        run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
-          sudo install -m 0755 mcp-publisher /usr/local/bin/mcp-publisher
-      - name: Login (GitHub Actions OIDC)
-        run: mcp-publisher login github-oidc
-      - name: Publish
-        run: make registry-publish VERSION=${{ needs.version.outputs.version }}

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,66 @@
+# Publishes the Official MCP Registry entry (io.github.stackql/stackql-mcp)
+# for a released version.  This is the FINAL publish step of a release: the
+# registry validates every package entry in server.json against its upstream
+# registry at the exact version, so the .mcpb release assets, the OCI image
+# (mcp-packaging), and the npm + PyPI wrappers (manual, 2FA) must ALL be live
+# before this runs.  Dispatch it after steps 7a/7b of
+# docs/stackql release process.md.
+#
+# Auth is GitHub Actions OIDC: the registry grants io.github.<owner>/* to
+# OIDC tokens from this repo's workflows, so no secret is required.
+
+name: mcp-registry-publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: stackql release version without the leading v (e.g. 0.10.559); the .mcpb assets, OCI image, npm and PyPI wrappers must already be published
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: packaging/mcpb
+
+jobs:
+  registry-publish:
+    name: publish to MCP registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Preflight - verify all upstream vectors are live
+        working-directory: .
+        run: |
+          v="${{ inputs.version }}"
+          fail=0
+          curl -fsSL "https://registry.npmjs.org/@stackql/mcp-server/$v" >/dev/null \
+            || { echo "::error::npm @stackql/mcp-server@$v not published (release doc step 7a)"; fail=1; }
+          curl -fsSL "https://pypi.org/pypi/stackql-mcp-server/$v/json" >/dev/null \
+            || { echo "::error::PyPI stackql-mcp-server $v not published (release doc step 7b)"; fail=1; }
+          docker manifest inspect "docker.io/stackql/stackql-mcp:$v" >/dev/null \
+            || { echo "::error::OCI image stackql/stackql-mcp:$v not on Docker Hub (mcp-packaging oci-publish job)"; fail=1; }
+          exit $fail
+      - name: Fetch published bundle checksums from the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          gh release download "v${{ inputs.version }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'stackql-mcp-*.mcpb.sha256' \
+            --dir dist
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          sudo install -m 0755 mcp-publisher /usr/local/bin/mcp-publisher
+      - name: Login (GitHub Actions OIDC)
+        run: mcp-publisher login github-oidc
+      - name: Publish
+        run: make registry-publish VERSION=${{ inputs.version }}

--- a/docs/stackql release process.md
+++ b/docs/stackql release process.md
@@ -54,7 +54,9 @@ Invoke the `mcp-packaging` workflow in [stackql/stackql](https://github.com/stac
 
 7. Publish the MCP wrapper packages (manual last mile)
 
-The `mcp-packaging` workflow attaches the `.mcpb` bundles (and `.sha256` files) to the release, pushes the multi-arch OCI image to Docker Hub, and publishes the Official MCP Registry entry (via GitHub Actions OIDC - see 7c) automatically. Only the npm and PyPI wrappers need interactive (2FA) credentials, so they cannot be automated end to end and are published from a local clone using the steps below (a Linux/WSL/macOS shell, from the repo root).
+The `mcp-packaging` workflow attaches the `.mcpb` bundles (and `.sha256` files) to the release and pushes the multi-arch OCI image to Docker Hub automatically. The npm and PyPI wrappers need interactive (2FA) credentials, so they are published from a local clone using the steps below (a Linux/WSL/macOS shell, from the repo root). The MCP Registry entry is then published by dispatching the `mcp-registry-publish` workflow (7c).
+
+Order matters and is strictly one-way: 7a and 7b (either order) only after step 6 completes, and 7c strictly last. The registry validates every package entry in server.json against its upstream registry at the exact version when publishing - if the npm or PyPI wrapper (or the OCI image) for the version is not live yet, the registry publish is rejected. There is no cycle: nothing references the registry entry, it references everything else.
 
 The render targets (`make npm-pack` / `make pypi-build`) consume the published `.sha256` release assets, so run them only after step 6 completes. The renderers also stamp the version into `packaging/mcpb/npm/package.json` and `packaging/mcpb/pypi/pyproject.toml` in place - commit or revert the stamps afterwards.
 
@@ -82,9 +84,11 @@ python -m twine check pypi/dist/*
 python -m twine upload pypi/dist/*
 ```
 
-7c. Official MCP Registry (`io.github.stackql/stackql-mcp`) - automated, manual fallback below
+7c. Official MCP Registry (`io.github.stackql/stackql-mcp`) - dispatch last
 
-The `registry-publish` job in `mcp-packaging.yml` publishes this automatically: it authenticates with `mcp-publisher login github-oidc` (the registry grants `io.github.<repository_owner>/*` to GitHub Actions OIDC tokens, so no secret is needed) and renders server.json from the release `.sha256` assets. Nothing to do unless the job fails or an out-of-band publish is needed - in that case, the manual procedure:
+After 7a and 7b are live, dispatch the `mcp-registry-publish` workflow in [stackql/stackql](https://github.com/stackql/stackql) with the version. It needs no credentials: it authenticates with `mcp-publisher login github-oidc` (the registry grants `io.github.<repository_owner>/*` to GitHub Actions OIDC tokens, so no secret is stored) and renders server.json from the release `.sha256` assets. A preflight step fails fast with a pointer to the missing step if the npm, PyPI or OCI package for the version is not yet live.
+
+Manual fallback (if the workflow fails or an out-of-band publish is needed):
 
 Requires the latest `mcp-publisher` CLI and a classic GitHub PAT (scope `read:org` only, no repo scopes) created by a `stackql` org Owner at https://github.com/settings/tokens/new. The server.json renderer reads the four `.sha256` files from the local `dist/` directory, so download the published checksum files from the release first.
 

--- a/packaging/mcpb/npm/package.json
+++ b/packaging/mcpb/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackql/mcp-server",
-  "version": "0.10.500",
+  "version": "0.10.559",
   "description": "StackQL MCP server - SQL-native query and provisioning engine for cloud infrastructure, served over MCP. Downloads the signed stackql binary on first run.",
   "bin": {
     "stackql-mcp": "bin/stackql-mcp.js"

--- a/packaging/mcpb/pypi/pyproject.toml
+++ b/packaging/mcpb/pypi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stackql-mcp-server"
-version = "0.10.557"
+version = "0.10.559"
 description = "StackQL MCP server - SQL-native query and provisioning engine for cloud infrastructure, served over MCP. Downloads the signed stackql binary on first run."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Description

The Official MCP Registry validates every `server.json` package entry against its upstream registry at the exact version being published. The `registry-publish` job added in #690 ran inside `mcp-packaging` - before the manual npm/PyPI wrapper publishes exist and racing the `oci-publish` job - so it fails for every fresh release (confirmed on the v0.10.559 dispatch).

This PR makes registry publication the explicit final step of a release:

- New standalone `workflow_dispatch` workflow `.github/workflows/mcp-registry-publish.yml`, dispatched after the npm/PyPI wrappers are live. Auth is GitHub Actions OIDC (the registry grants `io.github.<repository_owner>/*` to OIDC tokens from this repo), so no secret is stored. A preflight step checks npm, PyPI and Docker Hub for the target version and fails fast with a pointer to the missing release-process step.
- The mis-ordered `registry-publish` job is removed from `mcp-packaging.yml`.
- `docs/stackql release process.md` step 7 rewritten: strict one-way publish order (bundles/OCI -> wrappers -> registry entry last), 7c as a dispatch, manual PAT fallback retained with the gotchas hit during the v0.10.557/v0.10.559 releases.
- New workflow added to `build.yml` `paths-ignore` (both triggers).
- v0.10.559 wrapper version stamps (`npm/package.json`, `pypi/pyproject.toml`), matching the published packages.

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).
- [ ] Feature (non-breaking change to add functionality).
- [ ] Breaking change.
- [x] Other (eg: documentation change).  **Please explain**. Release-process documentation updated to match the corrected publish ordering; no engine or query behaviour is touched.

## Issues referenced.

None. The defect was introduced in #690 and observed on the v0.10.559 publish dispatch (see Evidence) before any issue was raised.

## Evidence

- Failing run demonstrating the ordering defect: https://github.com/stackql/stackql/actions/runs/29893367438/job/88838670927 (registry rejects the publish because `@stackql/mcp-server@0.10.559` / `stackql-mcp-server 0.10.559` did not yet exist upstream).
- The exact sequence the new workflow encodes was executed manually end to end for v0.10.559 and succeeded, registry last:
  - npm: https://www.npmjs.com/package/@stackql/mcp-server/v/0.10.559
  - PyPI: https://pypi.org/project/stackql-mcp-server/0.10.559/
  - MCP Registry (0.10.559 active/latest): https://registry.modelcontextprotocol.io/v0/servers?search=io.github.stackql/stackql-mcp
- OIDC auth path, latest-CLI install and release-checksum rendering were each proven in CI by the failed run (all steps green up to the registry's version validation, which this PR re-orders around).

## Checklist:

- [ ] A full round of testing has been completed, and there are no test failures as a result of these changes.
- [ ] The changes are covered with functional and/or integration robot testing.
- [ ] The changes work on all supported platforms.
- [ ] Unit tests pass locally, as per [the developer guide](/docs/developer_guide.md#unit-tests).
- [ ] Robot tests pass locally, as per [the developer guide](/docs/developer_guide.md#robot-tests).
- [ ] Linter passes locally, as per [the developer guide](/docs/developer_guide.md#linting).

### Variations

The diff is CI workflow + documentation + wrapper version stamps only: no Go code, no query surface, no packaged artefact content. Unit/robot/lint runs exercise none of these paths, and the touched paths are all under `build.yml` `paths-ignore`, so the checklist items above are not applicable. Fitness for purpose is evidenced by the manual end-to-end execution of the encoded sequence for v0.10.559 (Evidence section). The new workflow's first CI execution will be the next release; the manual fallback in doc step 7c remains available if it misbehaves.

## Tech Debt

No new technical debt. The npm and PyPI publishes remain manual - that is an inherent 2FA constraint of those registries, pre-existing and now accurately documented rather than papered over by CI jobs that could never succeed (three such jobs were removed in #690/this change). The registry step, which was the newly-introduced debt in #690, is resolved here by correct ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
