### PR TITLE
docs: add query-before-mutation GCS tutorial

### DIFF
--- a/docs/tutorials/query-before-mutation-01/README.md
+++ b/docs/tutorials/query-before-mutation-01/README.md
@@ -1,59 +1,79 @@
-# Tutorial 2: Query Before Mutation
+# Query Before Mutation
 
-Demo assets for the query-before-mutation tutorial.
+Companion demo for the tutorial **Query before you mutate: how agents should touch your infrastructure**.
 
-## Argument
-
-Agents managing infrastructure should query live state before mutating.
-
-State files still represent useful intent, but they are not authoritative for what exists in the cloud right now.
-
-The execution pattern is:
+The example demonstrates a simple infrastructure control loop using Google Cloud Storage:
 
 1. Query live state
-2. Identify the delta
-3. Apply a policy gate
-4. Mutate only the non-compliant resources
+2. Identify resources that differ from policy
+3. Apply bounded policy gates
+4. Mutate only non-compliant resources
 5. Query again to verify convergence
+6. Skip mutation when the resource is already compliant
 
-Correctness comes from querying live state before acting.
+## Scenario
 
-Safety comes from bounded execution through policy gates such as location locks, resource count caps, budget ceilings, and allowlists.
+The policy for this demo requires GCS buckets to use a customer-managed Cloud KMS key (CMEK).
 
-## Demo scenario
+Buckets where `encryption` is `NULL` are using Google-managed encryption.
 
-The demo uses Google Cloud Storage.
-
-Policy:
-
-Every bucket managed by the agent should use a customer-managed Cloud KMS key.
-
-The demo starts with buckets using Google-managed encryption, represented by `encryption = null`.
-
-The agent:
-
-1. Queries the current bucket state
-2. Identifies buckets without CMEK
-3. Checks location and count policy gates
-4. Updates the bucket encryption configuration
-5. Queries again to confirm convergence
-6. Skips mutation on subsequent runs when the resource already matches policy
+The demo queries the live GCS API, identifies buckets that do not satisfy the policy, checks location and resource-count gates, applies CMEK, and verifies the resulting state.
 
 ## Requirements
 
 - Docker
 - Google Cloud project
-- Credentials that can read and update Cloud Storage buckets
+- Service account credentials with permission to read and update Cloud Storage buckets
 - Existing Cloud KMS key
 - stackql
 
 ## Provider
 
-The demo uses:
+This demo uses:
 
-`google.storage.buckets`
+```text
+google.storage.buckets
+```
 
-The Google provider is pulled with:
+Pull the validated Google provider version:
 
 ```sql
-REGISTRY PULL google;
+REGISTRY PULL google v26.07.00432;
+```
+
+## Run the demo
+
+Follow the SQL statements in:
+
+```text
+queries.sql
+```
+
+Before running them, replace:
+
+- `your-project-id`
+- `demo-app-bucket1`
+- `your-ring`
+- `your-key`
+
+with values from your Google Cloud environment.
+
+The flow is:
+
+```text
+live query -> policy check -> bounded gate -> mutation -> verification -> repeat safely
+```
+
+The important property is that every execution begins by querying current cloud state.
+
+A previous state snapshot can describe what was managed before. The live API describes what exists now.
+
+## Agent usage
+
+The same pattern can be exposed to an agent through the StackQL MCP server.
+
+An MCP-capable client can use StackQL to query the same live cloud APIs and reason over the results before taking an allowed action.
+
+The SQL walkthrough in this folder keeps the underlying query, gate, mutation, and verification steps explicit.
+
+

--- a/docs/tutorials/query-before-mutation-01/README.md
+++ b/docs/tutorials/query-before-mutation-01/README.md
@@ -1,20 +1,59 @@
-# Tutorial 2: Query Before Mutation (WIP)
+# Tutorial 2: Query Before Mutation
 
-Demo assets for Tutorial 2 of the DevRel campaign.
+Demo assets for the query-before-mutation tutorial.
 
 ## Argument
 
