### PR TITLE
ci: move test tooling image stages from bullseye to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,10 @@ RUN   cd ${SRC_DIR} \
       && go build \
         -o ${BUILD_DIR}/stackql_mcp_client ./mcp_client/cmd
 
-FROM python:3.11-bullseye AS utility
+# bookworm, not bullseye: bullseye LTS ended 2026-08-31 and its security suite
+# is being withdrawn from the mirrors (expired Release file, packages vanishing
+# from the pool), which broke apt-get in this stage on arm64 first.
+FROM python:3.11-bookworm AS utility
 
 ARG TEST_ROOT_DIR=/opt/test/stackql
 
@@ -92,7 +95,7 @@ RUN openssl req -x509 -keyout ${TEST_ROOT_DIR}/test/server/mtls/credentials/pg_s
     && openssl req -x509 -keyout ${TEST_ROOT_DIR}/test/server/mtls/credentials/pg_client_key.pem -out  ${TEST_ROOT_DIR}/test/server/mtls/credentials/pg_client_cert.pem  -config ${TEST_ROOT_DIR}/test/server/mtls/openssl.cnf -days 365 \
     && openssl req -x509 -keyout ${TEST_ROOT_DIR}/test/server/mtls/credentials/pg_rubbish_key.pem -out ${TEST_ROOT_DIR}/test/server/mtls/credentials/pg_rubbish_cert.pem -config ${TEST_ROOT_DIR}/test/server/mtls/openssl.cnf -days 365
 
-FROM python:3.11-bullseye AS registrymock
+FROM python:3.11-bookworm AS registrymock
 
 ARG TEST_ROOT_DIR=/opt/test/stackql
 


### PR DESCRIPTION
# Description

`Docker Build (linux/arm64)` failed five times on 2026-09-06 across #736, #737, the #724 main build and the #736 main build, always with:

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/p/postgresql-13/libpq5_13.23-0%2bdeb11u4_arm64.deb  404  Not Found
```

This is not a CDN flake. Debian 11 bullseye left LTS on 2026-08-31 and its security suite is being withdrawn from the mirrors:

- `bullseye-security/Release` was last published on 2026-08-31 with `Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC`.
- The arm64 `libpq5` package is already gone from the pool directory while the Packages index still lists it.
- Once the Release file expires, `apt-get update` in the bullseye stages fails on both architectures, so retries and mirror fallbacks would have bought hours at most.

The `utility` stage (base of `certificates` and `integration`) and the `registrymock` stage are the only remaining bullseye users in the build. This PR moves both to `python:3.11-bookworm`. `builder` was already on bookworm and `app` is on ubuntu:22.04. One file changed.

## Type of change

- [x] Other: CI build infrastructure. No product code changes.

## Evidence

Built locally with Docker buildx, both platforms:

- `--target certificates` on linux/arm64 and linux/amd64: apt succeeds, image is Debian 12, psql 15.19, sqlite 3.40.1, OpenSSL 3.0.20; all six mTLS pems are generated from the repo's `openssl.cnf`.
- `--target registrymock` on linux/amd64: registry rewrite completes and produces the 20 mocked provider directories.

Compose precursors map onto these stages (`credentialsgen` builds `certificates`, `mockserver` builds `integration`), so the CI matrix on this PR is the full verification.

Behavioural deltas to be aware of: psql 13 to 15 inside the test image, OpenSSL 1.1.1 to 3.0. The Linux and WSL robot jobs already run the same `openssl req` commands under OpenSSL 3.0 on ubuntu-22.04 runners, so the cert config is known-good there.

## Tech Debt

None added. The `docker pull golang:1.23-bullseye` cache-warming line in build.yml is a harmless no-op left untouched to keep this PR to one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)