### PR TITLE
feat: add local ChatGPT and Codex stdio plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "stackql",
+  "interface": {
+    "displayName": "StackQL"
+  },
+  "plugins": [
+    {
+      "name": "stackql",
+      "source": {
+        "source": "local",
+        "path": "./packaging/openai-plugin/plugins/stackql"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.github/workflows/openai-plugin.yml
+++ b/.github/workflows/openai-plugin.yml
@@ -1,0 +1,63 @@
+name: openai-stdio-plugin
+
+on:
+  pull_request:
+    paths:
+      - '.agents/plugins/marketplace.json'
+      - 'packaging/openai-plugin/**'
+      - '.github/workflows/openai-plugin.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: stdio smoke (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: python3
+            binary: stackql-plugin-smoke
+          - os: macos-latest
+            python: python3
+            binary: stackql-plugin-smoke
+          - os: windows-latest
+            python: python
+            binary: stackql-plugin-smoke.exe
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Configure Windows C toolchain
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $mingwPath = 'C:\mingw64'
+          if (-not (Test-Path $mingwPath)) {
+            $mingwPath = 'C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64'
+          }
+          if (-not (Test-Path $mingwPath)) {
+            throw 'MinGW toolchain not found'
+          }
+          "$mingwPath\bin" | Out-File $env:GITHUB_PATH -Append
+          "CC=$mingwPath\bin\x86_64-w64-mingw32-gcc" | Out-File $env:GITHUB_ENV -Append
+          "CXX=$mingwPath\bin\x86_64-w64-mingw32-g++" | Out-File $env:GITHUB_ENV -Append
+      - name: Build StackQL
+        env:
+          CGO_ENABLED: '1'
+        run: go build --tags sqlite_stackql -o ${{ matrix.binary }} ./stackql
+      - name: Validate package
+        run: ${{ matrix.python }} packaging/openai-plugin/scripts/validate.py
+      - name: Test stdio connector
+        env:
+          STACKQL_MCP_BIN: ${{ github.workspace }}/${{ matrix.binary }}
+        run: ${{ matrix.python }} packaging/openai-plugin/scripts/smoke-test.py

--- a/docs/chatgpt-codex-plugin.md
+++ b/docs/chatgpt-codex-plugin.md
@@ -1,0 +1,70 @@
+# StackQL local plugin for ChatGPT and Codex
+
+The StackQL plugin runs the existing StackQL MCP server as a local process over
+stdio. ChatGPT desktop or Codex starts the process, and provider credentials
+remain on the user's machine.
+
+Supported clients:
+
+- ChatGPT desktop app
+- Codex CLI
+
+ChatGPT web cannot run a local stdio server. Plugins are not available in the
+Codex IDE extension.
+
+## Install
+
+Install Node.js 18 or later, then run:
+
+```shell
+codex plugin marketplace add stackql/stackql --sparse .agents/plugins --sparse packaging/openai-plugin
+codex plugin add stackql@stackql
+```
+
+Restart ChatGPT desktop or Codex. In Codex CLI, use `/plugins` to confirm the
+plugin is installed and `/mcp` to confirm that the `stackql` server is active.
+
+The plugin launches a pinned `@stackql/mcp-server` package. On first use, the
+package downloads the matching StackQL binary, verifies the published SHA-256,
+and caches it under `~/.stackql/mcp-server-bin`.
+
+## Hello world
+
+Start a new ChatGPT desktop or Codex session and enter:
+
+```text
+Use StackQL to install the GitHub provider if needed, then list the first five GitHub services.
+```
+
+The agent should use `pull_provider` followed by `list_services`. No GitHub auth
+block or credential is needed for public data. A successful result includes
+GitHub services such as `actions` or `apps`. All tool calls run through the
+local StackQL process over stdio.
+
+## Provider credentials
+
+The plugin passes these local files to StackQL:
+
+- `~/.stackql/.env` contains provider credential values.
+- `~/.stackql/.stackqlrc` contains optional nonstandard auth configuration.
+
+StackQL creates `.env` on first launch. Providers define standard environment
+variable names, so most users only add values to that file. AWS and AWS Cloud
+Control use:
+
+```dotenv
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+```
+
+No `--auth` configuration is needed for those names. Use `.stackqlrc` only when
+an auth type or credential source differs from the provider defaults.
+
+After changing `.env`, ask the agent to call `reload_credentials`. It re-sources
+the file and reports variable names plus a per-provider status of `ok`,
+`unresolved`, or `not_checked`; it never returns secret values. Restart the
+plugin after changing `.stackqlrc`, because the tool reloads credential values
+but not auth contexts.
+
+See [MCP server documentation](mcp.md) for tools and server modes, and
+[authentication documentation](auth.md) for provider-specific configuration.

--- a/docs/stackql release process.md
+++ b/docs/stackql release process.md
@@ -119,4 +119,20 @@ Gotchas (all hit during the v0.10.557 release):
 - The registry JWT minted at login is short-lived - run `make registry-publish` immediately after `mcp-publisher login github`.
 - Old `mcp-publisher` versions (pre-1.2) drop `.mcpregistry_*` token files in the working directory (gitignored); current versions store the token in `~/.config/mcp-publisher/token.json`.
 
+7d. Update the ChatGPT/Codex stdio plugin
+
+After 7a confirms `@stackql/mcp-server@X.Y.Z` is live, update the local plugin in a follow-up PR:
+
+1. Set `version` in `packaging/openai-plugin/plugins/stackql/.codex-plugin/plugin.json` to `X.Y.Z`.
+2. Set the pinned `@stackql/mcp-server@X.Y.Z` in `packaging/openai-plugin/plugins/stackql/bin/stackql-mcp.js`.
+3. Run:
+
+```
+npm view @stackql/mcp-server@X.Y.Z version
+python3 packaging/openai-plugin/scripts/validate.py
+python3 packaging/openai-plugin/scripts/smoke-test.py
+```
+
+The marketplace entry is version-independent. This step does not change the MCPB, Anthropic, PyPI, OCI, or MCP Registry artifacts. See `packaging/mcpb/README.md` for the detailed addendum.
+
 8. Push the same release version tag to [stackql/releases.stackql.io](https://github.com/stackql/releases.stackql.io)

--- a/internal/stackql/mcpbackend/credential_reload.go
+++ b/internal/stackql/mcpbackend/credential_reload.go
@@ -89,7 +89,10 @@ func (b *stackqlMCPService) ReloadCredentials(
 	_ context.Context,
 	input mcp_dto.CredentialsReloadInput,
 ) (mcp_dto.CredentialsReloadDTO, error) {
-	rv := mcp_dto.CredentialsReloadDTO{EnvFile: b.envFile}
+	rv := mcp_dto.CredentialsReloadDTO{
+		EnvFile:   b.envFile,
+		Providers: []mcp_dto.ProviderCredentialStatusDTO{},
+	}
 	sourcedVars, sourced, err := envfile.Source(b.envFile)
 	if err != nil {
 		return rv, fmt.Errorf("failed to source env file '%s': %w", b.envFile, err)

--- a/packaging/mcpb/README.md
+++ b/packaging/mcpb/README.md
@@ -414,6 +414,31 @@ python3 scripts/smoke-test.py --docker stackql/stackql-mcp:X.Y.Z
 For future tagged releases, set the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
 repo secrets and the publish workflow pushes the image automatically.
 
+## Updating the ChatGPT/Codex stdio plugin
+
+The local plugin under `packaging/openai-plugin` is an addendum to this release
+flow. It launches the npm wrapper over stdio and does not change the MCPB,
+Anthropic submission, PyPI, OCI, or MCP Registry artifacts.
+
+Update it only after `@stackql/mcp-server@X.Y.Z` is published:
+
+1. Set `version` in
+   `packaging/openai-plugin/plugins/stackql/.codex-plugin/plugin.json` to
+   `X.Y.Z`.
+2. Set the pinned `@stackql/mcp-server@X.Y.Z` in
+   `packaging/openai-plugin/plugins/stackql/bin/stackql-mcp.js`.
+3. From the repository root, run:
+
+```bash
+npm view @stackql/mcp-server@X.Y.Z version
+python3 packaging/openai-plugin/scripts/validate.py
+python3 packaging/openai-plugin/scripts/smoke-test.py
+```
+
+The plugin workflow repeats validation and the stdio smoke test on Linux,
+macOS, and Windows. The marketplace entry is version-independent and should
+not change for a routine StackQL release.
+
 ## Makefile reference
 
 ```

--- a/packaging/openai-plugin/README.md
+++ b/packaging/openai-plugin/README.md
@@ -1,0 +1,66 @@
+# StackQL local plugin for ChatGPT and Codex
+
+This package installs StackQL as a local MCP stdio server for the ChatGPT
+desktop app and Codex CLI. It does not expose an HTTP service or send StackQL
+credentials to StackQL Studios.
+
+The plugin launches the pinned `@stackql/mcp-server` npm wrapper. That wrapper
+selects the host platform, downloads the matching StackQL MCPB release,
+verifies its SHA-256, and starts `stackql mcp --mcp.server.type=stdio`.
+
+## Install from this repository
+
+Node.js 18 or later is required.
+
+```shell
+codex plugin marketplace add stackql/stackql --sparse .agents/plugins --sparse packaging/openai-plugin
+codex plugin add stackql@stackql
+```
+
+Restart the ChatGPT desktop app or Codex after installation. The plugin is
+also available automatically as a repo marketplace when working in this
+repository.
+
+ChatGPT web cannot run local stdio MCP servers, and plugins are not available
+in the Codex IDE extension. Public directory submission requires a remote HTTPS
+MCP server and is outside this package's scope.
+
+## Provider authentication
+
+The launcher uses these existing StackQL configuration files:
+
+- `~/.stackql/.env` for provider credential values
+- `~/.stackql/.stackqlrc` for optional nonstandard auth configuration
+
+Providers define their standard environment variable names. No auth block is
+needed when those names are used. For example, AWS and AWS Cloud Control use:
+
+```dotenv
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+```
+
+GitHub public resources need no auth configuration when no GitHub credential
+environment variables are set. Use `.stackqlrc` only when an auth type or
+credential source differs from the provider defaults.
+
+StackQL creates `.env` on first launch. The `reload_credentials` MCP tool
+re-sources it without restarting the server. It reports variable names and a
+per-provider status of `ok`, `unresolved`, or `not_checked`, but never returns
+secret values. Restart after changing optional auth configuration in
+`.stackqlrc`, because `reload_credentials` reloads values but not auth contexts.
+
+## Validate
+
+From the repository root:
+
+```shell
+python packaging/openai-plugin/scripts/validate.py
+python packaging/openai-plugin/scripts/smoke-test.py
+```
+
+The smoke test exercises the plugin entrypoint, MCP initialization, tool
+discovery, provider download, and a provider query over stdio.
+
+For a release update, change the version in `plugin.json` and the pinned npm
+package in `bin/stackql-mcp.js` after that npm version is published.

--- a/packaging/openai-plugin/plugins/stackql/.codex-plugin/plugin.json
+++ b/packaging/openai-plugin/plugins/stackql/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "stackql",
+  "version": "0.10.582",
+  "description": "Query and manage cloud infrastructure with StackQL over a local MCP stdio server.",
+  "author": {
+    "name": "StackQL Studios",
+    "url": "https://stackql.io"
+  },
+  "homepage": "https://stackql.io",
+  "repository": "https://github.com/stackql/stackql",
+  "license": "MIT",
+  "keywords": [
+    "stackql",
+    "mcp",
+    "sql",
+    "cloud",
+    "infrastructure"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "StackQL",
+    "shortDescription": "Query and manage cloud infrastructure with SQL",
+    "longDescription": "Use StackQL locally through MCP to discover providers, query resources, and manage cloud infrastructure with SQL. Credentials remain in the user's local StackQL environment and the MCP server communicates over stdio.",
+    "developerName": "StackQL Studios",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://stackql.io",
+    "privacyPolicyURL": "https://stackql.io/privacy",
+    "defaultPrompt": [
+      "List the cloud providers available through StackQL.",
+      "Use StackQL to inventory resources in my cloud account.",
+      "Use StackQL to investigate configuration drift in my cloud environment."
+    ]
+  }
+}

--- a/packaging/openai-plugin/plugins/stackql/.mcp.json
+++ b/packaging/openai-plugin/plugins/stackql/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "stackql": {
+      "command": "node",
+      "args": [
+        "./bin/stackql-mcp.js"
+      ],
+      "cwd": "."
+    }
+  }
+}

--- a/packaging/openai-plugin/plugins/stackql/bin/stackql-mcp.js
+++ b/packaging/openai-plugin/plugins/stackql/bin/stackql-mcp.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const { spawn } = require("child_process");
+const os = require("os");
+const path = require("path");
+
+const stackqlRoot =
+  process.env.STACKQL_PLUGIN_CONFIG_DIR || path.join(os.homedir(), ".stackql");
+const args = [
+  "-y",
+  "@stackql/mcp-server@0.10.582",
+  "--approot",
+  stackqlRoot,
+  "--env.file",
+  path.join(stackqlRoot, ".env"),
+  "--configfile",
+  path.join(stackqlRoot, ".stackqlrc"),
+];
+const child = spawn("npx", args, {
+  shell: process.platform === "win32",
+  stdio: "inherit",
+  windowsHide: true,
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    try {
+      child.kill(signal);
+    } catch {}
+  });
+}
+
+child.on("error", (err) => {
+  console.error(`stackql-plugin: ${err.message}`);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  process.exit(signal ? 1 : code === null ? 1 : code);
+});

--- a/packaging/openai-plugin/scripts/smoke-test.py
+++ b/packaging/openai-plugin/scripts/smoke-test.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_ROOT = REPO_ROOT / "packaging" / "openai-plugin" / "plugins" / "stackql"
+SHARED_SMOKE = REPO_ROOT / "packaging" / "mcpb" / "scripts" / "smoke-test.py"
+
+
+def load_shared_smoke():
+    spec = importlib.util.spec_from_file_location("stackql_mcp_smoke", SHARED_SMOKE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {SHARED_SMOKE}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def exercise_plugin(smoke, node: str, launcher: Path) -> None:
+    proc = subprocess.Popen(
+        [node, str(launcher)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    failed = False
+    try:
+        client = smoke.JsonRpcClient(proc)
+        client.send(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "stackql-openai-plugin-smoke", "version": "1"},
+            },
+            id_=1,
+        )
+        if "result" not in client.wait(1, smoke.INIT_TIMEOUT_S):
+            raise RuntimeError("initialize failed")
+        client.send("notifications/initialized", {})
+
+        client.send("tools/list", {}, id_=2)
+        tools = client.wait(2, smoke.CALL_TIMEOUT_S).get("result", {}).get("tools", [])
+        names = {tool["name"] for tool in tools}
+        required = {"reload_credentials", "pull_provider", "list_services"}
+        if not required.issubset(names):
+            raise RuntimeError(f"missing tools: {sorted(required - names)}")
+
+        client.send(
+            "tools/call",
+            {"name": "pull_provider", "arguments": {"provider": "github"}},
+            id_=3,
+        )
+        if "error" in client.wait(3, smoke.CALL_TIMEOUT_S):
+            raise RuntimeError("pull_provider failed")
+
+        client.send(
+            "tools/call",
+            {"name": "list_services", "arguments": {"provider": "github", "row_limit": 5}},
+            id_=4,
+        )
+        services = client.wait(4, smoke.CALL_TIMEOUT_S)
+        if "error" in services:
+            raise RuntimeError(f"list_services failed: {services['error']}")
+        text = "\n".join(
+            block.get("text", "")
+            for block in services.get("result", {}).get("content", [])
+            if isinstance(block, dict)
+        )
+        if "actions" not in text and "apps" not in text:
+            raise RuntimeError("list_services returned no expected GitHub service")
+
+        client.send(
+            "tools/call",
+            {"name": "pull_provider", "arguments": {"provider": "aws"}},
+            id_=5,
+        )
+        if "error" in client.wait(5, smoke.CALL_TIMEOUT_S):
+            raise RuntimeError("pull_provider aws failed")
+
+        client.send(
+            "tools/call",
+            {"name": "list_services", "arguments": {"provider": "aws", "row_limit": 1}},
+            id_=6,
+        )
+        if "error" in client.wait(6, smoke.CALL_TIMEOUT_S):
+            raise RuntimeError("list_services aws failed")
+
+        client.send(
+            "tools/call",
+            {"name": "reload_credentials", "arguments": {}},
+            id_=7,
+        )
+        reload_response = client.wait(7, smoke.CALL_TIMEOUT_S)
+        if "error" in reload_response:
+            raise RuntimeError(f"reload_credentials failed: {reload_response['error']}")
+        structured = reload_response.get("result", {}).get("structuredContent", {})
+        providers = structured.get("providers", [])
+        aws = next((item for item in providers if item.get("provider") == "aws"), None)
+        expected_vars = {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}
+        if not structured.get("env_file_sourced"):
+            raise RuntimeError(f"reload_credentials did not source the env file: {structured}")
+        if not expected_vars.issubset(structured.get("sourced_vars", [])):
+            raise RuntimeError(f"reload_credentials missed AWS variables: {structured}")
+        if aws is None or aws.get("status") != "ok":
+            raise RuntimeError(f"unexpected AWS credential status: {aws}")
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        if proc.stdin and not proc.stdin.closed:
+            proc.stdin.close()
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        if failed and proc.stderr:
+            stderr = proc.stderr.read().decode("utf-8", errors="replace").strip()
+            if stderr:
+                print(stderr, file=sys.stderr)
+
+
+def main() -> None:
+    node = shutil.which("node")
+    if node is None:
+        raise RuntimeError("node is required")
+    launcher = PLUGIN_ROOT / "bin" / "stackql-mcp.js"
+    smoke = load_shared_smoke()
+
+    config_dir_var = "STACKQL_PLUGIN_CONFIG_DIR"
+    original_config_dir = os.environ.get(config_dir_var)
+    try:
+        with tempfile.TemporaryDirectory(prefix="stackql-openai-plugin-") as temp:
+            stackql_root = Path(temp) / ".stackql"
+            stackql_root.mkdir()
+            (stackql_root / ".env").write_text(
+                "AWS_ACCESS_KEY_ID=plugin-smoke-key\n"
+                "AWS_SECRET_ACCESS_KEY=plugin-smoke-secret\n",
+                encoding="utf-8",
+            )
+            os.environ[config_dir_var] = str(stackql_root)
+            exercise_plugin(smoke, node, launcher)
+    finally:
+        if original_config_dir is None:
+            os.environ.pop(config_dir_var, None)
+        else:
+            os.environ[config_dir_var] = original_config_dir
+
+    print("OpenAI stdio plugin smoke test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/openai-plugin/scripts/validate.py
+++ b/packaging/openai-plugin/scripts/validate.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_ROOT = REPO_ROOT / "packaging" / "openai-plugin"
+PLUGIN_ROOT = PACKAGE_ROOT / "plugins" / "stackql"
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as err:
+        raise ValueError(f"{path}: {err}") from err
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate() -> None:
+    marketplace = load_json(REPO_ROOT / ".agents" / "plugins" / "marketplace.json")
+    require(marketplace.get("name") == "stackql", "marketplace name must be stackql")
+    entries = marketplace.get("plugins", [])
+    require(len(entries) == 1, "marketplace must contain one plugin")
+    entry = entries[0]
+    require(entry.get("name") == "stackql", "marketplace plugin name must be stackql")
+    require(entry.get("policy") == {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL",
+    }, "marketplace policy is invalid")
+    source = entry.get("source", {})
+    require(source.get("source") == "local", "plugin source must be local")
+    source_path = (REPO_ROOT / source.get("path", "")).resolve()
+    require(source_path == PLUGIN_ROOT.resolve(), "marketplace source path is invalid")
+
+    manifest = load_json(PLUGIN_ROOT / ".codex-plugin" / "plugin.json")
+    require(manifest.get("name") == PLUGIN_ROOT.name, "manifest name must match its directory")
+    version = manifest.get("version", "")
+    require(re.fullmatch(r"\d+\.\d+\.\d+", version) is not None, "manifest version is invalid")
+    require(manifest.get("mcpServers") == "./.mcp.json", "manifest MCP path is invalid")
+    require(manifest.get("interface", {}).get("category") == entry.get("category"),
+            "manifest and marketplace categories differ")
+
+    mcp = load_json(PLUGIN_ROOT / ".mcp.json")
+    servers = mcp.get("mcpServers", {})
+    require(set(servers) == {"stackql"}, "MCP config must contain only the stackql server")
+    server = servers["stackql"]
+    require(server == {
+        "command": "node",
+        "args": ["./bin/stackql-mcp.js"],
+        "cwd": ".",
+    }, "MCP config must launch the bundled stdio entrypoint")
+
+    launcher = (PLUGIN_ROOT / "bin" / "stackql-mcp.js").read_text(encoding="utf-8")
+    match = re.search(r'"@stackql/mcp-server@(\d+\.\d+\.\d+)"', launcher)
+    require(match is not None, "launcher must pin @stackql/mcp-server")
+    require(match.group(1) == version, "launcher and manifest versions differ")
+    require('"--approot"' in launcher, "launcher must configure the application root")
+    require('"--env.file"' in launcher, "launcher must configure the credential env file")
+    require('"--configfile"' in launcher, "launcher must configure .stackqlrc")
+    require('"--auth"' not in launcher, "launcher must use provider default authentication")
+
+
+if __name__ == "__main__":
+    try:
+        validate()
+    except ValueError as err:
+        print(f"validation failed: {err}", file=sys.stderr)
+        raise SystemExit(1) from err
+    print("OpenAI stdio plugin validation passed")

--- a/test/python/stackql_test_tooling/mcp_stdio_client.py
+++ b/test/python/stackql_test_tooling/mcp_stdio_client.py
@@ -262,6 +262,76 @@ def _tool_result_text(response):
     return "\n".join(parts)
 
 
+def run_stdio_empty_credential_reload_roundtrip(
+    stackql_exe,
+    env_file_path,
+    timeout_seconds=90,
+):
+    """Calls reload_credentials with no explicit auth contexts."""
+    if os.path.exists(env_file_path):
+        os.remove(env_file_path)
+    argv = [
+        stackql_exe,
+        "mcp",
+        "--mcp.server.type=stdio",
+        "--mcp.config",
+        '{"server": {"audit": {"disabled": true}} }',
+        f"--env.file={env_file_path}",
+    ]
+    proc = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    watchdog = threading.Timer(timeout_seconds, proc.kill)
+    watchdog.start()
+    stdout_lines = []
+    stderr = b""
+    reload_response = None
+    try:
+        def send(message):
+            proc.stdin.write(_frame_messages([message], b"\n"))
+            proc.stdin.flush()
+
+        send({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "robot-stdio-harness", "version": "0.1.0"},
+            },
+        })
+        _await_response(proc, 1, stdout_lines)
+        send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        send({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "reload_credentials", "arguments": {}},
+        })
+        reload_response = _await_response(proc, 2, stdout_lines)
+        try:
+            proc.stdin.close()
+        except OSError:
+            pass
+        stdout_lines.append(proc.stdout.read())
+        stderr = proc.stderr.read()
+        proc.wait(timeout=timeout_seconds)
+    finally:
+        watchdog.cancel()
+        if proc.poll() is None:
+            proc.kill()
+    return {
+        "reload": _tool_result_text(reload_response),
+        "stdout": b"".join(stdout_lines).decode("utf-8", errors="replace"),
+        "stderr": stderr.decode("utf-8", errors="replace"),
+        "returncode": proc.returncode,
+    }
+
+
 def run_stdio_credential_reload_roundtrip(
     stackql_exe,
     registry_cfg,

--- a/test/robot/functional/mcp.robot
+++ b/test/robot/functional/mcp.robot
@@ -1251,6 +1251,18 @@ MCP HTTP Upstream 404 Returns Empty Result Set
 # --env.file dotenv file via the reload_credentials tool.
 # ===========================================================================
 
+MCP Stdio Reload Credentials Without Auth Contexts
+    [Documentation]    Unscoped credential reload returns an empty provider list
+    ...                when no explicit auth contexts are configured.
+    Pass Execution If    "%{IS_SKIP_MCP_TEST=false}" == "true"    Some platforms do not have the MCP client available
+    ${env_file}=    Set Variable    ${CURDIR}${/}tmp${/}mcp-reload-empty.env
+    ${result}=    Evaluate    stackql_test_tooling.mcp_stdio_client.run_stdio_empty_credential_reload_roundtrip($STACKQL_EXE, $env_file)    modules=stackql_test_tooling.mcp_stdio_client
+    Log    ${result['stderr']}
+    Should Contain        ${result['reload']}    "env_file_sourced": true
+    Should Contain        ${result['reload']}    "providers": []
+    Should Not Contain    ${result['reload']}    isError=true
+    Should Be Equal As Integers    ${result['returncode']}    0
+
 MCP Stdio Reload Credentials Sources Env File Mid Session
     [Documentation]    Issue #688: credential (re)sourcing at any point in the
     ...                MCP server lifecycle, stdio transport, cross-platform.


### PR DESCRIPTION
## Description

Adds a repository-distributed StackQL plugin for ChatGPT desktop and Codex CLI using the existing MCP npm packaging over stdio.

The plugin:

- launches pinned `@stackql/mcp-server@0.10.582`
- reuses the existing signed MCPB download and verification workflow
- uses standard provider authentication environment variables
- supports credential refresh through `reload_credentials`
- includes Linux, macOS, and Windows CI coverage
- includes local installation and hello-world documentation

Also fixes credential reload with no authentication contexts returning `providers: null`. It now returns an empty array matching the MCP output schema.

This does not alter the Anthropic submission or existing npm, MCPB, PyPI, OCI, or MCP Registry installation paths.

Public ChatGPT directory submission is not included because that requires a public production MCP endpoint and domain verification. This change covers the local stdio use case.

## Type of change

- [x] Feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## Issues referenced.

Addresses https://github.com/stackql/stackql/issues/699

## Evidence

- Full Go unit test suite passed
- Targeted MCP backend tests and vet passed
- Plugin manifest validation passed
- Linux stdio smoke test passed
- GitHub public access without authentication passed
- AWS authentication using predefined environment variables passed
- `reload_credentials` smoke coverage passed
- Focused Robot regression passed: 1 passed, 0 failed
- Workflow actionlint passed
- Diff-scoped golangci-lint passed with 0 issues

## Checklist

- [x] A full round of tests have been performed and there are no test failures as a result of these changes
- [x] Functional Robot coverage has been added
- [ ] Changes have been tested on all supported platforms
- [x] Unit tests pass locally
- [ ] Robot tests pass locally
- [ ] Linter passes locally

## Variations

The new focused Robot regression passes.

The full functional Robot run completed with 461 passed and 66 failures caused by the existing local environment:

- missing `build/stackql_mcp_client`
- PostgreSQL key permission rejection from WSL-mounted NTFS

The new regression passed within that full run.

Full repository lint reports 20 pre-existing `revive` findings in untouched files. Diff-scoped lint reports 0 issues.

The added CI matrix will verify Linux, macOS, and Windows on the PR.

## Tech Debt

No technical debt introduced.

Public universal directory deployment and submission should be tracked separately because it requires a hosted MCP endpoint and domain verification.