### PR TITLE
docs: add preview-bucket-01 tutorial (multi-cloud bucket audit)

### DIFF
--- a/docs/tutorials/preview-bucket-01/.gitignore
+++ b/docs/tutorials/preview-bucket-01/.gitignore
@@ -1,6 +1,2 @@
 # Never commit real credentials
 audit/.env.audit
-
-# Ignore any audit output artefacts
-audit/output/*
-!audit/output/.gitkeep

--- a/docs/tutorials/preview-bucket-01/.gitignore
+++ b/docs/tutorials/preview-bucket-01/.gitignore
@@ -1,0 +1,6 @@
+# Never commit real credentials
+audit/.env.audit
+
+# Ignore any audit output artefacts
+audit/output/*
+!audit/output/.gitkeep

--- a/docs/tutorials/preview-bucket-01/README.md
+++ b/docs/tutorials/preview-bucket-01/README.md
@@ -40,12 +40,8 @@ docker compose -f docker-compose.bucket.audit.yaml pull
 **3. Run the audit**
 
 ```bash
-docker compose --env-file ./audit/.env.audit -f docker-compose.bucket.audit.yaml run --rm stackql
+docker compose -f docker-compose.bucket.audit.yaml run --rm stackql
 ```
-
-The `--env-file` flag is important. Without it, Docker Compose won't substitute
-the `AWS_REGION` value into the SQL query and the run fails. Keep it in the
-command exactly as shown.
 
 On a modest account this takes about 30 seconds. Output goes straight to your
 terminal as a table.

--- a/docs/tutorials/preview-bucket-01/README.md
+++ b/docs/tutorials/preview-bucket-01/README.md
@@ -1,0 +1,70 @@
+# Multi-cloud bucket audit (preview)
+
+A one-command audit of storage buckets across AWS, GCP, and Azure using StackQL.
+Reports encryption class, public flag, HTTPS enforcement, and other configuration
+in a single normalised table.
+
+This is preview material under `stackql_preview.*`. The view schema is still
+evolving, so pin the Docker image (as this tutorial does) for reproducibility.
+
+## What you'll need
+
+- Docker installed
+- Read-only credentials for whichever clouds you want to audit. All three are
+  optional; blank credentials mean that cloud is skipped.
+
+For the specific IAM permissions per provider, see
+[required-auth.md](https://github.com/stackql/stackql-audit-action/blob/main/docs/required-auth.md)
+in the `stackql-audit-action` repo.
+
+## Run it
+
+**1. Copy the env template**
+
+```bash
+cp ./audit/.env.audit.example ./audit/.env.audit
+```
+
+Open `./audit/.env.audit` and fill in credentials for whichever clouds you want.
+The variables are named for what they are: `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+`AZURE_CLIENT_SECRET`, `GOOGLE_CREDENTIALS` (the service account JSON, on one
+line), and `GOOGLE_ORG_ID`.
+
+**2. Pull the pinned StackQL Docker image**
+
+```bash
+docker compose -f docker-compose.bucket.audit.yaml pull
+```
+
+**3. Run the audit**
+
+```bash
+docker compose --env-file ./audit/.env.audit -f docker-compose.bucket.audit.yaml run --rm stackql
+```
+
+The `--env-file` flag is important. Without it, Docker Compose won't substitute
+the `AWS_REGION` value into the SQL query and the run fails. Keep it in the
+command exactly as shown.
+
+On a modest account this takes about 30 seconds. Output goes straight to your
+terminal as a table.
+
+## What the output tells you
+
+A single normalised table with a row per bucket, columns for provider, name,
+encryption class, public flag, HTTPS enforcement, region, and versioning. Three
+different underlying resource types (S3 buckets, GCS buckets, Azure Storage
+Accounts) unified into one view with the same columns for each.
+
+## What this covers today
+
+Storage buckets across AWS, GCP, and Azure. One AWS region at a time, one GCP
+organization at a time. Entitlements, IAM, and other resource types are on the
+roadmap as separate audits under `stackql_preview.*`.
+
+## Where to go next
+
+- Move it into CI: [stackql-audit-action](https://github.com/stackql/stackql-audit-action) has ready-to-use GitHub Actions workflows for all-clouds, single-cloud, deep-audit, and OIDC-authenticated variants.
+- Ask questions: [StackQL community Slack](https://join.slack.com/t/stackqlcommunity/shared_invite/zt-46ndqydvn-X8ip8b9xgkT__IOTFbMlVg).
+- Read the full tutorial: [Auditing three clouds without writing three scripts](https://stackql.io/blog/) *(link updates once published)*.

--- a/docs/tutorials/preview-bucket-01/audit/.env.audit.example
+++ b/docs/tutorials/preview-bucket-01/audit/.env.audit.example
@@ -1,0 +1,19 @@
+# Fill in only the clouds you want to audit. Leave others blank to skip.
+
+# --- AWS ---
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_SESSION_TOKEN=
+AWS_REGION=us-east-1
+
+# --- GCP ---
+# GOOGLE_CREDENTIALS must be the service account JSON on ONE line
+GOOGLE_CREDENTIALS=
+GCP_SA_JSON=
+GOOGLE_ORG_ID=
+
+# --- Azure ---
+AZURE_TENANT_ID=
+AZURE_CLIENT_ID=
+AZURE_CLIENT_SECRET=
+AZURE_MGMT_GROUP=

--- a/docs/tutorials/preview-bucket-01/audit/output/.gitignore
+++ b/docs/tutorials/preview-bucket-01/audit/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/tutorials/preview-bucket-01/docker-compose.bucket.audit.yaml
+++ b/docs/tutorials/preview-bucket-01/docker-compose.bucket.audit.yaml
@@ -1,0 +1,21 @@
+# Docker audit quickstart — cross-cloud StackQL security audit.
+#
+# Setup (per README.md):
+#   cp ./audit/.env.audit.example ./audit/.env.audit    # add read-only creds
+#   docker compose -f docker-compose.bucket.audit.yaml pull
+#   docker compose --env-file ./audit/.env.audit -f docker-compose.bucket.audit.yaml run --rm stackql
+#
+# stackql/stackql runs as the query engine. Empty clouds are skipped.
+# Pinned to v0.10.601 for reproducibility; override via STACKQL_IMAGE env var.
+
+services:
+  stackql:
+    image: ${STACKQL_IMAGE:-stackql/stackql:v0.10.601}
+    env_file: [./audit/.env.audit]
+    command:
+      - bash
+      - -c
+      - |
+        stackql exec \
+          --auth='{"aws":{"type":"aws_signing_v4","keyIDenvvar":"AWS_ACCESS_KEY_ID","credentialsenvvar":"AWS_SECRET_ACCESS_KEY"},"google":{"type":"service_account","credentialsenvvar":"GCP_SA_JSON"},"azure":{"type":"azure_default"}}' \
+          "select * from stackql_preview.audit.omni_storage_buckets where region = '$${AWS_REGION}' and google_org = '$${GOOGLE_ORG_ID}';"


### PR DESCRIPTION
Adds a new tutorial under `docs/tutorials/preview-bucket-01/` that runs a cross-cloud storage bucket audit against AWS, GCP, and Azure in one Docker command.

Discussed and approved in Slack (`#stackql-socials`, 15 Aug) — first of the "docs/tutorials/" convention we agreed to establish for reader-facing walkthroughs that live alongside the main repo.

### What's in this PR

- `README.md` — standalone tutorial walkthrough
- `docker-compose.bucket.audit.yaml` — pinned to `stackql/stackql:v0.10.601`, with the `AWS_REGION` region substitution fix so the query is env-driven rather than hardcoded
- `audit/.env.audit.example` — env template, blank values, safe to commit
- `.gitignore` — excludes `audit/.env.audit` (real credentials) and `audit/output/*`
- `audit/output/.gitkeep` — placeholder so the output folder exists

### Tested

Ran end-to-end against real cross-cloud credentials tonight. Audit returned 225 rows across AWS, GCP, and Azure. Both the region substitution fix and the `v0.10.601` pin verified working.

### Related

Companion blog post ("Auditing three clouds without writing three scripts") going to `stackql.io/blog` tomorrow after review.