-Agents managing infrastructure need to query live state before mutating, because state files represent intent rather than reality. The execution pattern is: query live state, identify delta, policy gate, mutate, query again, verify.
+Agents managing infrastructure should query live state before mutating.
+
+State files still represent useful intent, but they are not authoritative for what exists in the cloud right now.
+
+The execution pattern is:
+
+1. Query live state
+2. Identify the delta
+3. Apply a policy gate
+4. Mutate only the non-compliant resources
+5. Query again to verify convergence
+
+Correctness comes from querying live state before acting.
+
+Safety comes from bounded execution through policy gates such as location locks, resource count caps, budget ceilings, and allowlists.
 
 ## Demo scenario
 
-AWS S3 encryption policy: every bucket managed by the agent must use SSE-KMS with a customer-managed key. Demo shows detection of SSE-S3 default, mutation to SSE-KMS, and convergence verification.
+The demo uses Google Cloud Storage.
 
-## Status
+Policy:
 
-- Read path validated (SELECT on aws.s3.bucket_encryptions works)
-- Test bucket and KMS key created successfully via stackql
-- Mutation path blocked: REPLACE on aws.s3.bucket_encryptions returns "xml: start tag with no name"
-- Awaiting input on expected payload shape for put_bucket_encryption
+Every bucket managed by the agent should use a customer-managed Cloud KMS key.
 
-See queries.sql for the full sequence with commented notes on what works and what does not.
+The demo starts with buckets using Google-managed encryption, represented by `encryption = null`.
+
+The agent:
+
+1. Queries the current bucket state
+2. Identifies buckets without CMEK
+3. Checks location and count policy gates
+4. Updates the bucket encryption configuration
+5. Queries again to confirm convergence
+6. Skips mutation on subsequent runs when the resource already matches policy
+
+## Requirements
+
+- Docker
+- Google Cloud project
+- Credentials that can read and update Cloud Storage buckets
+- Existing Cloud KMS key
+- stackql
+
+## Provider
+
+The demo uses:
+
+`google.storage.buckets`
+
+The Google provider is pulled with:
+
+```sql
+REGISTRY PULL google;

--- a/docs/tutorials/query-before-mutation-01/README.md
+++ b/docs/tutorials/query-before-mutation-01/README.md
@@ -1,0 +1,20 @@
+# Tutorial 2: Query Before Mutation (WIP)
+
+Demo assets for Tutorial 2 of the DevRel campaign.
+
+## Argument
+
+Agents managing infrastructure need to query live state before mutating, because state files represent intent rather than reality. The execution pattern is: query live state, identify delta, policy gate, mutate, query again, verify.
+
+## Demo scenario
+
+AWS S3 encryption policy: every bucket managed by the agent must use SSE-KMS with a customer-managed key. Demo shows detection of SSE-S3 default, mutation to SSE-KMS, and convergence verification.
+
+## Status
+
+- Read path validated (SELECT on aws.s3.bucket_encryptions works)
+- Test bucket and KMS key created successfully via stackql
+- Mutation path blocked: REPLACE on aws.s3.bucket_encryptions returns "xml: start tag with no name"
+- Awaiting input on expected payload shape for put_bucket_encryption
+
+See queries.sql for the full sequence with commented notes on what works and what does not.

--- a/docs/tutorials/query-before-mutation-01/queries.sql
+++ b/docs/tutorials/query-before-mutation-01/queries.sql
@@ -1,7 +1,3 @@
-
-### `queries.sql`
-
-```sql
 -- Tutorial 2: Query Before Mutation
 -- Validated end to end against Google Cloud Storage.
 --
@@ -17,7 +13,7 @@
 -- SETUP
 -- ============================================================
 
-REGISTRY PULL google;
+REGISTRY PULL google v26.07.00432;
 
 
 -- ============================================================
@@ -125,11 +121,6 @@ WHERE bucket = 'demo-app-bucket1';
 -- STEP 5: IDEMPOTENCE CHECK
 -- ============================================================
 
--- Query again for resources that still violate policy.
---
--- Once the target bucket has CMEK configured, it should no longer
--- appear in this result set.
-
 SELECT
   name,
   location,
@@ -140,8 +131,9 @@ AND location = 'US'
 AND encryption IS NULL;
 
 
