### PR TITLE
fix: guard primitive graph txn control counter slice against concurrent appends

### DIFF
--- a/internal/stackql/primitivegraph/base_dag.go
+++ b/internal/stackql/primitivegraph/base_dag.go
@@ -3,6 +3,7 @@ package primitivegraph
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/stackql/stackql/internal/stackql/acid/binlog"
 	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
@@ -24,6 +25,7 @@ type standardBasePrimitiveGraph struct {
 	g                      *simple.WeightedDirectedGraph
 	sorted                 []graph.Node
 	txnControlCounterSlice []internaldto.TxnControlCounters
+	txnControlCounterMutex sync.Mutex // guards txnControlCounterSlice; executors append concurrently
 	errGroup               *errgroup.Group
 	errGroupCtx            context.Context
 	containsView           bool
@@ -100,10 +102,14 @@ func (pg *standardBasePrimitiveGraph) GetUndoLog() (binlog.LogEntry, bool) {
 }
 
 func (pg *standardBasePrimitiveGraph) AddTxnControlCounters(t internaldto.TxnControlCounters) {
+	pg.txnControlCounterMutex.Lock()
+	defer pg.txnControlCounterMutex.Unlock()
 	pg.txnControlCounterSlice = append(pg.txnControlCounterSlice, t)
 }
 
 func (pg *standardBasePrimitiveGraph) GetTxnControlCounterSlice() []internaldto.TxnControlCounters {
+	pg.txnControlCounterMutex.Lock()
+	defer pg.txnControlCounterMutex.Unlock()
 	return pg.txnControlCounterSlice
 }
 

--- a/internal/stackql/primitivegraph/base_dag_test.go
+++ b/internal/stackql/primitivegraph/base_dag_test.go
@@ -1,0 +1,32 @@
+package primitivegraph_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stackql/stackql/internal/stackql/internal_data_transfer/internaldto"
+	"github.com/stackql/stackql/internal/stackql/primitivegraph"
+)
+
+// Executors append txn control counters to the graph from inside the
+// errgroup, so concurrent UNION arms race on the slice unless it is guarded.
+// Run with -race to catch a regression; the length check catches lost writes.
+func TestAddTxnControlCountersConcurrent(t *testing.T) {
+	const writers = 64
+	const perWriter = 100
+	holder := primitivegraph.NewPrimitiveGraphHolder(-1)
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				holder.AddTxnControlCounters(internaldto.NewTxnControlCountersFromVals(id, id, i, i))
+			}
+		}(w)
+	}
+	wg.Wait()
+	if got := len(holder.GetTxnControlCounterSlice()); got != writers*perWriter {
+		t.Fatalf("expected %d txn control counters, got %d", writers*perWriter, got)
+	}
+}


### PR DESCRIPTION
# Description

`standardBasePrimitiveGraph.AddTxnControlCounters` appended to `txnControlCounterSlice` with no synchronisation, but it is called from executor closures that run inside the graph's errgroup. With an unbounded concurrency limit the arms of a `UNION ALL` execute in parallel and append at the same time; the torn slice header surfaces as a nil pointer panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/stackql/stackql/internal/stackql/primitivegraph.(*standardBasePrimitiveGraph).AddTxnControlCounters
	internal/stackql/primitivegraph/base_dag.go:103
github.com/stackql/stackql/internal/stackql/execution.(*monoValentExecution).GetExecutor.func1
	internal/stackql/execution/mono_valent_execution.go:1449
```

This hit the `Linux Test (test/registry-mocked)` job on #733 (a test-only PR) in the `CONCURRENCY_LIMIT: -1` robot pass, on the scenario `CTE With Partitioned Window Over Combined Provider Rows`. The first pass of the same job (default concurrency) passed, and the same scenario passed on #735 minutes later, so this is a pre-existing intermittent race on `main` rather than anything in those PRs.

The fix adds a mutex on the graph guarding the append and the getter. Readers (`GetTxnControlCounterSlice`) only run at plan-build time, so no other call sites change.

## Type of change

- [x] Bug fix (non-breaking change to fix a bug).

## Evidence

- New unit test `TestAddTxnControlCountersConcurrent` in `internal/stackql/primitivegraph`. On the unfixed code it loses writes (`expected 6400 txn control counters, got 1645`) and trips `-race`; with the guard it passes with `-count=5`.
- The existing robot scenario above, run under the `CONCURRENCY_LIMIT: -1` pass in CI, is the integration regression check. The race is too narrow to reproduce on demand locally (0 panics in 200 local runs of an 8-arm UNION on the unfixed binary), so no new robot scenario is added; a scenario that only fails on a timing window would be flaky by construction.
- `golangci-lint run ./internal/stackql/primitivegraph/...` clean; `go build --tags sqlite_stackql ./...` clean.

## Tech Debt

None added. Files touched: `base_dag.go` plus the new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)