### PR TITLE
fix: [BUG] query rewriting error using JSON_EXTRACT

### DIFF
--- a/internal/stackql/astvisit/query_rewriting.go
+++ b/internal/stackql/astvisit/query_rewriting.go
@@ -109,13 +109,9 @@ func (v *standardQueryRewriteAstVisitor) isJSONEachCompatible(col parserutil.Col
 	return isJSONEachCompatibleRegexp.MatchString(s)
 }
 
-func (v *standardQueryRewriteAstVisitor) isAnonymous(col parserutil.ColumnHandle) bool {
-	switch col.Expr.(type) {
-	case *sqlparser.OrExpr:
-		return true
-	default:
-		return false
-	}
+func (v *standardQueryRewriteAstVisitor) isExpressionProjection(node *sqlparser.AliasedExpr) bool {
+	_, isColumnReference := node.Expr.(*sqlparser.ColName)
+	return !isColumnReference
 }
 
 // TODO: introduce dependency on RDBMS
@@ -704,7 +700,7 @@ func (v *standardQueryRewriteAstVisitor) Visit(node sqlparser.SQLNode) error {
 					} else {
 						r, ok := indirect.GetColumnByName(col.Name)
 						if !ok {
-							if !v.isJSONEachCompatible(col) && !v.isAnonymous(col) {
+							if !v.isJSONEachCompatible(col) && !v.isExpressionProjection(node) {
 								return fmt.Errorf("query rewriting for indirection: cannot find col = '%s'", col.Name)
 							}
 							relationalCol = typing.NewRelationalColumn(col.Name, "").WithDecorated(col.DecoratedColumn) // TOOO: clean this up

--- a/test/robot/functional/stackql_function_projection.robot
+++ b/test/robot/functional/stackql_function_projection.robot
@@ -4,7 +4,10 @@ Test Teardown     Stackql Per Test Teardown
 Documentation     Scalar-function projections over provider table columns (issue 687):
 ...               a function projection must not inherit its argument column's schema
 ...               type (typeof/date/datetime yielded 0/null and corrupted same-named
-...               siblings). Uses the no-auth stackql_native_test provider.
+...               siblings). Also covers function projections over a subquery
+...               (issue 352), where an expression that does not resolve to a source
+...               column of the subquery must not abort query rewriting.
+...               Uses the no-auth stackql_native_test provider.
 
 *** Test Cases ***
 Typeof Over Bare Integer Column Returns Underlying Type
@@ -93,3 +96,34 @@ Function Expression Containing Column Reference Stays Client Side
     ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
     ...    select volumeId from aws.ec2.volumes where region \= lower('AP-SOUTHEAST-2') and size \= abs(size) order by volumeId asc;
     ...    vol-00200000000000000
+
+Json Extract Over Subquery Function Argument Projects Value
+    [Documentation]    Issue #352: a JSON_EXTRACT projection over a subquery whose argument
+    ...                is itself an expression previously failed with
+    ...                "query rewriting for indirection: cannot find col".
+    Pass Execution If    "${SQL_BACKEND}" == "postgres_tcp"    json_extract and json_object are sqlite-native functions; asserted on the sqlite backend.
+    Should StackQL Exec Inline Contain
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    select json_extract(json_object('vid', volume_id), '$.vid') as vid from (select volume_id from stackql_native_test.xml_ec2.volumes) foo;
+    ...    vol-1
+
+Literal Leading Function Projection Over Subquery Projects Value
+    [Documentation]    Issue #352 generalisation: a function projection over a subquery whose
+    ...                leading argument is a literal has no inferable source column and must
+    ...                still be projected, on either backend.
+    Should StackQL Exec Inline Contain
+    ...    ${STACKQL_EXE}
+    ...    ${OKTA_SECRET_STR}
+    ...    ${GITHUB_SECRET_STR}
+    ...    ${K8S_SECRET_STR}
+    ...    ${REGISTRY_NO_VERIFY_CFG_STR}
+    ...    ${AUTH_CFG_STR}
+    ...    ${SQL_BACKEND_CFG_STR_CANONICAL}
+    ...    select coalesce('vol-fallback', volume_id) as vid from (select volume_id from stackql_native_test.xml_ec2.volumes) foo;
+    ...    vol-fallback


### PR DESCRIPTION
Fixes #352

## Root cause

Query rewriter rejects non-column projections over an indirection (subquery)

## Changes

- In internal/stackql/astvisit/query_rewriting.go the indirection branch of the AliasedExpr visit only tolerated an unresolvable column name when it looked like a json_each value or was an OrExpr (isAnonymous). Any other projected expression whose inferred name is not a column of the subquery (a function whose leading argument is a literal or a nested function, arithmetic, scalar subquery, ...) hard-failed. isAnonymous is replaced by isExpressionProjection, which treats every projection that is not a bare *sqlparser.ColName as opaque to the indirection's column inventory: the untyped relational column carrying the already-rendered decorated expression is emitted and passed to the SQL backend, exactly as the pre-existing json_each escape hatch does. Bare column references that do not exist in the subquery still error as before. Two robot scenarios were added to test/robot/functional/stackql_function_projection.robot (the json_extract-over-subquery case, sqlite-gated, and a backend-agnostic literal-leading function projection).