--- If no non-compliant target remains, no UPDATE should run.
+-- Once the target bucket has CMEK configured, it should no longer
+-- appear in this result set.
 --
--- This is the key property of the pattern:
--- every execution starts from live state and mutates only when
+-- If no non-compliant target remains, no UPDATE should run.
+-- Every execution starts from live state and mutates only when
 -- the current state differs from policy.

--- a/docs/tutorials/query-before-mutation-01/queries.sql
+++ b/docs/tutorials/query-before-mutation-01/queries.sql
@@ -1,0 +1,91 @@
+-- Tutorial 2: Query Before Mutation
+-- Demo sequence, validated against real AWS account (us-east-1)
+-- WIP - mutation payload serialization for put_bucket_encryption is the open blocker
+
+-- Prerequisites:
+-- 1. AWS credentials in .env with permissions for s3:*, kms:*
+-- 2. A customer-managed KMS key in us-east-1
+-- 3. stackql v0.10.601 or later
+
+-- ============================================================
+-- SETUP: Pull AWS provider (once per shell session)
+-- ============================================================
+REGISTRY PULL aws;
+
+-- ============================================================
+-- STEP 0: Create demo resources (one-time setup for tutorial reader)
+-- ============================================================
+
+-- Create the test bucket
+-- Returns: "The operation was despatched successfully"
+INSERT INTO aws.s3.buckets(bucket, region) 
+SELECT 'stackql-tut2-demo-nirmal-01', 'us-east-1';
+
+-- Create a customer-managed KMS key for the demo
+-- Returns: "The operation was despatched successfully"
+-- Reader captures the resulting KMS Key ARN for use in the REPLACE below
+INSERT INTO aws.kms.keys(region, Description) 
+SELECT 'us-east-1', 'KMS key for stackql Tutorial 2 S3 encryption demo';
+
+-- ============================================================
+-- STEP 1: Query live encryption state (the "query before mutation" step)
+-- ============================================================
+
+-- Returns rules column with current encryption configuration
+-- Example current state: SSE-S3 (AES256), which does not match SSE-KMS policy
+SELECT * 
+FROM aws.s3.bucket_encryptions 
+WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
+AND region = 'us-east-1';
+
+-- Current live output:
+-- rules: {"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},...}
+
+-- ============================================================
+-- STEP 2: Mutate to policy-compliant state (SSE-KMS)
+-- ============================================================
+
+-- BLOCKER: this REPLACE returns "xml: start tag with no name"
+-- Confirmed via SHOW METHODS: put_bucket_encryption is exposed as REPLACE
+-- with required params (bucket, ServerSideEncryptionConfiguration, region)
+-- Kieran flagged that "some of the serialization stuff is not perfect"
+-- Awaiting his input on the expected payload shape
+
+-- Attempt A: REPLACE ... SET ... WHERE
+-- Returns: xml: start tag with no name
+REPLACE aws.s3.bucket_encryptions 
+SET ServerSideEncryptionConfiguration = 
+  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms","KMSMasterKeyID":"arn:aws:kms:us-east-1:824532806693:key/5784aa16-d7a5-4f78-9372-a85cd7784abc"},"BucketKeyEnabled":true}]}'
+WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
+AND region = 'us-east-1';
+
+-- Attempt B: UPDATE with data__ prefix
+-- Returns: no appropriate method = 'update' for resource
+UPDATE aws.s3.bucket_encryptions 
+SET data__ServerSideEncryptionConfiguration = 
+  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms","KMSMasterKeyID":"arn:aws:kms:us-east-1:824532806693:key/5784aa16-d7a5-4f78-9372-a85cd7784abc"},"BucketKeyEnabled":true}]}'
+WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
+AND region = 'us-east-1';
+
+-- ============================================================
+-- STEP 3: Verify convergence (re-run STEP 1)
+-- ============================================================
+
+-- Expected after successful mutation:
+-- rules: {"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms","KMSMasterKeyID":"arn:aws:kms:us-east-1:..."},...}
+
+SELECT * 
+FROM aws.s3.bucket_encryptions 
+WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
+AND region = 'us-east-1';
+
+-- ============================================================
+-- CLEANUP (post-tutorial)
+-- ============================================================
+
+DELETE FROM aws.s3.buckets 
+WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
+AND region = 'us-east-1';
+
+-- Note: KMS key scheduled for deletion via aws.kms.keys DELETE, 
+-- with mandatory 7-30 day pending window

