### PR TITLE
ci: skip Docker image build on Dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,9 @@ env:
   PLANCACHEENABLED: "false"
   CI_IS_EXPRESS: ${{ github.ref_type == 'tag' && contains(github.ref_name, 'express') && 'true' || 'false' }}
   STACKQL_IMAGE_NAME: ${{ vars.STACKQL_IMAGE_NAME != '' && vars.STACKQL_IMAGE_NAME || (github.repository == 'stackql/stackql' ||  github.repository == 'stackql/stackql-devel') && github.repository || 'stackql/stackql' }}
-  IS_FORK_PR: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository)) && 'true' || 'false' }}
+  # Dependabot PRs run without repository secrets (only Dependabot secrets), so the Docker Hub login and
+  # image push cannot succeed; treat them like fork PRs and skip the image build.
+  IS_FORK_PR: ${{ ((github.event_name == 'pull_request') && ((github.event.pull_request.head.repo.full_name != github.repository) || (github.event.pull_request.user.login == 'dependabot[bot]'))) && 'true' || 'false' }}
 
 jobs:
 


### PR DESCRIPTION
# Description

Both open Dependabot PRs (#724, #730) fail the `Docker Build (linux/amd64)` and `Docker Build (linux/arm64)` jobs with:

```
##[error]Username and password required
```

Dependabot-triggered `pull_request` runs receive only Dependabot secrets, not repository secrets, so `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` are empty and the login step fails. The image build then pushes by digest, which needs that login anyway.

Fork PRs already skip the image build for the same reason via the `IS_FORK_PR` env gate. This PR extends that gate to PRs authored by `dependabot[bot]`. One line changed plus a comment; the three consumers of `IS_FORK_PR` are unchanged.

Alternative considered: adding `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` as Dependabot secrets in repo settings. Rejected because a dependency bump PR should not push image digests to Docker Hub any more than a fork PR should.

Once merged, `@dependabot rebase` on #724 and #730 will pick up the new workflow. The other failures on those PRs were transient: a golangci schema download timeout on #724's lint job, and a hosted runner losing communication on #730's arm64 build.

## Type of change

- [x] Other: CI workflow change only.

## Evidence

Workflow parses as YAML. Behaviour is verified by the CI run on this PR (non-Dependabot, so the image build still runs) and by the Dependabot PRs after rebase.

## Tech Debt

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)