--- a/docs/tutorials/query-before-mutation-01/queries.sql
+++ b/docs/tutorials/query-before-mutation-01/queries.sql
@@ -1,91 +1,147 @@
+
+### `queries.sql`
+
+```sql
 -- Tutorial 2: Query Before Mutation
--- Demo sequence, validated against real AWS account (us-east-1)
--- WIP - mutation payload serialization for put_bucket_encryption is the open blocker
+-- Validated end to end against Google Cloud Storage.
+--
+-- Pattern:
+-- query live state
+-- identify delta
+-- policy gate
+-- mutate
+-- verify convergence
 
--- Prerequisites:
--- 1. AWS credentials in .env with permissions for s3:*, kms:*
--- 2. A customer-managed KMS key in us-east-1
--- 3. stackql v0.10.601 or later
-
--- ============================================================
--- SETUP: Pull AWS provider (once per shell session)
--- ============================================================
-REGISTRY PULL aws;
 
 -- ============================================================
--- STEP 0: Create demo resources (one-time setup for tutorial reader)
+-- SETUP
 -- ============================================================
 
--- Create the test bucket
--- Returns: "The operation was despatched successfully"
-INSERT INTO aws.s3.buckets(bucket, region) 
-SELECT 'stackql-tut2-demo-nirmal-01', 'us-east-1';
+REGISTRY PULL google;
 
--- Create a customer-managed KMS key for the demo
--- Returns: "The operation was despatched successfully"
--- Reader captures the resulting KMS Key ARN for use in the REPLACE below
-INSERT INTO aws.kms.keys(region, Description) 
-SELECT 'us-east-1', 'KMS key for stackql Tutorial 2 S3 encryption demo';
 
 -- ============================================================
--- STEP 1: Query live encryption state (the "query before mutation" step)
+-- STEP 1: QUERY LIVE STATE
 -- ============================================================
 
--- Returns rules column with current encryption configuration
--- Example current state: SSE-S3 (AES256), which does not match SSE-KMS policy
-SELECT * 
-FROM aws.s3.bucket_encryptions 
-WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
-AND region = 'us-east-1';
+-- Replace your-project-id with the Google Cloud project used for the demo.
 
--- Current live output:
--- rules: {"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},...}
+SELECT
+  name,
+  location,
+  encryption
+FROM google.storage.buckets
+WHERE project = 'your-project-id';
 
--- ============================================================
--- STEP 2: Mutate to policy-compliant state (SSE-KMS)
--- ============================================================
 
--- BLOCKER: this REPLACE returns "xml: start tag with no name"
--- Confirmed via SHOW METHODS: put_bucket_encryption is exposed as REPLACE
--- with required params (bucket, ServerSideEncryptionConfiguration, region)
--- Kieran flagged that "some of the serialization stuff is not perfect"
--- Awaiting his input on the expected payload shape
+-- Buckets where encryption is NULL use Google-managed encryption.
+-- For this tutorial, the desired policy is CMEK.
 
--- Attempt A: REPLACE ... SET ... WHERE
--- Returns: xml: start tag with no name
-REPLACE aws.s3.bucket_encryptions 
-SET ServerSideEncryptionConfiguration = 
-  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms","KMSMasterKeyID":"arn:aws:kms:us-east-1:824532806693:key/5784aa16-d7a5-4f78-9372-a85cd7784abc"},"BucketKeyEnabled":true}]}'
-WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
-AND region = 'us-east-1';
+SELECT
+  name,
+  location,
+  encryption
+FROM google.storage.buckets
+WHERE project = 'your-project-id'
+AND encryption IS NULL;
 
--- Attempt B: UPDATE with data__ prefix
--- Returns: no appropriate method = 'update' for resource
-UPDATE aws.s3.bucket_encryptions 
-SET data__ServerSideEncryptionConfiguration = 
-  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms","KMSMasterKeyID":"arn:aws:kms:us-east-1:824532806693:key/5784aa16-d7a5-4f78-9372-a85cd7784abc"},"BucketKeyEnabled":true}]}'
-WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
-AND region = 'us-east-1';
 
 -- ============================================================
--- STEP 3: Verify convergence (re-run STEP 1)
+-- STEP 2: POLICY GATE
 -- ============================================================
 
--- Expected after successful mutation:
--- rules: {"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms","KMSMasterKeyID":"arn:aws:kms:us-east-1:..."},...}
+-- Gate 1:
+-- Only operate on buckets in the expected location.
 
-SELECT * 
-FROM aws.s3.bucket_encryptions 
-WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
-AND region = 'us-east-1';
+SELECT
+  name,
+  location,
+  encryption
+FROM google.storage.buckets
+WHERE project = 'your-project-id'
+AND location = 'US'
+AND encryption IS NULL;
+
+
+-- Gate 2:
+-- Count the number of resources that would be mutated.
+--
+-- The automation should stop if this number is higher than
+-- the configured safety threshold.
+
+SELECT COUNT(*)
+FROM google.storage.buckets
+WHERE project = 'your-project-id'
+AND location = 'US'
+AND encryption IS NULL;
+
 
 -- ============================================================
--- CLEANUP (post-tutorial)
+-- STEP 3: MUTATE TO CONVERGE
 -- ============================================================
 
-DELETE FROM aws.s3.buckets 
-WHERE bucket = 'stackql-tut2-demo-nirmal-01' 
-AND region = 'us-east-1';
+-- Apply a customer-managed Cloud KMS key to one non-compliant bucket.
+--
+-- Replace:
+--   demo-app-bucket1
+--   your-project-id
+--   your-ring
+--   your-key
+--
+-- with values from your environment.
 
--- Note: KMS key scheduled for deletion via aws.kms.keys DELETE, 
--- with mandatory 7-30 day pending window
+UPDATE google.storage.buckets
+SET data__encryption =
+  '{"defaultKmsKeyName":"projects/your-project-id/locations/us/keyRings/your-ring/cryptoKeys/your-key"}'
+WHERE bucket = 'demo-app-bucket1';
+
+
+-- Expected result:
+-- The operation was despatched successfully
+
+
+-- ============================================================
+-- STEP 4: VERIFY CONVERGENCE
+-- ============================================================
+
+SELECT
+  name,
+  encryption
+FROM google.storage.buckets
+WHERE bucket = 'demo-app-bucket1';
+
+
+-- Expected state:
+--
+-- encryption should now contain a defaultKmsKeyName similar to:
+--
+-- {
+--   "defaultKmsKeyName":
+--   "projects/your-project-id/locations/us/keyRings/your-ring/cryptoKeys/your-key"
+-- }
+
+
+-- ============================================================
+-- STEP 5: IDEMPOTENCE CHECK
+-- ============================================================
+
+-- Query again for resources that still violate policy.
+--
+-- Once the target bucket has CMEK configured, it should no longer
+-- appear in this result set.
+
+SELECT
+  name,
+  location,
+  encryption
+FROM google.storage.buckets
+WHERE project = 'your-project-id'
+AND location = 'US'
+AND encryption IS NULL;
+
+
+-- If no non-compliant target remains, no UPDATE should run.
+--
+-- This is the key property of the pattern:
+-- every execution starts from live state and mutates only when
+-- the current state differs from policy.


### PR DESCRIPTION
## Summary

Adds the companion demo for the "Query before you mutate: how agents should touch your infrastructure" tutorial.

The example uses Google Cloud Storage to demonstrate a query-before-mutation control loop:

- query live cloud state
- identify resources that differ from policy
- apply location and resource-count policy gates
- mutate a non-compliant bucket to use CMEK
- verify convergence
- rerun safely without mutating already-compliant resources

## Included

- `README.md` explaining the pattern and demo scenario
- `queries.sql` containing the validated end-to-end GCS flow
- Google provider pinned to `v26.07.00432`

The SQL flow was validated end to end against Google Cloud Storage.

This is the companion repo content for Tutorial 2.